### PR TITLE
Modified data_assoc.py to call functions from utils/ellipsoid.py

### DIFF
--- a/gtsfm/utils/ellipsoid.py
+++ b/gtsfm/utils/ellipsoid.py
@@ -1,0 +1,163 @@
+"""Algorithms to fit Ellisoid geometry to 3D points and extract the rotation matrix necessary to align point cloud with
+x, y, and z axes. Used in React Three Fiber Visualization Tool.
+
+Authors: Adi Singh
+"""
+
+import numpy as np
+from numpy.linalg import eig, inv
+from scipy.spatial import ConvexHull, convex_hull_plot_2d
+
+
+def center_point_cloud(pointsList: list) -> np.ndarray:
+    """Centers a point cloud with respect using mean values of x, y, and z.
+
+    Args:
+        pointCloud: list(length N) of lists(length 3) (representing the point cloud)
+
+    Returns:
+        Centered point cloud, of shape Nx3
+
+    Raises:
+        TypeError: if points list is not 3 dimensional
+    """
+    if len(pointsList[0]) != 3:
+        raise TypeError("Points list should be 3D")
+
+    points = np.array([np.array(p) for p in pointsList])
+
+    means = np.mean(points, axis=0)
+    points_centered = points - means
+    return points_centered
+
+
+def compute_convex_hull(points_np: np.ndarray) -> np.ndarray:
+    """Returns a set of vertices which represent the 3D Convex Hull (outer perimeter) of our point cloud.
+
+    Args:
+        points_np: point cloud of shape N x 3
+
+    Returns:
+        a reduced collection of points representing the convex hull, of shape M x 3 (M <= N)
+
+    Raises:
+        TypeError: if points_np is not 3 dimensional
+    """
+    if points_np.shape[1] != 3:
+        raise TypeError("Point Cloud should be 3D")
+
+    hull = ConvexHull(points_np)
+    hullSet = set()
+    for simplex in hull.simplices:
+        hullSet.add(tuple(points_np[simplex[0]]))
+        hullSet.add(tuple(points_np[simplex[1]]))
+
+    hull_set = np.array([np.array(p) for p in hullSet])
+    return hull_set
+
+
+def fit_ls_ellipsoid(hull_set: np.ndarray) -> np.ndarray:
+    """Fits an ellipsoid to a given set (x,y,z) 3D points using a least squares approximation approach.
+    Uses the formula for a general quadric surface:
+    Ax^2 + By^2 + Cz^2 +  Dxy +  Exz +  Fyz +  Gx +  Hy +  Iz + J = 0
+
+    See https://www.physics.smu.edu/~scalise/SMUpreprints/SMU-HEP-10-14.pdf for more details on the
+    mathematical approach to ellipsoidal fitting.
+
+    Args:
+        hull_set: the convex hull of the original point cloud, of shape N x 3
+
+    Returns:
+        Array, of length 9, for parameters A, B, ..., J
+
+    Raises:
+        TypeError: if hull_set is not 3 dimensional
+    """
+    if hull_set.shape[1] != 3:
+        raise TypeError("Point Cloud should be 3D")
+
+    x = hull_set[:, 0].reshape(hull_set.shape[0], 1)
+    y = hull_set[:, 1].reshape(hull_set.shape[0], 1)
+    z = hull_set[:, 2].reshape(hull_set.shape[0], 1)
+
+    A = np.hstack((x * x, y * y, z * z, 2 * x * y, 2 * x * z, 2 * y * z, 2 * x, 2 * y, 2 * z))
+    b = np.ones_like(x)
+
+    # solve normal equations to find the 9 parameters
+    ATA = A.T @ A
+    ATA_inv = np.linalg.inv(ATA)
+    params = ATA_inv @ (A.T @ b)
+    params = np.append(params, -1)
+
+    return params
+
+
+def extract_params_from_poly(params: np.ndarray) -> np.ndarray:
+    """Extracts the center, axes, and rotation matrix for an ellipsoid given the quadric surface polynomial equation.
+
+    Args:
+        params: parameters (A, B, ..., J) for the polynomial equation
+
+    Returns:
+        Center, Axes Lengths, and Rotation Matrix for the Ellipsoid.
+
+    Raises:
+        TypeError: if params is not of the length 10
+    """
+    if params.shape[0] != 10:
+        raise TypeError("Params should of length 10")
+
+    M = np.array(
+        [
+            [params[0], params[3] / 2.0, params[4] / 2.0, params[6] / 2.0],
+            [params[3] / 2.0, params[1], params[5] / 2.0, params[7] / 2.0],
+            [params[4] / 2.0, params[5] / 2.0, params[2], params[8] / 2.0],
+            [params[6] / 2.0, params[7] / 2.0, params[8] / 2.0, params[9]],
+        ]
+    )
+
+    # find center of ellipsoid
+    A3 = M[0:3, 0:3]
+    A3_inv = inv(A3)
+    ofs = params[6:9] / 2.0
+    center = -(A3_inv @ ofs)
+
+    # center ellipsoid at origin
+    Tofs = np.eye(4)
+    Tofs[3, 0:3] = center
+    R = Tofs @ (M @ Tofs.T)
+
+    # eigen decomp
+    R3 = R[0:3, 0:3]
+    s1 = -R[3, 3]
+    R3S = R3 / s1
+    (el, ec) = eig(R3S)
+
+    recip = 1.0 / np.abs(el)
+    axes = np.sqrt(recip)
+    inve = inv(ec)
+
+    return (center, axes, inve)
+
+
+def apply_ellipsoid_rotation(rot: np.ndarray, centered_pc: np.ndarray):
+    """Applies a rotation on the centered point cloud.
+
+    Args:
+        rot: rotation matrix, shape 3x3
+        centered_pc: centered point cloud, shape Nx3
+
+    Returns:
+        a modified point cloud entirely in list form
+
+    Raises:
+        TypeError: if rot matrix isn't 3x3 or centered_pc is not of dimension 3
+    """
+    if rot.shape[0] != 3 or rot.shape[1] != 3:
+        raise TypeError("Rotation Matrix should be of shape 3x3")
+    if centered_pc.shape[1] != 3:
+        raise TypeError("Point Cloud shoud be 3 dimensional")
+
+    rotated_points = rot @ centered_pc.T
+    rotated_points_list = (rotated_points.T).tolist()
+    return rotated_points_list

