### PR TITLE
Fixing case of no ground truth pose

### DIFF
--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -101,13 +101,16 @@ class LoaderBase(metaclass=abc.ABCMeta):
 
         return [dask.delayed(self.get_camera_intrinsics)(x) for x in range(N)]
 
-    def create_computation_graph_for_poses(self) -> List[Delayed]:
+    def create_computation_graph_for_poses(self) -> Optional[List[Delayed]]:
         """Creates the computation graph for camera poses.
 
         Returns:
             list of delayed tasks for camera poses.
         """
         N = self.__len__()
+
+        if self.get_camera_pose(0) is None:
+            return None
 
         return [dask.delayed(self.get_camera_pose)(x) for x in range(N)]
 

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -110,6 +110,7 @@ class LoaderBase(metaclass=abc.ABCMeta):
         N = self.__len__()
 
         if self.get_camera_pose(0) is None:
+            # if the 0^th pose is None, we assume none of the pose are available
             return None
 
         return [dask.delayed(self.get_camera_pose)(x) for x in range(N)]


### PR DESCRIPTION
In the scene optimizer, we try to read the pose graph to generate visualizations. This crashed the program when there was no ground truth pose available. In this PR, I fix it by simply returning a `None` instead of the list of poses.