### PR TITLE
Sim3 pose comparison

### DIFF
--- a/.github/scripts/python.sh
+++ b/.github/scripts/python.sh
@@ -8,9 +8,9 @@ echo "Running .github/scripts/python.sh..."
 conda init
 conda info --envs
 
-wget -O 2020_03_12_gtsam_python38_wheel.zip --no-check-certificate "https://drive.google.com/uc?export=download&id=1TDpvTb5YoP7v4WRugJyWhTq5Wol-C_il"
+wget -O 2021_03_12_gtsam_python38_wheel.zip --no-check-certificate "https://drive.google.com/uc?export=download&id=1JvsLYngMzSqvmD6RwEgEb_HXXHfw_EJ2"
 
-unzip 2020_03_12_gtsam_python38_wheel.zip
+unzip 2021_03_12_gtsam_python38_wheel.zip
 pip install gtsam-4.1.1-cp38-cp38-manylinux2014_x86_64.whl
 
 ##########################################################

--- a/.github/scripts/python.sh
+++ b/.github/scripts/python.sh
@@ -8,9 +8,9 @@ echo "Running .github/scripts/python.sh..."
 conda init
 conda info --envs
 
-wget -O 2020_03_08_gtsam_python38_wheel.zip --no-check-certificate "https://drive.google.com/uc?export=download&id=1lpU4TFqh5puH41h2kcqfIgX7_br_a0nb"
+wget -O 2020_03_12_gtsam_python38_wheel.zip --no-check-certificate "https://drive.google.com/uc?export=download&id=1TDpvTb5YoP7v4WRugJyWhTq5Wol-C_il"
 
-unzip 2020_03_08_gtsam_python38_wheel.zip
+unzip 2020_03_12_gtsam_python38_wheel.zip
 pip install gtsam-4.1.1-cp38-cp38-manylinux2014_x86_64.whl
 
 ##########################################################

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GTSFM is designed in an extremely modular way. Each module can be swapped out wi
         - `translation`: translation averaging implementations (1d-SFM, etc)
     - `bundle`: bundle adjustment implementations
     - `common`: basic classes used through GTSFM, such as `Keypoints`, `Image`, `SfmTrack2d`, etc
-    - `data_association`: 
+    - `data_association`: 3d point triangulation or w/o RANSAC, from 2d point-tracks 
     - `densify`
     - `frontend`: SfM front-end code, including:
         - `detector`: keypoint detector implementations (DoG, etc)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ On Linux, with CUDA support:
 conda env create -f environment_linux.yml
 conda activate gtsfm-v1 # you may need "source activate gtsfm-v1" depending upon your bash and conda set-up
 ```
-The Python3.8 `gtsam` wheel for Linux is available [here](https://github.com/borglab/gtsam-manylinux-build/suites/1859835370/artifacts/36145194).
+The Python3.8 `gtsam` wheel for Linux is available [here](https://github.com/borglab/gtsam-manylinux-build/suites/2239592652/artifacts/46493264).
 
 **Mac**
 On Mac OSX, there is no CUDA support and no `pydegensac` wheel in `pypi`, so run:
@@ -23,7 +23,7 @@ On Mac OSX, there is no CUDA support and no `pydegensac` wheel in `pypi`, so run
 conda env create -f environment_mac.yml
 conda activate gtsfm-v1
 ```