--- a/gtsfm/utils/test_ellipsoid_utils.py
+++ b/gtsfm/utils/test_ellipsoid_utils.py
@@ -1,0 +1,121 @@
+"""Unit tests for functions in ellipsoid utils file.
+
+Authors: Adi Singh
+"""
+import gtsfm.utils.ellipsoid as ellipsoid_utils
+import numpy as np
+import numpy.testing as npt
+import unittest
+
+
+class TestEllipsoidUtils(unittest.TestCase):
+    def test_center_point_cloud_sample_points(self):
+        """Testing the center_point_cloud() function with 5 sample points."""
+        sample_points = [[6, 13, 9], [5, 9, 7], [6, 10, 9], [9, 13, 6], [5, 12, 9]]
+        computed = ellipsoid_utils.center_point_cloud(sample_points)
+        expected = np.array([[-0.2, 1.6, 1], [-1.2, -2.4, -1], [-0.2, -1.4, 1], [2.8, 1.6, -2], [-1.2, 0.6, 1]])
+        npt.assert_almost_equal(computed, expected, 6)
+
+    def test_center_point_cloud_wrong_dims(self):
+        """Testing the center_point_cloud() function with 5 sample points of 2 dimensions."""
+        sample_points = [[6, 13], [5, 9], [6, 10], [9, 13], [5, 12]]
+        self.assertRaises(TypeError, ellipsoid_utils.center_point_cloud, sample_points)
+
+    def test_compute_convex_hull_sample_points(self):
+        """Testing the compute_convex_hull() function with 5 sample points."""
+        sample_points = np.array([[6, 13, 9], [5, 9, 7], [6, 10, 9], [9, 13, 6], [5, 12, 9]])
+        computed = ellipsoid_utils.compute_convex_hull(sample_points)
+        computed = np.sort(computed, axis=0)
+
+        expected = np.array([[5, 12, 9], [6, 13, 9], [6, 10, 9], [9, 13, 6]])
+        expected = np.sort(expected, axis=0)
+
+        npt.assert_almost_equal(computed, expected, 6)
+
+    def test_compute_convex_hull_wrong_dims(self):
+        """Testing the compute_convex_hull() function with 5 sample points of 2 dimesions."""
+        sample_points = np.array([[6, 13], [5, 9], [6, 10], [9, 13], [5, 12]])
+        self.assertRaises(TypeError, ellipsoid_utils.compute_convex_hull, sample_points)
+
+    def test_fit_ls_ellipsoid_sample_points(self):
+        """Testing the fit_ls_ellipsoid() function with 5 sample points."""
+        sample_points = np.array([[0.1, 1.3, 0.9], [0.5, 0.9, 0.7], [0.6, 1.0, 0.9], [0.9, 1.3, 0.6], [0.5, 1.2, 0.9]])
+        computed = ellipsoid_utils.fit_ls_ellipsoid(sample_points)
+        expected = np.array([0.125, 3.875, -10.5, -4, 10.304688, -1, -1, 0.25, 1.65625, -1])
+        npt.assert_almost_equal(computed, expected, 6)
+
+    def test_fit_ls_ellipsoid_wrong_dims(self):
+        """Testing the fit_ls_ellipsoid() function with 5 sample points of dimension 2."""
+        sample_points = np.array([[0.1, 1.3], [0.5, 0.9], [0.6, 1.0], [0.9, 1.3], [0.5, 1.2]])
+        self.assertRaises(TypeError, ellipsoid_utils.fit_ls_ellipsoid, sample_points)
+
+    def test_extract_params_from_poly_sample_points(self):
+        """Testing the extract_params_from_poly() function."""
+        params = np.array(
+            [
+                0.04026749,
+                0.04943968,
+                0.0519318,
+                0.00137289,
+                0.01238955,
+                0.02562406,
+                0.03067298,
+                -0.00346132,
+                0.02130539,
+                -1,
+            ]
+        )
+
+        computed_center, computed_axes, computed_rot = ellipsoid_utils.extract_params_from_poly(params)
+
+        expected_center = np.array([-0.35396952, 0.08774596, -0.18455235])
+        expected_axes = np.array([3.94845524, 4.88893746, 5.37621732])
+        expected_rot = np.array(
+            [
+                [-0.20692656, -0.63630763, -0.74316485],
+                [-0.75280031, 0.58871614, -0.29445713],
+                [-0.62487846, -0.49852373, 0.60083358],
+            ]
+        )
+
+        npt.assert_almost_equal(computed_center, expected_center, 6)
+        npt.assert_almost_equal(computed_axes, expected_axes, 6)
+        npt.assert_almost_equal(computed_rot, expected_rot, 6)
+
+    def test_extract_params_from_poly_wrong_dims(self):
+        """Testing the extract_params_from_poly() function with 11 parameters."""
+        params = np.array(
+            [
+                0.04026749,
+                0.04943968,
+                0.0519318,
+                0.00137289,
+                0.01238955,
+                0.02562406,
+                0.03067298,
+                -0.00346132,
+                0.02130539,
+                -1,
+                -1,
+            ]
+        )
+        self.assertRaises(TypeError, ellipsoid_utils.extract_params_from_poly, params)
+
+    def test_apply_ellipsoid_rotation_sample_points(self):
+        """Testing the apply_ellipsoid_rotation() function with 3 sample points and a matrix which rotates 180 degrees about z."""
+        sample_rot = np.array([[-1, 0, 0], [0, -1, 0], [0, 0, 1]])  # 180 degrees rotation about z axis
+        sample_points = np.array([[2, 3, 5], [-1, 4, 6], [-2, -2, 3]])
+
+        computed = ellipsoid_utils.apply_ellipsoid_rotation(sample_rot, sample_points)
+        expected = [[-2, -3, 5], [1, -4, 6], [2, 2, 3]]
+        self.assertListEqual(computed, expected)
+
+    def test_apply_ellipsoid_rotation_wrong_dims(self):
+        """Testing the apply_ellipsoid_rotation() function with a rotation matrix of shape 3 x 2."""
+        sample_rot = np.array([[-1, 0], [0, -1], [0, 0]])
+        sample_points = np.array([[2, 3, 5], [-1, 4, 6], [-2, -2, 3]])
+        self.assertRaises(TypeError, ellipsoid_utils.apply_ellipsoid_rotation, sample_rot, sample_points)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Note:** this PR is outdated. Once the rest of the React application code is merged into master, I will work make a new PR similar to this where I add ellipsoid fitting functionality.

Modified `data_association/data_assoc.py` to import some helper functions from `util/ellipsoid.py`. These helper functions serve to 

- fit an ellipsoid quadric surface to the generated point cloud
- center the point cloud with respect to the origin
- apply a rotation matrix to the point cloud to align it along the x, y, z axes

This new rotated point cloud is added as a key/vaue pair to the `data_assoc_metrics` dictionary (line 145), which ultimately gets saved into the `data_association_metrics.json`.