### PR TITLE
Fixing logger by moving to the common getter function

### DIFF
--- a/gtsfm/bundle/bundle_adjustment.py
+++ b/gtsfm/bundle/bundle_adjustment.py
@@ -2,10 +2,6 @@
 
 Authors: Xiaolong Wu, John Lambert, Ayush Baid
 """
-
-import logging
-import sys
-
 import dask
 import gtsam
 from dask.delayed import Delayed
@@ -17,6 +13,7 @@ from gtsam import (
     symbol_shorthand,
 )
 
+import gtsfm.utils.logger as logger_utils
 from gtsfm.common.sfm_result import SfmResult
 
 # TODO: any way this goes away?
@@ -27,7 +24,7 @@ PINHOLE_CAM_CAL3BUNDLER_DOF = 9  # 6 dof for pose, and 3 dof for f, k1, k2
 IMG_MEASUREMENT_DIM = 2  # 2d measurements (u,v) have 2 dof
 POINT3_DOF = 3  # 3d points have 3 dof
 
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+logger = logger_utils.get_logger()
 
 
 class BundleAdjustmentOptimizer:
@@ -44,7 +41,7 @@ class BundleAdjustmentOptimizer:
         Results:
             optimized camera poses, 3D point w/ tracks, and error metrics.
         """