-Download the Python 3.8 gtsam wheel [here](https://github.com/borglab/gtsam-manylinux-build/suites/1859835370/artifacts/36145196), and install it as
+Download the Python 3.8 gtsam wheel for Mac [here](https://github.com/borglab/gtsam-manylinux-build/suites/2239592652/artifacts/46493266), and install it as
 ```bash
 pip install ~/Downloads/gtsam-4.1.1-py3-none-any.whl
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ GTSFM is designed in an extremely modular way. Each module can be swapped out wi
         - `translation`: translation averaging implementations (1d-SFM, etc)
     - `bundle`: bundle adjustment implementations
     - `common`: basic classes used through GTSFM, such as `Keypoints`, `Image`, `SfmTrack2d`, etc
-    - `data_association`: 3d point triangulation or w/o RANSAC, from 2d point-tracks 
+    - `data_association`: 3d point triangulation w/ or w/o RANSAC, from 2d point-tracks 
     - `densify`
     - `frontend`: SfM front-end code, including:
         - `detector`: keypoint detector implementations (DoG, etc)

--- a/gtsfm/data_association/data_assoc.py
+++ b/gtsfm/data_association/data_assoc.py
@@ -137,8 +137,8 @@ class DataAssociation(NamedTuple):
             "3d_tracks_length": {
                 "median": median_3d_track_length,
                 "mean": mean_3d_track_length,
-                "min": int(track_lengths_3d.min()),
-                "max": int(track_lengths_3d.max()),
+                "min": int(track_lengths_3d.min()) if track_lengths_3d.size > 0 else None,
+                "max": int(track_lengths_3d.max()) if track_lengths_3d.size > 0 else None,
                 "track_lengths_histogram": histogram_dict,
             },
             "mean_accepted_track_avg_error": np.array(per_accepted_track_avg_errors).mean(),

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -304,7 +304,7 @@ def visualize_camera_poses(
     viz_utils.plot_poses_3d(pre_ba_poses, ax, center_marker_color="c", label_name="Pre-BA")
     viz_utils.plot_poses_3d(post_ba_poses, ax, center_marker_color="k", label_name="Post-BA")
     if gt_pose_graph is not None:
-        gt_pose_graph = comp_utils.align_poses(gt_pose_graph, post_ba_poses)
+        gt_pose_graph = comp_utils.align_poses_sim3(post_ba_poses, gt_pose_graph)
         viz_utils.plot_poses_3d(gt_pose_graph, ax, center_marker_color="m", label_name="GT")
 
     ax.legend(loc="upper left")

--- a/gtsfm/utils/geometry_comparisons.py
+++ b/gtsfm/utils/geometry_comparisons.py
@@ -158,20 +158,20 @@ def compare_global_poses(
     aTi_list = [aTi_list[i] for i in aTi_valid]
     bTi_list = [bTi_list[i] for i in bTi_valid]
 
-    #  We set the reference as the ground truth.
-    bTi_list = align_poses_sim3(aTi_list, bTi_list)
+    #  We set frame "a" the target/reference
+    aTi_list_ = align_poses_sim3(aTi_list, bTi_list)
 
     return all(
         [
             (
-                aTi.rotation().equals(bTi.rotation(), rot_err_thresh)
+                aTi.rotation().equals(aTi_.rotation(), rot_err_thresh)
                 and np.allclose(
                     aTi.translation(),
-                    bTi.translation(),
+                    aTi_.translation(),
                     rtol=trans_err_thresh,
                 )
             )
-            for (aTi, bTi) in zip(aTi_list, bTi_list)
+            for (aTi, aTi_) in zip(aTi_list, aTi_list_)
         ]
     )
 

--- a/gtsfm/utils/metrics.py
+++ b/gtsfm/utils/metrics.py
@@ -169,7 +169,7 @@ def compute_averaging_metrics(
     wTi_list = []
     for (wRi, wti) in zip(wRi_list, wti_list):
         wTi_list.append(Pose3(wRi, wti))
-    wTi_aligned_list = comp_utils.align_poses(wTi_list, gt_wTi_list)
+    wTi_aligned_list = comp_utils.align_poses_sim3(gt_wTi_list, wTi_list)
 
     def get_rotations_translations_from_poses(
         poses: List[Optional[Pose3]],

--- a/tests/data_association/test_data_association.py
+++ b/tests/data_association/test_data_association.py
@@ -152,7 +152,8 @@ class TestDataAssociation(GtsamTestCase):
             mode=triangulation_mode,
             num_ransac_hypotheses=20,
         )
-        triangulated_landmark_map = da.run(cameras, matches_dict, keypoints_list)
+        triangulated_landmark_map, stats = da.run(cameras, matches_dict, keypoints_list)
+        
         # assert that we cannot obtain even 1 length-3 track if we have only 2 camera poses
         # result should be empty, since nb_measurements < min track length
         assert (
@@ -186,7 +187,7 @@ class TestDataAssociation(GtsamTestCase):
             min_track_len=2,  # at least 2 measurements required
             mode=TriangulationParam.NO_RANSAC,
         )
-        sfm_data = da.run(cameras, matches_dict, keypoints_list)
+        sfm_data, _ = da.run(cameras, matches_dict, keypoints_list)
         estimated_landmark = sfm_data.track(0).point3()
         self.gtsamAssertEquals(estimated_landmark, self.expected_landmark, 1e-2)
 
@@ -236,7 +237,7 @@ class TestDataAssociation(GtsamTestCase):
             mode=triangulation_mode,
             num_ransac_hypotheses=20,
         )
-        sfm_data = da.run(cameras, matches_dict, keypoints_list)
+        sfm_data, _ = da.run(cameras, matches_dict, keypoints_list)
 
         estimated_landmark = sfm_data.track(0).point3()
         # checks if computed 3D point is as expected
@@ -269,10 +270,10 @@ class TestDataAssociation(GtsamTestCase):
             mode=TriangulationParam.RANSAC_TOPK_BASELINES,
             num_ransac_hypotheses=20,
         )
-        expected_sfm_data = da.run(cameras, matches_dict, keypoints_list)
+        expected_sfm_data, _ = da.run(cameras, matches_dict, keypoints_list)
 
         # Run with computation graph
-        delayed_sfm_data = da.create_computation_graph(
+        delayed_sfm_data, _ = da.create_computation_graph(
             cameras,
             matches_dict,
             keypoints_list,

--- a/tests/data_association/test_point3d_initializer.py
+++ b/tests/data_association/test_point3d_initializer.py
@@ -106,7 +106,7 @@ class TestPoint3dInitializer(unittest.TestCase):
         """Run the initialization with a track with all correct measurements, and checks for correctness of the
         recovered 3D point."""
 
-        sfm_track = obj.triangulate(SfmTrack2d(MEASUREMENTS))
+        sfm_track, _, _ = obj.triangulate(SfmTrack2d(MEASUREMENTS))
         point3d = sfm_track.point3()
 
         return np.allclose(point3d, LANDMARK_POINT)
@@ -115,14 +115,14 @@ class TestPoint3dInitializer(unittest.TestCase):
         """Run the initialization with a track with all correct measurements, and checks for correctness of the
         recovered 3D point."""
 
-        sfm_track = obj.triangulate(SfmTrack2d(MEASUREMENTS[:2]))
+        sfm_track, _, _ = obj.triangulate(SfmTrack2d(MEASUREMENTS[:2]))
         point3d = sfm_track.point3()
 
         return np.allclose(point3d, LANDMARK_POINT)
 
     def __runWithOneMeasurement(self, obj: Point3dInitializer) -> bool:
         """Run the initialization with a track with all correct measurements, and checks for a None track as a result."""
-        sfm_track = obj.triangulate(SfmTrack2d(MEASUREMENTS[:1]))
+        sfm_track, _, _ = obj.triangulate(SfmTrack2d(MEASUREMENTS[:1]))
 
         return sfm_track is None
 
@@ -130,7 +130,7 @@ class TestPoint3dInitializer(unittest.TestCase):
         """Run the initialization for a track with all inlier measurements except one, and checks for correctness of
         the estimated point."""
 
-        sfm_track = obj.triangulate(SfmTrack2d(get_track_with_one_outlier()))
+        sfm_track, _, _ = obj.triangulate(SfmTrack2d(get_track_with_one_outlier()))
         point3d = sfm_track.point3()
 
         return np.array_equal(point3d, LANDMARK_POINT)
@@ -155,7 +155,7 @@ class TestPoint3dInitializer(unittest.TestCase):
             obj.num_ransac_hypotheses,
         )
 
-        sfm_track = obj_with_flipped_cameras.triangulate(SfmTrack2d(MEASUREMENTS))
+        sfm_track, _, _ = obj_with_flipped_cameras.triangulate(SfmTrack2d(MEASUREMENTS))
 
         return sfm_track is None
 
@@ -163,7 +163,7 @@ class TestPoint3dInitializer(unittest.TestCase):
         """Run the initialization for a track with all inlier measurements except one, and checks for correctness of
         the estimated point."""
 
-        sfm_track = obj.triangulate(SfmTrack2d(get_track_with_duplicate_measurements()))
+        sfm_track, _, _ = obj.triangulate(SfmTrack2d(get_track_with_duplicate_measurements()))
         point3d = sfm_track.point3()
 
         return np.allclose(point3d, LANDMARK_POINT, atol=1, rtol=1e-1)
@@ -179,7 +179,7 @@ class TestPoint3dInitializer(unittest.TestCase):
 
     def testSimpleTriangulationWithOutlierMeasurements(self):
 
-        sfm_track = self.simple_triangulation_initializer.triangulate(SfmTrack2d(get_track_with_one_outlier()))
+        sfm_track, _, _ = self.simple_triangulation_initializer.triangulate(SfmTrack2d(get_track_with_one_outlier()))
 
         self.assertIsNone(sfm_track)
 
@@ -244,7 +244,7 @@ class TestPoint3dInitializer(unittest.TestCase):
         ]
 
         for track_2d in tracks:
-            triangulated_track = initializer.triangulate(track_2d)
+            triangulated_track, _, _ = initializer.triangulate(track_2d)
 
             if triangulated_track is None:
                 # assert we have failures which are already expected

--- a/tests/test_scene_optimizer.py
+++ b/tests/test_scene_optimizer.py
@@ -15,7 +15,6 @@ from hydra.experimental import compose, initialize_config_module
 from hydra.utils import instantiate
 
 import gtsfm.utils.geometry_comparisons as comp_utils
-import gtsfm.utils.serialization  # import needed to register serialization fns
 from gtsfm.common.sfm_result import SfmResult
 from gtsfm.loader.folder_loader import FolderLoader
 from gtsfm.scene_optimizer import SceneOptimizer


### PR DESCRIPTION
- Make the target poses the first arg in pose alignment. Frame "A" is considered the first class frame (ground truth frame), and we move the inputs from frame "B" into frame "A" with `aSb`
- Fix unit tests from previous DA PR
- Remove old notation where there were two "world frames", because there can only be one such frame