### PR TITLE
Refactoring scene optimizer into separate files

### DIFF
--- a/gtsfm/feature_extractor.py
+++ b/gtsfm/feature_extractor.py
@@ -6,9 +6,6 @@ import logging
 import sys
 from typing import Tuple
 
-import matplotlib
-
-matplotlib.use("Agg")
 from dask.delayed import Delayed
 from gtsam import (
     Cal3Bundler,
@@ -37,11 +34,24 @@ pil_logger.setLevel(logging.INFO)
 class FeatureExtractor:
     """Wrapper for running detection and description on each image."""
 
-    def __init__(self, detector_descriptor: DetectorDescriptorBase):
+    def __init__(self, detector_descriptor: DetectorDescriptorBase) -> None:
+        """Initializes the detector-descriptor
+
+        Args:
+            detector_descriptor: the joint detector-descriptor to use.
+        """
         self.detector_descriptor = detector_descriptor
 
     def create_computation_graph(
         self, image_graph: Delayed
     ) -> Tuple[Delayed, Delayed]:
-        """ Given an image, create detection and descriptor generation tasks """
+        """Given an image, create detection and descriptor generation tasks
+
+        Args:
+            image_graph: image wrapped up in Delayed
+
+        Returns:
+            Delayed object for detected keypoints.
+            Delayed object for corr. descriptors.
+        """
         return self.detector_descriptor.create_computation_graph(image_graph)

--- a/gtsfm/feature_extractor.py
+++ b/gtsfm/feature_extractor.py
@@ -1,0 +1,47 @@
+"""Extracts features and their descriptors from a single image.
+
+Authors: Ayush Baid, John Lambert
+"""
+import logging
+import sys
+from typing import Tuple
+
+import matplotlib
+
+matplotlib.use("Agg")
+from dask.delayed import Delayed
+from gtsam import (
+    Cal3Bundler,
+    PinholeCameraCal3Bundler,
+    Pose3,
+    Rot3,
+    SfmData,
+    Unit3,
+)
+
+import gtsfm.utils.serialization  # import needed to register serialization fns
+from gtsfm.frontend.detector_descriptor.detector_descriptor_base import (
+    DetectorDescriptorBase,
+)
+
+# configure loggers to avoid DEBUG level stdout messages
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+mpl_logger = logging.getLogger("matplotlib")
+mpl_logger.setLevel(logging.WARNING)
+
+pil_logger = logging.getLogger("PIL")
+pil_logger.setLevel(logging.INFO)
+
+
+class FeatureExtractor:
+    """Wrapper for running detection and description on each image."""
+
+    def __init__(self, detector_descriptor: DetectorDescriptorBase):
+        self.detector_descriptor = detector_descriptor
+
+    def create_computation_graph(
+        self, image_graph: Delayed
+    ) -> Tuple[Delayed, Delayed]:
+        """ Given an image, create detection and descriptor generation tasks """
+        return self.detector_descriptor.create_computation_graph(image_graph)

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -1,0 +1,148 @@
+"""Optimizer which performs averaging and bundle adjustment on all images in
+the scene.
+
+Authors: Ayush Baid, John Lambert
+"""
+import logging
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+import dask
+import matplotlib
+
+matplotlib.use("Agg")
+import networkx as nx
+from dask.delayed import Delayed
+from gtsam import Cal3Bundler, PinholeCameraCal3Bundler, Pose3, Rot3, Unit3
+
+import gtsfm.utils.serialization  # import needed to register serialization fns
+from gtsfm.averaging.rotation.rotation_averaging_base import (
+    RotationAveragingBase,
+)
+from gtsfm.averaging.translation.translation_averaging_base import (
+    TranslationAveragingBase,
+)
+from gtsfm.bundle.bundle_adjustment import BundleAdjustmentOptimizer
+from gtsfm.data_association.data_assoc import DataAssociation
+
+# configure loggers to avoid DEBUG level stdout messages
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+mpl_logger = logging.getLogger("matplotlib")
+mpl_logger.setLevel(logging.WARNING)
+
+pil_logger = logging.getLogger("PIL")
+pil_logger.setLevel(logging.INFO)
+
+
+class MultiViewOptimizer:
+    def __init__(
+        self,
+        rot_avg_module: RotationAveragingBase,
+        trans_avg_module: TranslationAveragingBase,
+        config: Any,
+    ):
+        self.rot_avg_module = rot_avg_module
+        self.trans_avg_module = trans_avg_module
+        self.data_association_module = DataAssociation(
+            config.reproj_error_thresh,
+            config.min_track_len,
+            config.triangulation_mode,
+            config.num_ransac_hypotheses,
+        )
+        self.ba_optimizer = BundleAdjustmentOptimizer()
+
+    def create_computation_graph(
+        self,
+        num_images: int,
+        keypoints_graph: List[Delayed],
+        i2Ri1_graph: Dict[Tuple[int, int], Delayed],
+        i2Ui1_graph: Dict[Tuple[int, int], Delayed],
+        v_corr_idxs_graph: Dict[Tuple[int, int], Delayed],
+        intrinsics_graph: List[Delayed],
+    ) -> Tuple[Delayed, Delayed]:
+        # prune the graph to a single connected component.
+        pruned_graph = dask.delayed(self.select_largest_connected_component)(
+            i2Ri1_graph, i2Ui1_graph
+        )
+
+        pruned_i2Ri1_graph = pruned_graph[0]
+        pruned_i2Ui1_graph = pruned_graph[1]
+
+        wRi_graph = self.rot_avg_module.create_computation_graph(
+            num_images, pruned_i2Ri1_graph
+        )
+
+        wti_graph = self.trans_avg_module.create_computation_graph(
+            num_images, pruned_i2Ui1_graph, wRi_graph
+        )
+
+        init_cameras_graph = dask.delayed(self.init_cameras)(
+            wRi_graph, wti_graph, intrinsics_graph
+        )
+
+        ba_input_graph = self.data_association_module.create_computation_graph(
+            init_cameras_graph, v_corr_idxs_graph, keypoints_graph
+        )
+
+        ba_result_graph = self.ba_optimizer.create_computation_graph(
+            ba_input_graph
+        )
+
+        return ba_input_graph, ba_result_graph
+
+    @classmethod
+    def select_largest_connected_component(
+        cls,
+        rotations: Dict[Tuple[int, int], Optional[Rot3]],
+        unit_translations: Dict[Tuple[int, int], Optional[Unit3]],
+    ) -> Tuple[Dict[Tuple[int, int], Rot3], Dict[Tuple[int, int], Unit3]]:
+        """Process the graph of image indices with Rot3s/Unit3s defining edges,
+        and select the largest connected component."""
+
+        input_edges = [k for (k, v) in rotations.items() if v is not None]
+
+        # create a graph from all edges which have an essential matrix
+        result_graph = nx.Graph()
+        result_graph.add_edges_from(input_edges)
+
+        # get the largest connected components
+        largest_cc = max(nx.connected_components(result_graph), key=len)
+        result_subgraph = result_graph.subgraph(largest_cc).copy()
+
+        # get the remaining edges and construct the dictionary back
+        pruned_edges = list(result_subgraph.edges())
+
+        # as the edges are non-directional, they might have flipped and should
+        # be corrected
+        selected_edges = []
+        for i1, i2 in pruned_edges:
+            if (i1, i2) in rotations:
+                selected_edges.append((i1, i2))
+            else:
+                selected_edges.append((i2, i1))
+
+        # return the subset of original input
+        return (
+            {k: rotations[k] for k in selected_edges},
+            {k: unit_translations[k] for k in selected_edges},
+        )
+
+    @classmethod
+    def init_cameras(
+        cls,
+        wRi_list: List[Optional[Rot3]],
+        wti_list: List[Optional[Unit3]],
+        intrinsics_list: List[Cal3Bundler],
+    ) -> Dict[int, PinholeCameraCal3Bundler]:
+        """Generate camera from valid rotations and unit-translations."""
+
+        cameras = {}
+
+        for idx, (wRi, wti) in enumerate(zip(wRi_list, wti_list)):
+            if wRi is not None and wti is not None:
+                cameras[idx] = PinholeCameraCal3Bundler(
+                    Pose3(wRi, wti), intrinsics_list[idx]
+                )
+
+        return cameras

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -14,13 +14,11 @@ import matplotlib
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+import numpy as np
 from dask.delayed import Delayed
 from dask.distributed import Client, LocalCluster, performance_report
 from gtsam import (
-    Cal3Bundler,
-    PinholeCameraCal3Bundler,
     Pose3,
-    Rot3,
     SfmData,
     Unit3,
 )
@@ -39,6 +37,8 @@ from gtsfm.averaging.translation.averaging_1dsfm import (
 from gtsfm.averaging.translation.translation_averaging_base import (
     TranslationAveragingBase,
 )
+from gtsfm.common.image import Image
+from gtsfm.common.keypoints import Keypoints
 from gtsfm.common.sfm_result import SfmResult
 from gtsfm.data_association.data_assoc import TriangulationParam
 from gtsfm.feature_extractor import FeatureExtractor
@@ -77,7 +77,6 @@ class SceneOptimizer:
         trans_avg_module: TranslationAveragingBase,
         config: Any,
     ) -> None:
-
         self.feature_extractor = FeatureExtractor(detector_descriptor)
 
         self.two_view_estimator = TwoViewEstimator(matcher, verifier)
@@ -89,85 +88,6 @@ class SceneOptimizer:
         self._save_viz = config.save_viz
         self._save_bal_files = config.save_bal_files
         self._config = config
-
-    def __visualize_twoview_correspondences(
-        self,
-        image_i1_graph: Delayed,
-        image_i2_graph: Delayed,
-        corr_idxs_graph: Delayed,
-        keypoints_i1_graph: Delayed,
-        keypoints_i2_graph: Delayed,
-        file_name: str,
-    ) -> None:
-        plot_img = viz_utils.plot_twoview_correspondences(
-            image_i1_graph,
-            image_i2_graph,
-            keypoints_i1_graph,
-            keypoints_i2_graph,
-            corr_idxs_graph,
-        )
-
-        io_utils.save_image(plot_img, file_name)
-
-    def __visualize_sfm_data(self, sfm_data: Delayed, folder_name: str) -> None:
-        fig = plt.figure()
-        ax = fig.gca(projection="3d")
-
-        viz_utils.plot_sfm_data_3d(sfm_data, ax)
-        viz_utils.set_axes_equal(ax)
-
-        # save the 3D plot in the original view
-        fig.savefig(os.path.join(folder_name, "3d.png"))
-
-        # save the BEV representation
-        default_camera_elevation = 100  # in metres above ground
-        ax.view_init(azim=0, elev=default_camera_elevation)
-        fig.savefig(os.path.join(folder_name, "bev.png"))
-
-        plt.close(fig)
-
-    def __visualize_camera_poses(
-        self,
-        pre_ba_sfm_data: Delayed,
-        post_ba_sfm_data: Delayed,
-        gt_pose_graph: Optional[List[Delayed]],
-        folder_name: str,
-    ) -> None:
-        # extract camera poses
-        pre_ba_poses = []
-        for i in range(pre_ba_sfm_data.number_cameras()):
-            pre_ba_poses.append(pre_ba_sfm_data.camera(i).pose())
-
-        post_ba_poses = []
-        for i in range(post_ba_sfm_data.number_cameras()):
-            post_ba_poses.append(post_ba_sfm_data.camera(i).pose())
-
-        fig = plt.figure()
-        ax = fig.gca(projection="3d")
-
-        viz_utils.plot_poses_3d(pre_ba_poses, ax, center_marker_color="c")
-        viz_utils.plot_poses_3d(post_ba_poses, ax, center_marker_color="k")
-        if gt_pose_graph is not None:
-            gt_pose_graph = comp_utils.align_poses(gt_pose_graph, post_ba_poses)
-            viz_utils.plot_poses_3d(gt_pose_graph, ax, center_marker_color="m")
-
-        # save the 3D plot in the original view
-        fig.savefig(os.path.join(folder_name, "poses_3d.png"))
-
-        # save the BEV representation
-        default_camera_elevation = 100  # in metres above ground
-        ax.view_init(azim=0, elev=default_camera_elevation)
-        fig.savefig(os.path.join(folder_name, "poses_bev.png"))
-
-        plt.close(fig)
-
-    def __write_sfmdata_to_disk(
-        self, sfm_data: SfmData, save_fpath: str
-    ) -> None:
-        """Write SfmData object as a "Bundle Adjustment in the Large" (BAL) file
-        See https://grail.cs.washington.edu/projects/bal/ for more details on the format.
-        """
-        gtsam.writeBAL(save_fpath, sfm_data)
 
     def create_computation_graph(
         self,
@@ -220,12 +140,12 @@ class SceneOptimizer:
             if self._save_viz:
                 os.makedirs("plots/correspondences", exist_ok=True)
                 auxiliary_graph_list.append(
-                    dask.delayed(self.__visualize_twoview_correspondences)(
+                    dask.delayed(visualize_twoview_correspondences)(
                         image_graph[i1],
                         image_graph[i2],
-                        v_corr_idxs,
                         keypoints_graph_list[i1],
                         keypoints_graph_list[i2],
+                        v_corr_idxs,
                         "plots/correspondences/{}_{}.jpg".format(i1, i2),
                     )
                 )
@@ -260,19 +180,19 @@ class SceneOptimizer:
             os.makedirs("plots/results", exist_ok=True)
 
             auxiliary_graph_list.append(
-                dask.delayed(self.__visualize_sfm_data)(
+                dask.delayed(visualize_sfm_data)(
                     ba_input_graph, "plots/ba_input/"
                 )
             )
 
             auxiliary_graph_list.append(
-                dask.delayed(self.__visualize_sfm_data)(
+                dask.delayed(visualize_sfm_data)(
                     filtered_sfm_data_graph, "plots/results/"
                 )
             )
 
             auxiliary_graph_list.append(
-                dask.delayed(self.__visualize_camera_poses)(
+                dask.delayed(visualize_camera_poses)(
                     ba_input_graph,
                     filtered_sfm_data_graph,
                     gt_pose_graph,
@@ -284,13 +204,13 @@ class SceneOptimizer:
             os.makedirs("results", exist_ok=True)
             # save the input to Bundle Adjustment (from data association)
             auxiliary_graph_list.append(
-                dask.delayed(self.__write_sfmdata_to_disk)(
+                dask.delayed(write_sfmdata_to_disk)(
                     ba_input_graph, "results/ba_input.bal"
                 )
             )
             # save the output of Bundle Adjustment (after optimization)
             auxiliary_graph_list.append(
-                dask.delayed(self.__write_sfmdata_to_disk)(
+                dask.delayed(write_sfmdata_to_disk)(
                     filtered_sfm_data_graph, "results/ba_output.bal"
                 )
             )
@@ -304,6 +224,88 @@ class SceneOptimizer:
 
         # return the entry with just the sfm result
         return output_graph[0]
+
+
+def visualize_twoview_correspondences(
+    image_i1: Image,
+    image_i2: Image,
+    keypoints_i1: Keypoints,
+    keypoints_i2: Keypoints,
+    corr_idxs_i1i2: np.ndarray,
+    file_name: str,
+) -> None:
+    plot_img = viz_utils.plot_twoview_correspondences(
+        image_i1,
+        image_i2,
+        keypoints_i1,
+        keypoints_i2,
+        corr_idxs_i1i2,
+    )
+
+    io_utils.save_image(plot_img, file_name)
+
+
+def visualize_sfm_data(sfm_data: SfmData, folder_name: str) -> None:
+    fig = plt.figure()
+    ax = fig.gca(projection="3d")
+
+    viz_utils.plot_sfm_data_3d(sfm_data, ax)
+    viz_utils.set_axes_equal(ax)
+
+    # save the 3D plot in the original view
+    fig.savefig(os.path.join(folder_name, "3d.png"))
+
+    # save the BEV representation
+    default_camera_elevation = 100  # in metres above ground
+    ax.view_init(azim=0, elev=default_camera_elevation)
+    fig.savefig(os.path.join(folder_name, "bev.png"))
+
+    plt.close(fig)
+
+
+def visualize_camera_poses(
+    pre_ba_sfm_data: SfmData,
+    post_ba_sfm_data: SfmData,
+    gt_pose_graph: Optional[List[Pose3]],
+    folder_name: str,
+) -> None:
+    # extract camera poses
+    pre_ba_poses = []
+    for i in range(pre_ba_sfm_data.number_cameras()):
+        pre_ba_poses.append(pre_ba_sfm_data.camera(i).pose())
+
+    post_ba_poses = []
+    for i in range(post_ba_sfm_data.number_cameras()):
+        post_ba_poses.append(post_ba_sfm_data.camera(i).pose())
+
+    fig = plt.figure()
+    ax = fig.gca(projection="3d")
+
+    viz_utils.plot_poses_3d(pre_ba_poses, ax, center_marker_color="c")
+    viz_utils.plot_poses_3d(post_ba_poses, ax, center_marker_color="k")
+    if gt_pose_graph is not None:
+        gt_pose_graph = comp_utils.align_poses(gt_pose_graph, post_ba_poses)
+        viz_utils.plot_poses_3d(gt_pose_graph, ax, center_marker_color="m")
+
+    # save the 3D plot in the original view
+    fig.savefig(os.path.join(folder_name, "poses_3d.png"))
+
+    # save the BEV representation
+    default_camera_elevation = 100  # in metres above ground
+    ax.view_init(azim=0, elev=default_camera_elevation)
+    fig.savefig(os.path.join(folder_name, "poses_bev.png"))
+
+    plt.close(fig)
+
+
+def write_sfmdata_to_disk(sfm_data: SfmData, save_fpath: str) -> None:
+    """Write SfmData object as a "Bundle Adjustment in the Large" (BAL) file
+    See https://grail.cs.washington.edu/projects/bal/ for more details on the format.
+
+    Note: Need this wrapper as dask cannot directly work on gtsam function
+    calls.
+    """
+    gtsam.writeBAL(save_fpath, sfm_data)
 
 
 if __name__ == "__main__":

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -232,8 +232,18 @@ def visualize_twoview_correspondences(
     keypoints_i1: Keypoints,
     keypoints_i2: Keypoints,
     corr_idxs_i1i2: np.ndarray,
-    file_name: str,
+    file_path: str,
 ) -> None:
+    """Visualize correspondences between pairs of images.
+
+    Args:
+        image_i1: image #i1.
+        image_i2: image #i2.
+        keypoints_i1: detected Keypoints for image #i1.
+        keypoints_i2: detected Keypoints for image #i2.
+        corr_idxs_i1i2: correspondence indices.
+        file_path: file path to save the visualization.
+    """
     plot_img = viz_utils.plot_twoview_correspondences(
         image_i1,
         image_i2,
@@ -242,10 +252,16 @@ def visualize_twoview_correspondences(
         corr_idxs_i1i2,
     )
 
-    io_utils.save_image(plot_img, file_name)
+    io_utils.save_image(plot_img, file_path)
 
 
 def visualize_sfm_data(sfm_data: SfmData, folder_name: str) -> None:
+    """Visualize the camera poses and 3d points in SfmData.
+
+    Args:
+        sfm_data: data to visualize.
+        folder_name: folder to save the visualization at.
+    """
     fig = plt.figure()
     ax = fig.gca(projection="3d")
 
@@ -269,6 +285,14 @@ def visualize_camera_poses(
     gt_pose_graph: Optional[List[Pose3]],
     folder_name: str,
 ) -> None:
+    """Visualize the camera pose and save to disk.
+
+    Args:
+        pre_ba_sfm_data: data input to bundle adjustment.
+        post_ba_sfm_data: output of bundle adjustment.
+        gt_pose_graph: ground truth poses.
+        folder_name: folder to save the visualization at.
+    """
     # extract camera poses
     pre_ba_poses = []
     for i in range(pre_ba_sfm_data.number_cameras()):
@@ -304,6 +328,10 @@ def write_sfmdata_to_disk(sfm_data: SfmData, save_fpath: str) -> None:
 
     Note: Need this wrapper as dask cannot directly work on gtsam function
     calls.
+
+    Args:
+        sfm_data: data to write.
+        save_fpath: filepath to save the data at.
     """
     gtsam.writeBAL(save_fpath, sfm_data)
 

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -7,17 +7,7 @@ import logging
 import sys
 from typing import Tuple
 
-import matplotlib
-
-matplotlib.use("Agg")
 from dask.delayed import Delayed
-from gtsam import (
-    PinholeCameraCal3Bundler,
-    Pose3,
-    Rot3,
-    SfmData,
-    Unit3,
-)
 
 import gtsfm.utils.serialization  # import needed to register serialization fns
 from gtsfm.frontend.matcher.matcher_base import MatcherBase
@@ -37,7 +27,13 @@ class TwoViewEstimator:
     """Wrapper for running two-view relative pose estimation on image pairs in
     the dataset."""
 
-    def __init__(self, matcher: MatcherBase, verifier: VerifierBase):
+    def __init__(self, matcher: MatcherBase, verifier: VerifierBase) -> None:
+        """Initializes the two-view estimator from matcher and verifier.
+
+        Args:
+            matcher: matcher to use.
+            verifier: verifier to use.
+        """
         self.matcher = matcher
         self.verifier = verifier
 
@@ -51,7 +47,24 @@ class TwoViewEstimator:
         camera_intrinsics_i2_graph: Delayed,
         exact_intrinsics: bool = True,
     ) -> Tuple[Delayed, Delayed, Delayed]:
-        """Create delayed tasks for matching and verification."""
+        """Create delayed tasks for matching and verification.
+
+        Args:
+            keypoints_i1_graph: keypoints for image #i1, wrapped as Delayed.
+            keypoints_i2_graph: keypoints for image #i2, wrapped as Delayed
+            descriptors_i1_graph: descriptors for image #i1, wrapped as Delayed.
+            descriptors_i2_graph: descriptors for image #i2, wrapped as Delayed.
+            camera_intrinsics_i1_graph: intrinsics for camera #i1.
+            camera_intrinsics_i2_graph: intrinsics for camera #i2.
+            exact_intrinsics (optional): flag to treat intrinsics as exact, and
+                                         use it in verification. Defaults to
+                                         True.
+
+        Returns:
+            i2Ri1, wrapped as Delayed.
+            i2Ui1, wrapped as Delayed.
+            indices of correspondences in i1 and i2, wrapped as Delayed.
+        """
 
         # graph for matching to obtain putative correspondences
         corr_idxs_graph = self.matcher.create_computation_graph(

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -1,0 +1,76 @@
+"""Estimator which operates on a pair of images to compute relative pose and
+verified indices.
+
+Authors: Ayush Baid, John Lambert
+"""
+import logging
+import sys
+from typing import Tuple
+
+import matplotlib
+
+matplotlib.use("Agg")
+from dask.delayed import Delayed
+from gtsam import (
+    PinholeCameraCal3Bundler,
+    Pose3,
+    Rot3,
+    SfmData,
+    Unit3,
+)
+
+import gtsfm.utils.serialization  # import needed to register serialization fns
+from gtsfm.frontend.matcher.matcher_base import MatcherBase
+from gtsfm.frontend.verifier.verifier_base import VerifierBase
+
+# configure loggers to avoid DEBUG level stdout messages
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+mpl_logger = logging.getLogger("matplotlib")
+mpl_logger.setLevel(logging.WARNING)
+
+pil_logger = logging.getLogger("PIL")
+pil_logger.setLevel(logging.INFO)
+
+
+class TwoViewEstimator:
+    """Wrapper for running two-view relative pose estimation on image pairs in
+    the dataset."""
+
+    def __init__(self, matcher: MatcherBase, verifier: VerifierBase):
+        self.matcher = matcher
+        self.verifier = verifier
+
+    def create_computation_graph(
+        self,
+        keypoints_i1_graph: Delayed,
+        keypoints_i2_graph: Delayed,
+        descriptors_i1_graph: Delayed,
+        descriptors_i2_graph: Delayed,
+        camera_intrinsics_i1_graph: Delayed,
+        camera_intrinsics_i2_graph: Delayed,
+        exact_intrinsics: bool = True,
+    ) -> Tuple[Delayed, Delayed, Delayed]:
+        """Create delayed tasks for matching and verification."""
+
+        # graph for matching to obtain putative correspondences
+        corr_idxs_graph = self.matcher.create_computation_graph(
+            descriptors_i1_graph, descriptors_i2_graph
+        )
+
+        # verification on putative correspondences to obtain relative pose
+        # and verified correspondences
+        (
+            i2Ri1_graph,
+            i2Ui1_graph,
+            v_corr_idxs_graph,
+        ) = self.verifier.create_computation_graph(
+            keypoints_i1_graph,
+            keypoints_i2_graph,
+            corr_idxs_graph,
+            camera_intrinsics_i1_graph,
+            camera_intrinsics_i2_graph,
+            exact_intrinsics,
+        )
+
+        return i2Ri1_graph, i2Ui1_graph, v_corr_idxs_graph

--- a/tests/test_scene_optimizer.py
+++ b/tests/test_scene_optimizer.py
@@ -24,6 +24,7 @@ from gtsfm.frontend.matcher.twoway_matcher import TwoWayMatcher
 from gtsfm.frontend.verifier.degensac import Degensac
 from gtsfm.loader.folder_loader import FolderLoader
 from gtsfm.scene_optimizer import SceneOptimizer
+from gtsfm.multi_view_optimizer import select_largest_connected_component
 
 DATA_ROOT_PATH = Path(__file__).resolve().parent / "data"
 
@@ -43,7 +44,7 @@ class TestSceneOptimizer(unittest.TestCase):
                 "triangulation_mode": TriangulationParam.RANSAC_SAMPLE_BIASED_BASELINE,
                 "num_ransac_hypotheses": 20,
                 "save_viz": False,
-                "save_bal_files": False
+                "save_bal_files": False,
             }
         )
         self.obj = SceneOptimizer(
@@ -86,7 +87,7 @@ class TestSceneOptimizer(unittest.TestCase):
         (
             computed_relative_rotations,
             computed_relative_unit_translations,
-        ) = self.obj.multiview_optimizer.select_largest_connected_component(
+        ) = select_largest_connected_component(
             input_relative_rotations, input_relative_unit_translations
         )
 


### PR DESCRIPTION
As we add more code for auxiliary tasks like metrics, visualizations, saving, the class for each plate becomes bigger and bigger. 

This PR separates out the classes in the scene optimizer into one class per file.