-        logging.info(
+        logger.info(
             f"Input: {initial_data.number_tracks()} tracks on {initial_data.number_cameras()} cameras\n"
         )
 
@@ -113,14 +110,14 @@ class BundleAdjustmentOptimizer:
             lm = gtsam.LevenbergMarquardtOptimizer(graph, initial, params)
             result_values = lm.optimize()
         except Exception as e:
-            logging.exception("LM Optimization failed")
+            logger.exception("LM Optimization failed")
             return SfmResult(SfmData(), float("Nan"))
 
         final_error = graph.error(result_values)
 
         # Error drops from ~2764.22 to ~0.046
-        logging.info(f"initial error: {graph.error(initial):.2f}")
-        logging.info(f"final error: {final_error:.2f}")
+        logger.info(f"initial error: {graph.error(initial):.2f}")
+        logger.info(f"final error: {final_error:.2f}")
 
         # construct the results
         optimized_data = values_to_sfm_data(result_values, initial_data)

--- a/gtsfm/data_association/data_assoc.py
+++ b/gtsfm/data_association/data_assoc.py
@@ -10,7 +10,6 @@ Understanding, Vol. 68, No. 2, November, pp. 146–157, 1997
 
 Authors: Sushmita Warrier, Xiaolong Wu
 """
-import logging
 from typing import Dict, List, NamedTuple, Optional, Tuple
 
 import dask
@@ -18,6 +17,7 @@ import numpy as np
 from dask.delayed import Delayed
 from gtsam import PinholeCameraCal3Bundler, SfmData, SfmTrack
 
+import gtsfm.utils.logger as logger_utils
 from gtsfm.common.keypoints import Keypoints
 from gtsfm.common.sfm_result import SfmResult
 from gtsfm.common.sfm_track import SfmTrack2d
@@ -27,20 +27,7 @@ from gtsfm.data_association.point3d_initializer import (
 )
 
 
-def get_logger():
-    """Getter for logger."""
-    logger_name = "main-logger"
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(logging.INFO)
-    if not logger.handlers:
-        handler = logging.StreamHandler()
-        fmt = "[%(asctime)s %(levelname)s %(filename)s line %(lineno)d %(process)d] %(message)s"
-        handler.setFormatter(logging.Formatter(fmt))
-        logger.addHandler(handler)
-    return logger
-
-
-logger = get_logger()
+logger = logger_utils.get_logger()
 
 
 class DataAssociation(NamedTuple):
@@ -94,10 +81,10 @@ class DataAssociation(NamedTuple):
         num_tracks = len(tracks)
         track_lengths = list(map(lambda x: x.number_measurements(), tracks))
 
-        logging.debug(
+        logger.debug(
             "[Data association] input number of tracks: %s", num_tracks
         )
-        logging.debug(
+        logger.debug(
             "[Data association] input avg. track length: %s",
             np.mean(track_lengths),
         )
@@ -131,11 +118,11 @@ class DataAssociation(NamedTuple):
                 raise RuntimeError("Some cameras must have been dropped ")
             triangulated_data.add_camera(cam)
 
-        logging.debug(
+        logger.debug(
             "[Data association] output number of tracks: %s",
             triangulated_data.number_tracks(),
         )
-        logging.debug(
+        logger.debug(
             "[Data association] output avg. track length: %s",
             SfmResult(triangulated_data, None).get_track_length_statistics()[0],
         )

--- a/gtsfm/data_association/point3d_initializer.py
+++ b/gtsfm/data_association/point3d_initializer.py
@@ -9,7 +9,6 @@ Authors: Sushmita Warrier, Xiaolong Wu
 """
 
 import itertools
-import logging
 from enum import Enum
 from typing import Dict, List, NamedTuple, Optional, Tuple
 
@@ -22,11 +21,14 @@ from gtsam import (
     SfmTrack,
 )
 
+import gtsfm.utils.logger as logger_utils
 from gtsfm.common.sfm_track import SfmMeasurement, SfmTrack2d
 
 NUM_SAMPLES_PER_RANSAC_HYPOTHESIS = 2
 SVD_DLT_RANK_TOL = 1e-9
 MAX_TRACK_REPROJ_ERROR = np.finfo(np.float32).max
+
+logger = logger_utils.get_logger()
 
 """We have different modes for robust and non-robust triangulation.
 In case of noise-free measurements, all the entries in a track are used w/o ransac.
@@ -127,7 +129,7 @@ class Point3dInitializer(NamedTuple):
                         )
                     except RuntimeError:
                         # TODO: handle cheirality exception properly?
-                        logging.info(
+                        logger.info(
                             "Cheirality exception from GTSAM's triangulatePoint3() likely due to outlier, skipping track"
                         )
                         continue
@@ -156,7 +158,7 @@ class Point3dInitializer(NamedTuple):
                             best_error = avg_error
                             best_inliers = is_inlier
                 else:
-                    logging.warning(
+                    logger.warning(
                         "Unestimated cameras found at indices {} or {}. Skipping them.".format(
                             i1, i2
                         )
@@ -186,7 +188,9 @@ class Point3dInitializer(NamedTuple):
                 optimize=True,
             )
         except RuntimeError:
-            logging.info("Cheirality exception from GTSAM's triangulatePoint3() likely due to outlier, skipping track")
+            logger.info(
+                "Cheirality exception from GTSAM's triangulatePoint3() likely due to outlier, skipping track"
+            )
             return None
 
         # compute reprojection errors for each measurement
@@ -327,7 +331,7 @@ class Point3dInitializer(NamedTuple):
                 track_cameras.append(self.track_camera_dict.get(i))
                 track_measurements.append(uv)
             else:
-                logging.warning(
+                logger.warning(
                     "Unestimated cameras found at index {}. Skipping them.".format(
                         i
                     )

--- a/gtsfm/feature_extractor.py
+++ b/gtsfm/feature_extractor.py
@@ -2,33 +2,14 @@
 
 Authors: Ayush Baid, John Lambert
 """
-import logging
-import sys
 from typing import Tuple
 
 from dask.delayed import Delayed
-from gtsam import (
-    Cal3Bundler,
-    PinholeCameraCal3Bundler,
-    Pose3,
-    Rot3,
-    SfmData,
-    Unit3,
-)
 
 import gtsfm.utils.serialization  # import needed to register serialization fns
 from gtsfm.frontend.detector_descriptor.detector_descriptor_base import (
     DetectorDescriptorBase,
 )
-
-# configure loggers to avoid DEBUG level stdout messages
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
-
-mpl_logger = logging.getLogger("matplotlib")
-mpl_logger.setLevel(logging.WARNING)
-
-pil_logger = logging.getLogger("PIL")
-pil_logger.setLevel(logging.INFO)
 
 
 class FeatureExtractor:

--- a/gtsfm/frontend/verifier/ransac.py
+++ b/gtsfm/frontend/verifier/ransac.py
@@ -9,7 +9,6 @@ pose problem. TPAMI, 2004.
 Authors: John Lambert
 """
 
-import logging
 from typing import Optional, Tuple
 
 import cv2
@@ -17,30 +16,17 @@ import numpy as np
 from gtsam import Cal3Bundler, Rot3, Unit3
 
 import gtsfm.utils.features as feature_utils
+import gtsfm.utils.logger as logger_utils
 import gtsfm.utils.verification as verification_utils
 from gtsfm.common.keypoints import Keypoints
 from gtsfm.frontend.verifier.verifier_base import VerifierBase
 
 # minimum matches required for computing the E-matrix
 NUM_MATCHES_REQ_E_MATRIX = 5
-NORMALIZED_COORD_RANSAC_THRESH = 0.001 # TODO: hyperparameter to tune
+NORMALIZED_COORD_RANSAC_THRESH = 0.001  # TODO: hyperparameter to tune
 DEFAULT_RANSAC_SUCCESS_PROB = 0.999
 
-
-def get_logger():
-    """
-    """
-    logger_name = "main-logger"
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(logging.INFO)
-    if not logger.handlers:
-        handler = logging.StreamHandler()
-        fmt = "[%(asctime)s %(levelname)s %(filename)s line %(lineno)d %(process)d] %(message)s"
-        handler.setFormatter(logging.Formatter(fmt))
-        logger.addHandler(handler)
-    return logger
-
-logger = get_logger()
+logger = logger_utils.get_logger()
 
 
 class Ransac(VerifierBase):
@@ -84,12 +70,10 @@ class Ransac(VerifierBase):
             return None, None, verified_indices
 
         uv_norm_i1 = feature_utils.normalize_coordinates(
-            keypoints_i1.coordinates,
-            camera_intrinsics_i1
+            keypoints_i1.coordinates, camera_intrinsics_i1
         )
         uv_norm_i2 = feature_utils.normalize_coordinates(
-            keypoints_i2.coordinates,
-            camera_intrinsics_i2
+            keypoints_i2.coordinates, camera_intrinsics_i2
         )
         K = np.eye(3)
 
@@ -99,21 +83,22 @@ class Ransac(VerifierBase):
             K,
             method=cv2.RANSAC,
             threshold=NORMALIZED_COORD_RANSAC_THRESH,
-            prob=DEFAULT_RANSAC_SUCCESS_PROB
+            prob=DEFAULT_RANSAC_SUCCESS_PROB,
         )
         inlier_idxs = np.where(inlier_mask.ravel() == 1)[0]
 
-        i2Ri1, i2Ui1 = \
-            verification_utils.recover_relative_pose_from_essential_matrix(
-                i2Ei1,
-                keypoints_i1.coordinates[match_indices[inlier_idxs, 0]],
-                keypoints_i2.coordinates[match_indices[inlier_idxs, 1]],
-                camera_intrinsics_i1,
-                camera_intrinsics_i2
-            )
+        (
+            i2Ri1,
+            i2Ui1,
+        ) = verification_utils.recover_relative_pose_from_essential_matrix(
+            i2Ei1,
+            keypoints_i1.coordinates[match_indices[inlier_idxs, 0]],
+            keypoints_i2.coordinates[match_indices[inlier_idxs, 1]],
+            camera_intrinsics_i1,
+            camera_intrinsics_i2,
+        )
 
         return i2Ri1, i2Ui1, match_indices[inlier_idxs]
-
 
     def verify_with_approximate_intrinsics(
         self,
@@ -142,5 +127,9 @@ class Ransac(VerifierBase):
             Indices of verified correspondences, of shape (N, 2) with N <= N3.
                 These indices are subset of match_indices.
         """
-        logger.info("Directly estimating essential matrix with approximate intrinsics not implemented")
-        raise NotImplementedError("Use Degensac instead for F-Matrix estimation")
+        logger.info(
+            "Directly estimating essential matrix with approximate intrinsics not implemented"
+        )
+        raise NotImplementedError(
+            "Use Degensac instead for F-Matrix estimation"
+        )

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -3,8 +3,6 @@ the scene.
 
 Authors: Ayush Baid, John Lambert
 """
-import logging
-import sys
 from typing import Any, Dict, List, Optional, Tuple
 
 import dask
@@ -28,15 +26,6 @@ from gtsfm.averaging.translation.translation_averaging_base import (
 )
 from gtsfm.bundle.bundle_adjustment import BundleAdjustmentOptimizer
 from gtsfm.data_association.data_assoc import DataAssociation
-
-# configure loggers to avoid DEBUG level stdout messages
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
-
-mpl_logger = logging.getLogger("matplotlib")
-mpl_logger.setLevel(logging.WARNING)
-
-pil_logger = logging.getLogger("PIL")
-pil_logger.setLevel(logging.INFO)
 
 
 class MultiViewOptimizer:

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -4,7 +4,6 @@ Authors: Ayush Baid, John Lambert
 """
 import logging
 import os
-import sys
 from types import SimpleNamespace
 from typing import Any, List, Optional, Tuple
 
@@ -25,6 +24,7 @@ from gtsam import (
 
 import gtsfm.utils.geometry_comparisons as comp_utils
 import gtsfm.utils.io as io_utils
+import gtsfm.utils.logger as logger_utils
 import gtsfm.utils.serialization  # import needed to register serialization fns
 import gtsfm.utils.viz as viz_utils
 from gtsfm.averaging.rotation.rotation_averaging_base import (
@@ -54,8 +54,7 @@ from gtsfm.loader.folder_loader import FolderLoader
 from gtsfm.multi_view_optimizer import MultiViewOptimizer
 from gtsfm.two_view_estimator import TwoViewEstimator
 
-# configure loggers to avoid DEBUG level stdout messages
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+logger = logger_utils.get_logger()
 
 mpl_logger = logging.getLogger("matplotlib")
 mpl_logger.setLevel(logging.WARNING)

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -4,17 +4,17 @@ verified indices.
 Authors: Ayush Baid, John Lambert
 """
 import logging
-import sys
-from typing import Tuple
+from typing import Tuple, Optional
 
 from dask.delayed import Delayed
 
+import gtsfm.utils.geometry_comparisons as comp_utils
+import gtsfm.utils.logger as logger_utils
 import gtsfm.utils.serialization  # import needed to register serialization fns
 from gtsfm.frontend.matcher.matcher_base import MatcherBase
 from gtsfm.frontend.verifier.verifier_base import VerifierBase
 
-# configure loggers to avoid DEBUG level stdout messages
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+logger = logger_utils.get_logger()
 
 mpl_logger = logging.getLogger("matplotlib")
 mpl_logger.setLevel(logging.WARNING)

--- a/gtsfm/utils/logger.py
+++ b/gtsfm/utils/logger.py
@@ -1,0 +1,20 @@
+"""Utilities for logging.
+
+Authors: Ayush Baid, John Lambert.
+"""
+import logging
+import sys
+from logging import Logger
+
+
+def get_logger() -> Logger:
+    """Getter for the main logger."""
+    logger_name = "main-logger"
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(logging.DEBUG)
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stdout)
+        fmt = "[%(asctime)s %(levelname)s %(filename)s line %(lineno)d %(process)d] %(message)s"
+        handler.setFormatter(logging.Formatter(fmt))
+        logger.addHandler(handler)
+    return logger


### PR DESCRIPTION
We had different modules using different ways to instantiate logging and as a result all the files were not able to log to stdout.

This PR moves every logger to use a common getter function and resolves the issues.