### PR TITLE
Removing custom serialization as GTSAM types are pickleable

### DIFF
--- a/.github/scripts/python.sh
+++ b/.github/scripts/python.sh
@@ -8,8 +8,9 @@ echo "Running .github/scripts/python.sh..."
 conda init
 conda info --envs
 
-wget -O 2020_01_13_gtsam_python38_wheel.zip --no-check-certificate "https://drive.google.com/uc?export=download&id=1b7zoYopU7jN3D62fuZMqwQgZdhZ4cH6P"
-unzip 2020_01_13_gtsam_python38_wheel.zip
+wget -O 2020_03_08_gtsam_python38_wheel.zip --no-check-certificate "https://drive.google.com/uc?export=download&id=1lpU4TFqh5puH41h2kcqfIgX7_br_a0nb"
+
+unzip 2020_03_08_gtsam_python38_wheel.zip
 pip install gtsam-4.1.1-cp38-cp38-manylinux2014_x86_64.whl
 
 ##########################################################

--- a/gtsfm/feature_extractor.py
+++ b/gtsfm/feature_extractor.py
@@ -6,10 +6,7 @@ from typing import Tuple
 
 from dask.delayed import Delayed
 
-import gtsfm.utils.serialization  # import needed to register serialization fns
-from gtsfm.frontend.detector_descriptor.detector_descriptor_base import (
-    DetectorDescriptorBase,
-)
+from gtsfm.frontend.detector_descriptor.detector_descriptor_base import DetectorDescriptorBase
 
 
 class FeatureExtractor:

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -19,13 +19,8 @@ from gtsam import (
 
 import gtsfm.utils.io as io
 import gtsfm.utils.metrics as metrics
-import gtsfm.utils.serialization  # import needed to register serialization fns
-from gtsfm.averaging.rotation.rotation_averaging_base import (
-    RotationAveragingBase,
-)
-from gtsfm.averaging.translation.translation_averaging_base import (
-    TranslationAveragingBase,
-)
+from gtsfm.averaging.rotation.rotation_averaging_base import RotationAveragingBase
+from gtsfm.averaging.translation.translation_averaging_base import TranslationAveragingBase
 from gtsfm.bundle.bundle_adjustment import BundleAdjustmentOptimizer
 from gtsfm.data_association.data_assoc import DataAssociation
 
@@ -105,10 +100,8 @@ class MultiViewOptimizer:
         return ba_input_graph, ba_result_graph, saved_metrics_graph
 
 
-
 def select_largest_connected_component(
-    rotations: Dict[Tuple[int, int], Optional[Rot3]],
-    unit_translations: Dict[Tuple[int, int], Optional[Unit3]],
+    rotations: Dict[Tuple[int, int], Optional[Rot3]], unit_translations: Dict[Tuple[int, int], Optional[Unit3]],
 ) -> Tuple[Dict[Tuple[int, int], Rot3], Dict[Tuple[int, int], Unit3]]:
     """Process the graph of image indices with Rot3s/Unit3s defining edges, and select the largest connected component.
 
@@ -149,9 +142,7 @@ def select_largest_connected_component(
 
 
 def init_cameras(
-    wRi_list: List[Optional[Rot3]],
-    wti_list: List[Optional[Point3]],
-    intrinsics_list: List[Cal3Bundler],
+    wRi_list: List[Optional[Rot3]], wti_list: List[Optional[Point3]], intrinsics_list: List[Cal3Bundler],
 ) -> Dict[int, PinholeCameraCal3Bundler]:
     """Generate camera from valid rotations and unit-translations.
 

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -13,7 +13,6 @@ from gtsam import Cal3Bundler, Pose3, Rot3, Unit3
 import gtsfm.utils.geometry_comparisons as comp_utils
 import gtsfm.utils.logger as logger_utils
 import gtsfm.utils.metrics as metric_utils
-import gtsfm.utils.serialization  # import needed to register serialization fns
 from gtsfm.common.keypoints import Keypoints
 from gtsfm.frontend.matcher.matcher_base import MatcherBase
 from gtsfm.frontend.verifier.verifier_base import VerifierBase
@@ -153,9 +152,7 @@ def compute_correspondence_metrics(
 
 
 def compute_relative_pose_metrics(
-    i2Ri1_computed: Optional[Rot3],
-    i2Ui1_computed: Optional[Unit3],
-    i2Ti1_expected: Pose3,
+    i2Ri1_computed: Optional[Rot3], i2Ui1_computed: Optional[Unit3], i2Ti1_expected: Pose3,
 ) -> Tuple[Optional[float], Optional[float]]:
     """Compute the metrics on relative camera pose.
 

--- a/tests/utils/test_serialization.py
+++ b/tests/utils/test_serialization.py
@@ -6,6 +6,7 @@ import unittest
 
 import gtsam
 import numpy as np
+from distributed.protocol.serialize import serialize, deserialize
 from gtsam import (
     Cal3Bundler,
     PinholeCameraCal3Bundler,
@@ -15,7 +16,6 @@ from gtsam import (
     Unit3,
 )
 
-import gtsfm.utils.serialization as serialization_utils
 from gtsfm.common.sfm_result import SfmResult
 
 GTSAM_EXAMPLE_FILE = "dubrovnik-3-7-pre"
@@ -28,36 +28,36 @@ class TestSerialization(unittest.TestCase):
     def test_point3_roundtrip(self):
         """Test the round-trip on Point3 object."""
         expected = Point3(np.random.randn(3))
-        header, frames = serialization_utils.serialize_Point3(expected)
-        recovered = serialization_utils.deserialize_Point3(header, frames)
+        header, frames = serialize(expected)
+        recovered = deserialize(header, frames)
         np.testing.assert_allclose(expected, recovered)
 
     def test_pose3_roundtrip(self):
         """Test the round-trip on Point3 object."""
         expected = Pose3(Rot3.RzRyRx(0, 0.1, 0.2), np.random.randn(3))
-        header, frames = serialization_utils.serialize_Pose3(expected)
-        recovered = serialization_utils.deserialize_Pose3(header, frames)
+        header, frames = serialize(expected)
+        recovered = deserialize(header, frames)
         self.assertTrue(recovered.equals(expected, 1e-5))
 
     def test_rot3_roundtrip(self):
         """Test the round-trip on Rot3 object."""
         expected = Rot3.RzRyRx(0, 0.05, 0.1)
-        header, frames = serialization_utils.serialize_Rot3(expected)
-        recovered = serialization_utils.deserialize_Rot3(header, frames)
+        header, frames = serialize(expected)
+        recovered = deserialize(header, frames)
         self.assertTrue(expected.equals(recovered, 1e-5))
 
     def test_unit3_roundtrip(self):
         """Test the round-trip on Unit3 object."""
         expected = Unit3(np.random.randn(3))
-        header, frames = serialization_utils.serialize_Unit3(expected)
-        recovered = serialization_utils.deserialize_Unit3(header, frames)
+        header, frames = serialize(expected)
+        recovered = deserialize(header, frames)
         self.assertTrue(expected.equals(recovered, 1e-5))
 
     def test_cal3Bundler_roundtrip(self):
         """Test the round-trip on Cal3Bundler object."""
         expected = Cal3Bundler(fx=100, k1=0.1, k2=0.2, u0=100, v0=70)
-        header, frames = serialization_utils.serialize_Cal3Bundler(expected)
-        recovered = serialization_utils.deserialize_Cal3Bundler(header, frames)
+        header, frames = serialize(expected)
+        recovered = deserialize(header, frames)
         self.assertTrue(expected.equals(recovered, 1e-5))
 
     def test_pinholeCameraCal3Bundler_roundtrip(self):
@@ -67,16 +67,16 @@ class TestSerialization(unittest.TestCase):
             Pose3(Rot3.RzRyRx(0, 0.1, -0.05), np.random.randn(3, 1)),
             Cal3Bundler(fx=100, k1=0.1, k2=0.2, u0=100, v0=70),
         )
-        header, frames = serialization_utils.serialize_PinholeCameraCal3Bundler(expected)
-        recovered = serialization_utils.deserialize_PinholeCameraCal3Bundler(header, frames)
+        header, frames = serialize(expected)
+        recovered = deserialize(header, frames)
 
         self.assertTrue(expected.equals(recovered, 1e-5))
 
     def test_sfmData_roundtrip(self):
         """Test for equality after serializing and then de-serializing an SfmData instance."""
         expected = EXAMPLE_DATA
-        header, frames = serialization_utils.serialize_SfmData(expected)
-        recovered = serialization_utils.deserialize_SfmData(header, frames)
+        header, frames = serialize(expected)
+        recovered = deserialize(header, frames)
 
         # comparing tracks in an order-sensitive fashion.
         self.assertTrue(recovered.equals(expected, 1e-9))
@@ -84,8 +84,8 @@ class TestSerialization(unittest.TestCase):
     def test_sfmResult_roundtrip(self):
         """Test for equality after serializing and then de-serializing an SfmResult instance."""
         expected = SfmResult(EXAMPLE_DATA, total_reproj_error=1.5)
-        header, frames = serialization_utils.serialize_SfmResult(expected)
-        recovered = serialization_utils.deserialize_SfmResult(header, frames)
+        header, frames = serialize(expected)
+        recovered = deserialize(header, frames)
 
         # comparing cameras and total reprojection error
         self.assertEqual(recovered.total_reproj_error, expected.total_reproj_error)


### PR DESCRIPTION
We were relying on custom serialization for GTSAM types. However, that was not very reliable on clusters as dask was falling back on pickle and not using custom serialization.

As GTSAM now supports pickle (https://github.com/borglab/gtsam/pull/709), we will remove all custom serialization.