### PR TITLE
Adding unit tests for Point3d initializer

### DIFF
--- a/tests/data_association/test_point3d_initializer.py
+++ b/tests/data_association/test_point3d_initializer.py
@@ -1,0 +1,199 @@
+"""Unit tests for initialization of 3D landmark from tracks of 2D measurements
+across cameras.
+
+Authors: Ayush Baid
+"""
+import copy
+import unittest
+from typing import List
+
+import numpy as np
+from gtsam import (
+    Cal3_S2,
+    Cal3Bundler,
+    PinholeCameraCal3Bundler,
+    Point2,
+    Point3,
+    Pose3,
+    Rot3,
+)
+from gtsam.examples import SFMdata
+
+from data_association.data_assoc import Point3dInitializer, TriangulationParam
+from data_association.feature_tracks import SfmMeasurement, SfmTrack2d
+
+CALIBRATION = Cal3Bundler(50, 0, 0, 0, 0)
+CAMERAS = {
+    i: PinholeCameraCal3Bundler(pose, CALIBRATION)
+    for i, pose in enumerate(
+        SFMdata.createPoses(
+            Cal3_S2(
+                CALIBRATION.fx(),
+                CALIBRATION.fx(),
+                0,
+                CALIBRATION.px(),
+                CALIBRATION.py(),
+            )
+        )
+    )
+}
+LANDMARK_POINT = Point3(0.0, 0.0, 0.0)
+MEASUREMENTS = [
+    SfmMeasurement(i, cam.project(LANDMARK_POINT)) for i, cam in CAMERAS.items()
+]
+
+
+def get_track_with_one_outlier() -> List[SfmMeasurement]:
+    """Generates a track with outlier measurement."""
+    # perturb one measurement
+    idx_to_perturb = 5
+
+    perturbed_measurements = copy.deepcopy(MEASUREMENTS)
+
+    original_measurement = perturbed_measurements[idx_to_perturb]
+    perturbed_measurements[idx_to_perturb] = SfmMeasurement(
+        original_measurement.i,
+        perturbed_measurements[idx_to_perturb].uv + Point2(20.0, -10.0),
+    )
+
+    return perturbed_measurements
+
+
+class TestPoint3dInitializer(unittest.TestCase):
+    """Unit tests for Point3dInitializer."""
+
+    def setUp(self):
+        super().setUp()
+
+        self.simple_triangulation_initializer = Point3dInitializer(
+            CAMERAS, TriangulationParam.NO_RANSAC
+        )
+
+        self.ransac_uniform_sampling_initializer = Point3dInitializer(
+            CAMERAS,
+            TriangulationParam.RANSAC_SAMPLE_UNIFORM,
+            num_ransac_hypotheses=100,
+            reproj_error_thresh=5,
+        )
+
+    def __runWithCorrectMeasurements(self, obj: Point3dInitializer) -> bool:
+        """Run the initialization with a track with all correct measurements,
+        and checks for correctness of the recovered 3D point."""
+
+        sfm_track = obj.triangulate(SfmTrack2d(MEASUREMENTS))
+        point3d = sfm_track.point3()
+
+        return np.allclose(point3d, LANDMARK_POINT)
+
+    def __runWithTwoMeasurements(self, obj: Point3dInitializer) -> bool:
+        """Run the initialization with a track with all correct measurements,
+        and checks for correctness of the recovered 3D point."""
+
+        sfm_track = obj.triangulate(SfmTrack2d(MEASUREMENTS[:2]))
+        point3d = sfm_track.point3()
+
+        return np.allclose(point3d, LANDMARK_POINT)
+
+    def __runWithOneMeasurement(self, obj: Point3dInitializer) -> bool:
+        """Run the initialization with a track with all correct measurements,
+        and checks for a None track as a result."""
+        sfm_track = obj.triangulate(SfmTrack2d(MEASUREMENTS[:1]))
+
+        return sfm_track is None
+
+    def __runWithSingleOutlier(self, obj: Point3dInitializer) -> bool:
+        """Run the initialization for a track with all inlier measurements
+        except one, and checks for correctness of the estimated point."""
+
+        sfm_track = obj.triangulate(SfmTrack2d(get_track_with_one_outlier()))
+        point3d = sfm_track.point3()
+
+        return np.array_equal(point3d, LANDMARK_POINT)
+
+    def __runWithCheiralityException(self, obj: Point3dInitializer) -> bool:
+        """Run the initialization in a a-cheiral setup, and check that the
+        result is a None track."""
+
+        cameras = obj.track_camera_dict
+
+        # flip the cameras first
+        camera_flip_pose = Pose3(Rot3.RzRyRx(np.pi, 0, 0), np.zeros((3, 1)))
+        flipped_cameras = {
+            i: PinholeCameraCal3Bundler(
+                cam.pose().compose(camera_flip_pose), cam.calibration()
+            )
+            for i, cam in cameras.items()
+        }
+
+        obj_with_flipped_cameras = Point3dInitializer(
+            flipped_cameras,
+            obj.mode,
+            obj.num_ransac_hypotheses,
+            obj.reproj_error_thresh,
+        )
+
+        sfm_track = obj_with_flipped_cameras.triangulate(
+            SfmTrack2d(MEASUREMENTS)
+        )
+
+        return sfm_track is None
+
+    def testSimpleTriangulationWithCorrectMeasurements(self):
+        self.assertTrue(
+            self.__runWithCorrectMeasurements(
+                self.simple_triangulation_initializer
+            )
+        )
+
+    def testSimpleTriangulationWithTwoMeasurements(self):
+        self.assertTrue(
+            self.__runWithTwoMeasurements(self.simple_triangulation_initializer)
+        )
+
+    def testSimpleTriangulationWithOneMeasurement(self):
+        self.assertTrue(
+            self.__runWithOneMeasurement(self.simple_triangulation_initializer)
+        )
+
+    def testSimpleTriangulationWithOutlierMeasurements(self):
+        self.assertFalse(
+            self.__runWithSingleOutlier(self.simple_triangulation_initializer)
+        )
+
+    def testSimpleTriangulationWithCheiralityException(self):
+        self.assertTrue(
+            self.__runWithCheiralityException(
+                self.simple_triangulation_initializer
+            )
+        )
+
+    def testRansacUniformSamplingWithCorrectMeasurements(self):
+        self.assertTrue(
+            self.__runWithCorrectMeasurements(
+                self.ransac_uniform_sampling_initializer
+            )
+        )
+
+    def testRansacUniformSamplingWithTwoMeasurements(self):
+        self.assertTrue(
+            self.__runWithTwoMeasurements(self.simple_triangulation_initializer)
+        )
+
+    def testRansacUniformSamplingWithOneMeasurement(self):
+        self.assertTrue(
+            self.__runWithOneMeasurement(self.simple_triangulation_initializer)
+        )
+
+    def testRansacUniformSamplingWithOutlierMeasurements(self):
+        self.assertTrue(
+            self.__runWithSingleOutlier(
+                self.ransac_uniform_sampling_initializer
+            )
+        )
+
+    def testRansacUniformSamplingWithCheiralityException(self):
+        self.assertTrue(
+            self.__runWithCheiralityException(
+                self.ransac_uniform_sampling_initializer
+            )
+        )


### PR DESCRIPTION
As part of #52, we discovered some issues with the data association module. These unit-tests codify the failures coming from the `Point3dInitializer` class.

Failing tests:
- `testRansacUniformSamplingWithCheiralityException`
- `testRansacUniformSamplingWithOneMeasurement`
- `testRansacUniformSamplingWithOutlierMeasurements`
- `testSimpleTriangulationWithCheiralityException`
- `testSimpleTriangulationWithOneMeasurement`