### PR TITLE
React Part 3: Components for Plate Summaries and Camera Frustum Rendering

### DIFF
--- a/rtf_vis_tool/README.md
+++ b/rtf_vis_tool/README.md
@@ -43,8 +43,8 @@ package.json
 - `@testing-library/react` : auto generated when initializing react app
 - `@testing-library/user-event` : auto generated when initializing react app
 - `drei` : used to render lines and text in the react three fiber point cloud (`Data_Association_PC.js`)
-- `numjs` : used to render camera frustums (`PCViewer.js`)
-- `quaternion` : used to extract rotation matrix from Quaternion (`PCViewer.js`)
+- `numjs` : used to render camera frustums (`AllFrustums.js`)
+- `quaternion` : used to extract rotation matrix from Quaternion (`AllFrustums.js`)
 - `react` : primary react import for all files in the `Components` folder
 - `react-dom` : helper library of react to perform live webpage updates upon refresh
 - `react-scripts` : used to run the application when user types `npm-start`

--- a/rtf_vis_tool/README.md
+++ b/rtf_vis_tool/README.md
@@ -18,11 +18,11 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 Note: running the application for the first time will auto generate a `/node_modules` folder and `.eslintcache` file which are included in `.gitignore`.
 
 
-4. Run the React Unit Tests:
+4. Run the React Unit Tests (within `gtsfm/rtf_vis_tool`):
 ```bash
-npm test
+npm test a
 ```
-Currently, the unit tests are written for smaller, helper components that do not involve React Three Fiber. This is because the React unit testing framework, Enzyme, does not provide native support for third party packages like React Three Fiber. Thus, it's incompatible with components with render 3D-related components.
+Currently, the unit tests are written for smaller, helper components that do not involve React Three Fiber. This is because the React unit testing framework, Enzyme, does not provide native support for third party packages like React Three Fiber. Thus, it's incompatible with components that render 3D-related components.
 
 ## Repository Structure
 - `node_modules`: internal packages used throughout the application. Don't edit these.

--- a/rtf_vis_tool/package-lock.json
+++ b/rtf_vis_tool/package-lock.json
@@ -11086,9 +11086,9 @@
       }
     },
     "node-abi": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
-      "integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.21.0.tgz",
+      "integrity": "sha512-smhrivuPqEM3H5LmnY3KU6HfYv0u4QklgAxfFyRNujKUzbUcYZ+Jc2EhukB9SRcD2VpqhxM7n/MIcp1Ua1/JMg==",
       "requires": {
         "semver": "^5.4.1"
       },
@@ -11293,8 +11293,8 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "numjs": {
-      "version": "git+ssh://git@github.com/nicolaspanel/numjs.git#1bd9f59f8eefb78fe33e8eb51964ed03e43187da",
-      "from": "numjs@https://github.com/nicolaspanel/numjs",
+      "version": "git+https://github.com/nicolaspanel/numjs.git#1bd9f59f8eefb78fe33e8eb51964ed03e43187da",
+      "from": "git+https://github.com/nicolaspanel/numjs.git",
       "requires": {
         "cwise": "^1.0.8",
         "deasync": "^0.1.4",

--- a/rtf_vis_tool/package.json
+++ b/rtf_vis_tool/package.json
@@ -7,7 +7,7 @@
     "@testing-library/react": "^11.2.3",
     "@testing-library/user-event": "^12.6.0",
     "drei": "^2.2.13",
-    "numjs": "https://github.com/nicolaspanel/numjs",
+    "numjs": "git+https://github.com/nicolaspanel/numjs.git",
     "quaternion": "^1.1.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/rtf_vis_tool/src/Components/AllFrustums.js
+++ b/rtf_vis_tool/src/Components/AllFrustums.js
@@ -76,20 +76,16 @@ function AllFrustums() {
             }
 
             // Set the important variables from inCamArray and exCamArray
-            var fx, img_w, img_h, qw, qx, qy, qz, tx, ty, tz;
+            var fx, img_w, img_h;
             inCamArray = inCamArray.map(Number);
             exCamArray = exCamArray.map(Number);
 
             fx = inCamArray[4];
             img_w = inCamArray[2];
             img_h = inCamArray[3];
-            qw = exCamArray[1];
-            qx = exCamArray[2];
-            qy = exCamArray[3];
-            qz = exCamArray[4];
-            tx = exCamArray[5];
-            ty = exCamArray[6];
-            tz = exCamArray[7];
+
+            const [qw, qx, qy, qz] = [exCamArray[1], exCamArray[2], exCamArray[3], exCamArray[4]];
+            const [tx, ty, tz] = [exCamArray[5], exCamArray[6], exCamArray[7]]
             const DEFAULT_FRUSTUM_RAY_LENGTH = 0.5;  //meters, arbitrary
 
             // Use Frustum and SE3 Classes to obtain frustum vertices in world frame coordinates.

--- a/rtf_vis_tool/src/Components/AllFrustums.js
+++ b/rtf_vis_tool/src/Components/AllFrustums.js
@@ -1,0 +1,115 @@
+/* Component that renders all of the Frustums using the files: cameras.txt and images.txt. Will be rendered within
+Bundle_Adj_PC.js.
+
+Author: Adi Singh
+*/
+import React, {useEffect, useState} from "react";
+import Frustum from './Frustum';
+
+// Third-Party Package Imports.
+var nj = require('numjs');
+var Quaternion = require('quaternion');
+
+// Local Imports.
+var SE3 = require('./frustum_classes/se3');
+var ViewFrustum = require('./frustum_classes/view_frustum');
+
+function AllFrustums() {
+    /* 
+    Returns:
+        A component rendering all the camera frustums.
+    */
+    const [frustumsJSX, setFrustumsJSX] = useState([]);
+
+    // Load camera intrinsics and extrinsics by fetching cameras.txt and images.txt respectively.
+    useEffect(() => {
+        
+        // Fetch camera intrinsics from cameras.txt.
+        fetch('results/ba_input/cameras.txt')
+            .then((response) => response.text())
+            .then((in_data) => {
+
+                // Fetch camera extrinsics from images.txt.
+                fetch('results/ba_input/images.txt')
+                .then((response) => response.text())
+                .then((ex_data) => {
+                    visualize_camera_frustums(in_data, ex_data)
+                });
+            });
+    }, []);
+
+    function visualize_camera_frustums(in_data, ex_data) {
+        /* Given all the intrinsic and extrinsic data for all cameras, creates an array of frustums to be 
+        rendered in react three fiber.
+
+        Args:
+            in_data (string): Raw string from cameras.txt. 
+            ex_data (string): Raw string from images.txt.
+        */
+
+        var in_cameraList = in_data.split('\n');
+        in_cameraList = in_cameraList.slice(3);  // Remove the first 3 lines of comments in cameras.txt.
+        in_cameraList.pop()  // Remove the last empty string from list.
+        
+        var ex_cameraList = ex_data.split('\n');
+        ex_cameraList = ex_cameraList.slice(4); // Remove the 4 lines of comments in images.txt.
+        ex_cameraList.pop() // remove the last empty string from list.
+
+        if (in_cameraList.length != ex_cameraList.length) {
+            alert('Camera count mismatch between images.txt and cameras.txt');
+            return;
+        }
+
+        var finalFrustumsJSX = [];
+        // Combine information from intrinsics and extrinsics to render frustums.
+        for (var i = 0; i < in_cameraList.length; i++) {
+            var inCamArray = in_cameraList[i].split(" ");
+            var exCamArray = ex_cameraList[i].split(" ");
+
+            if (inCamArray[0] !== exCamArray[0]) {
+                alert("Error: Cam IDs in Intrinsic and Extrinsic Files Don't Match.");
+                break;
+            }
+
+            // Set the important variables from inCamArray and exCamArray
+            var fx, img_w, img_h, qw, qx, qy, qz, tx, ty, tz;
+            inCamArray = inCamArray.map(Number);
+            exCamArray = exCamArray.map(Number);
+
+            fx = inCamArray[4];
+            img_w = inCamArray[2];
+            img_h = inCamArray[3];
+            qw = exCamArray[1];
+            qx = exCamArray[2];
+            qy = exCamArray[3];
+            qz = exCamArray[4];
+            tx = exCamArray[5];
+            ty = exCamArray[6];
+            tz = exCamArray[7];
+            const DEFAULT_FRUSTUM_RAY_LENGTH = 0.5;  //meters, arbitrary
+
+            // Use Frustum and SE3 Classes to obtain frustum vertices in world frame coordinates.
+            const frustumObj = new ViewFrustum(fx, img_w, img_h, DEFAULT_FRUSTUM_RAY_LENGTH);
+            const q = new Quaternion(qw, qx, qy, qz);
+            const rotation_matrix = q.toMatrix(true);
+            const rotation = nj.array(rotation_matrix);
+            const translation = nj.array([tx,ty,tz]);
+            const wTc = new SE3(rotation, translation);
+            var verts_worldframe = frustumObj.get_mesh_vertices_worldframe(wTc);
+
+            finalFrustumsJSX.push(<Frustum 
+                v0={verts_worldframe[0][0]}
+                v1={verts_worldframe[1][0]}
+                v2={verts_worldframe[2][0]}
+                v3={verts_worldframe[3][0]}
+                v4={verts_worldframe[4][0]}
+                width={0.5}
+                />)
+        }
+        setFrustumsJSX(finalFrustumsJSX);
+    }
+
+    return(frustumsJSX);
+}
+
+export default AllFrustums;

--- a/rtf_vis_tool/src/Components/AllFrustums.js
+++ b/rtf_vis_tool/src/Components/AllFrustums.js
@@ -43,8 +43,12 @@ function AllFrustums() {
         rendered in react three fiber.
 
         Args:
-            in_data (string): Raw string from cameras.txt. 
-            ex_data (string): Raw string from images.txt.
+            in_data (string): Raw string from cameras.txt, which contains instrinsic parameters of all reconstructed
+                              cameras as per the COLMAP output convention. 
+                              (https://colmap.github.io/format.html#cameras-txt)
+            ex_data (string): Raw string from images.txt, which contains pose and keypoints of all reconstructed images
+                              as per the COLMAP output convention.
+                              (https://colmap.github.io/format.html#images-txt)
         */
 
         var in_cameraList = in_data.split('\n');

--- a/rtf_vis_tool/src/Components/BlueNode.js
+++ b/rtf_vis_tool/src/Components/BlueNode.js
@@ -23,13 +23,19 @@ function BlueNode(props) {
     const nodeTopOffset = props.nodeInfo.topOffset;
     const nodeLeftOffset = props.nodeInfo.leftOffset;
 
+    function defaultFunction(text) {
+        alert(`You Clicked ${text}`);
+    }
+
     return (
         <GtsfmNode 
             textColor={'white'} 
             backgroundColor={aquaBlue} 
             topOffset={`${nodeTopOffset}%`} 
             leftOffset={`${nodeLeftOffset}%`}
-            text={nodeText}/>
+            text={nodeText}
+            onClickFunction={defaultFunction}
+            funcParam={nodeText}/>
     )
 }
 

--- a/rtf_vis_tool/src/Components/BlueNode.js
+++ b/rtf_vis_tool/src/Components/BlueNode.js
@@ -24,6 +24,12 @@ function BlueNode(props) {
     const nodeLeftOffset = props.nodeInfo.leftOffset;
 
     function defaultFunction(text) {
+        /* A placeholder function. Just displays the text of the node that is clicked on screen.
+
+        Args:
+            text (string): Name of the node.
+        */
+
         alert(`You Clicked ${text}`);
     }
 

--- a/rtf_vis_tool/src/Components/Bundle_Adj_PC.js
+++ b/rtf_vis_tool/src/Components/Bundle_Adj_PC.js
@@ -103,7 +103,7 @@ function Bundle_Adj_PC(props) {
     }
 
     return (
-        <div className="ba-container">
+        <div className="ba_container">
             <h2>Bundle Adjustment Point Cloud</h2>
             <Canvas colorManagement camera={{ fov: 20, position: [50, 50, 50], up: [0,0,1]}}>
                 <ambientLight intensity={0.5}/>

--- a/rtf_vis_tool/src/Components/Bundle_Adj_PC.js
+++ b/rtf_vis_tool/src/Components/Bundle_Adj_PC.js
@@ -9,6 +9,7 @@ import React, {useEffect, useState} from "react";
 import {Canvas} from "react-three-fiber"; // Used to render canvas containing 3D elements
 
 // Local Imports.
+import AllFrustums from './AllFrustums';
 import CoordinateGrid from './CoordinateGrid';
 import OrbitControlsComponent from './OrbitControlsComponent';
 import PointMesh from './PointMesh';
@@ -119,6 +120,7 @@ function Bundle_Adj_PC(props) {
                 {pointCloudJSX}
                 {showCoordGrid && <CoordinateGrid />}
                 <OrbitControlsComponent />
+                <AllFrustums/>
             </Canvas>
 
             <button className="ba_go_back_btn" onClick={() => props.toggleBA_PC(false)}>Go Back</button>

--- a/rtf_vis_tool/src/Components/FrontendSummary.js
+++ b/rtf_vis_tool/src/Components/FrontendSummary.js
@@ -1,0 +1,63 @@
+/* Component to render Frontend Summary metrics. Specifically rotation sucesses, translation
+successes, pose successes, and correspondence inliers.
+
+Author: Adi Singh
+*/
+import React from "react";
+
+// Local Imports.
+import '../stylesheets/FrontendSummary.css'
+
+function FrontendSummary(props) {
+    /*
+    Args:
+        props.json.rotation_success_count (int): Number of successes from rotation averaging.
+        props.json.translation_success_count (int): Number of successes frmo translation averaging.
+        props.json.num_valid_entries (int): Number of valid image pair entries.
+        props.json.num_total_entries (int): Number of total image pair entries.
+        props.json.pose.success_count (int): Number of pose successes.
+        props.json.correspondence.all_inliers (int): Number of correspondence inliers.
+        
+    Returns:
+        A component showing frontend summary metrics after clicking the 'TwoViewEstimator' Plate.
+    */
+
+    return (
+        <div className="fs_container">
+            <div className="fs_sub_container">
+                <h3>Frontend Summary Metrics</h3>
+                <p className="format_hint">
+                    Format: (success count)/(valid entries)/(total entries)
+                </p>
+
+                <p className="fs-text">
+                    Rotation Success: {props.json.rotation.success_count}/
+                                    {props.json.num_valid_entries}/
+                                    {props.json.num_total_entries}
+                </p>
+
+                <p className="fs-text">
+                    Translation Success: {props.json.translation.success_count}/
+                                        {props.json.num_valid_entries}/
+                                        {props.json.num_total_entries}
+                </p>
+
+                <p className="fs-text">
+                    Pose Success: {props.json.pose.success_count}/
+                                {props.json.num_valid_entries}/
+                                {props.json.num_total_entries}
+                </p>
+
+                <p className="fs-text">
+                    Correspondence Inliners: {props.json.correspondences.all_inliers}
+                </p>
+
+                <button className="go_back_btn" onClick={() => props.toggleFS(false)}>
+                    Go Back
+                </button>
+            </div>
+        </div>
+    )
+}
+
+export default FrontendSummary;

--- a/rtf_vis_tool/src/Components/FrontendSummary.js
+++ b/rtf_vis_tool/src/Components/FrontendSummary.js
@@ -11,8 +11,8 @@ import '../stylesheets/FrontendSummary.css'
 function FrontendSummary(props) {
     /*
     Args:
-        props.json.rotation_success_count (int): Number of successes from rotation averaging.
-        props.json.translation_success_count (int): Number of successes frmo translation averaging.
+        props.json.rotation.success_count (int): Number of successes from rotation averaging.
+        props.json.translation.success_count (int): Number of successes frmo translation averaging.
         props.json.num_valid_entries (int): Number of valid image pair entries.
         props.json.num_total_entries (int): Number of total image pair entries.
         props.json.pose.success_count (int): Number of pose successes.

--- a/rtf_vis_tool/src/Components/FrontendSummary.js
+++ b/rtf_vis_tool/src/Components/FrontendSummary.js
@@ -11,11 +11,13 @@ import '../stylesheets/FrontendSummary.css'
 function FrontendSummary(props) {
     /*
     Args:
-        props.json.rotation.success_count (int): Number of successes from rotation averaging.
-        props.json.translation.success_count (int): Number of successes frmo translation averaging.
+        props.json.rotation.success_count (int): Number of image pairs with estimated relative rotation error 
+        underneath the threshold.
+        props.json.translation.success_count (int): Number of image pairs with estimated relative translation error 
+        underneath the threshold.
         props.json.num_valid_entries (int): Number of valid image pair entries.
         props.json.num_total_entries (int): Number of total image pair entries.
-        props.json.pose.success_count (int): Number of pose successes.
+        props.json.pose.success_count (int): Number of image pairs with successfully recovered relative pose.
         props.json.correspondence.all_inliers (int): Number of correspondence inliers.
         
     Returns:
@@ -30,25 +32,25 @@ function FrontendSummary(props) {
                     Format: (success count)/(valid entries)/(total entries)
                 </p>
 
-                <p className="fs-text">
+                <p className="fs_text">
                     Rotation Success: {props.json.rotation.success_count}/
                                     {props.json.num_valid_entries}/
                                     {props.json.num_total_entries}
                 </p>
 
-                <p className="fs-text">
+                <p className="fs_text">
                     Translation Success: {props.json.translation.success_count}/
                                         {props.json.num_valid_entries}/
                                         {props.json.num_total_entries}
                 </p>
 
-                <p className="fs-text">
+                <p className="fs_text">
                     Pose Success: {props.json.pose.success_count}/
                                 {props.json.num_valid_entries}/
                                 {props.json.num_total_entries}
                 </p>
 
-                <p className="fs-text">
+                <p className="fs_text">
                     Correspondence Inliners: {props.json.correspondences.all_inliers}
                 </p>
 

--- a/rtf_vis_tool/src/Components/Frustum.js
+++ b/rtf_vis_tool/src/Components/Frustum.js
@@ -1,4 +1,4 @@
-/* Component that renders a single Camera Frustum given 5 vertices. USed in AllFrustums.js.
+/* Component that renders a single Camera Frustum given 5 vertices. Used in AllFrustums.js.
 
 Author: Adi Singh
 */

--- a/rtf_vis_tool/src/Components/Frustum.js
+++ b/rtf_vis_tool/src/Components/Frustum.js
@@ -1,0 +1,46 @@
+/* Component that renders a single Camera Frustum given 5 vertices. USed in AllFrustums.js.
+
+Author: Adi Singh
+*/
+import React from "react";
+
+// Third-Party Package Imports.
+import {Line} from "drei";
+
+function Frustum (props) {
+    /*
+    Args:
+        props.v0 (array: size 3 of floats): Camera's optical center.
+        props.v1 (array: size 3 of floats): First vertex in camera's far plane.
+        props.v2 (array: size 3 of floats): Second vertex in camera's far plane.
+        props.v3 (array: size 3 of floats): Third vertex in camera's far plane.
+        props.v4 (array: size 3 of floats): Fourth vertex in camera's far plane.
+        props.width (float): Width of the line segments forming the frustum.
+
+           (v1) o-------------------o (v2)
+                |                   |
+                |     (v0) o        |
+                |                   |
+           (v4) o-------------------o (v3)
+
+        
+    Returns:
+        A component rendering a camera frustum consisting of 5 vertices.
+    */
+    const black = "#000000"
+
+    return (
+      <mesh>
+        <Line points={[props.v0,props.v1]} color={black} lineWidth={props.width}/>
+        <Line points={[props.v0,props.v2]} color={black} lineWidth={props.width}/>
+        <Line points={[props.v0,props.v3]} color={black} lineWidth={props.width}/>
+        <Line points={[props.v0,props.v4]} color={black} lineWidth={props.width}/>
+        <Line points={[props.v1,props.v2]} color={black} lineWidth={props.width}/>
+        <Line points={[props.v2,props.v3]} color={black} lineWidth={props.width}/>
+        <Line points={[props.v3,props.v4]} color={black} lineWidth={props.width}/>
+        <Line points={[props.v4,props.v1]} color={black} lineWidth={props.width}/>
+      </mesh>
+    )
+}
+
+export default Frustum;

--- a/rtf_vis_tool/src/Components/GrayNode.js
+++ b/rtf_vis_tool/src/Components/GrayNode.js
@@ -23,13 +23,19 @@ function GrayNode(props) {
     const nodeTopOffset = props.nodeInfo.topOffset;
     const nodeLeftOffset = props.nodeInfo.leftOffset;
 
+    function defaultFunction(text) {
+        alert(`You Clicked ${text}`);
+    }
+
     return (
         <GtsfmNode 
             textColor={'black'} 
             backgroundColor={lightGray} 
             topOffset={`${nodeTopOffset}%`} 
             leftOffset={`${nodeLeftOffset}%`}
-            text={nodeText}/>
+            text={nodeText}
+            onClickFunction={defaultFunction}
+            funcParam={nodeText}/>
     )
 }
 

--- a/rtf_vis_tool/src/Components/LandingPageGraph.js
+++ b/rtf_vis_tool/src/Components/LandingPageGraph.js
@@ -14,10 +14,12 @@ import Bundle_Adj_PC from './Bundle_Adj_PC';
 import data_association_json from '../result_metrics/data_association_metrics.json';
 import EdgeList from './gtsfm_graph/edge_list.js';
 import frontend_summary_json from '../result_metrics/frontend_summary.json';
+import FrontendSummary from './FrontendSummary';
 import GrayNode from './GrayNode';
 import GrayNodes from './gtsfm_graph/gray_nodes.js';
-import multiview_optimizer_json from '../result_metrics/multiview_optimizer_metrics.json';
 import GtsfmNode from './GtsfmNode';
+import multiview_optimizer_json from '../result_metrics/multiview_optimizer_metrics.json';
+import MVOSummary from './MVOSummary';
 import '../stylesheets/LandingPageGraph.css'
 
 function LandingPageGraph() {
@@ -129,6 +131,8 @@ function LandingPageGraph() {
 
             {/* Render popups only when the respective node is clicked. */} 
             {showDA_PC && <Bundle_Adj_PC toggleBA_PC={toggleBundleAdj_PointCloud}/>}
+            {showFS && <FrontendSummary json={fs_json} toggleFS={toggleFrontEndSummaryDisplay}/>}
+            {showMVO && <MVOSummary json={mvo_json} toggleMVO={toggleMVOMetrics}/>}
 
             <div className="gtsfm_graph">
 

--- a/rtf_vis_tool/src/Components/MVOSummary.js
+++ b/rtf_vis_tool/src/Components/MVOSummary.js
@@ -1,0 +1,86 @@
+/* Component to render Multiview Optimizer Metrics. Specifically rotation averaging and
+translation averaging metrics.
+
+Author: Adi Singh
+*/
+import React from "react";
+
+// Local Imports.
+import '../stylesheets/MVOSummary.css'
+
+function MVOSummary(props) {
+    /*
+    Args:
+        props.json.rotation_averaging_angle_deg.median_error (float): Median error of rotation averaging.
+        props.json.rotation_averaging_angle_deg.min_error (float): Min error of rotation averaging.
+        props.json.rotation_averaging_angle_deg.max_error (float): Max error of rotation averaging.
+        props.json.translation_averaging_distance.median_error (float): Median error of translation averaging.
+        props.json.translation_averaging_distance.min_error (float): Min error of translation averaging.
+        props.json.translation_averaging_distance.max_error (float): Max error of translation averaging.
+        props.json.translation_to_direction_angle_deg.median_error (float): Median error of translation to direction.
+        props.json.translation_to_direction_angle_deg.min_error (float): Min error of translation to direction.
+        props.json.translation_to_direction_angle_deg.max_error (float): Max error of tranlation to direction.
+
+    Returns:
+        A component showing multiview optimizer metrics after clicking the 'Sparse Multiview Optimizer' Plate.
+    */
+
+    return (
+        <div className="mvo_container">
+            <h3>MultiView Optimizer Metrics</h3>
+            <div className="mvo_sub_container">
+                <div className="metrics_container">
+                    <p className="mvo-header">Rotation Averaging Angle Metrics</p>
+
+                    <p className="mvo-text">
+                        Median Error: {props.json.rotation_averaging_angle_deg.median_error.toFixed(5)}
+                    </p>
+
+                    <p className="mvo-text">
+                        Min Error: {props.json.rotation_averaging_angle_deg.min_error.toFixed(5)}
+                    </p>
+
+                    <p className="mvo-text">
+                        Max Error: {props.json.rotation_averaging_angle_deg.max_error.toFixed(5)}
+                    </p>
+                </div>
+
+                <div className="metrics_container">
+                    <p className="mvo-header">Translation Averaging Metrics</p>
+
+                    <p className="mvo-text">
+                        Median Error: {props.json.translation_averaging_distance.median_error.toFixed(5)}
+                    </p>
+
+                    <p className="mvo-text">
+                        Min Error: {props.json.translation_averaging_distance.min_error.toFixed(5)}
+                    </p>
+
+                    <p className="mvo-text">
+                        Max Error: {props.json.translation_averaging_distance.max_error.toFixed(5)}
+                    </p>
+                </div>
+
+                <div className="metrics_container">
+                    <p className="mvo-header">Translation to Direction Angle Metrics</p>
+
+                    <p className="mvo-text">
+                        Median Error: {props.json.translation_to_direction_angle_deg.median_error.toFixed(5)}
+                    </p>
+
+                    <p className="mvo-text">
+                        Min Error: {props.json.translation_to_direction_angle_deg.min_error.toFixed(5)}
+                    </p>
+
+                    <p className="mvo-text">
+                        Max Error: {props.json.translation_to_direction_angle_deg.max_error.toFixed(5)}
+                    </p>
+                </div>
+
+                <button className="go_back_btn" onClick={() => props.toggleMVO(false)}>Go Back</button>
+            </div>
+        </div>
+    )
+}
+
+export default MVOSummary;

--- a/rtf_vis_tool/src/Components/MVOSummary.js
+++ b/rtf_vis_tool/src/Components/MVOSummary.js
@@ -16,7 +16,7 @@ function MVOSummary(props) {
                                                                    after rotation averaging (pre-BA).
         props.json.rotation_averaging_angle_deg.max_error (float): Max angular error on global rotation for any frame 
                                                                    after rotation averaging (pre-BA).
-        props.json.translation_averaging_distance.median_error (float): Median error of translation averaging.
+        props.json.translation_averaging_distance.median_error (float): Median Euclidean error of translation averaging.
         props.json.translation_averaging_distance.min_error (float): Min Euclidean error on global translation for 
                                                                     any frame after translation averaging (pre-BA).
         props.json.translation_averaging_distance.max_error (float): Max Euclidean error on global translation for 
@@ -31,7 +31,7 @@ function MVOSummary(props) {
 
     return (
         <div className="mvo_container">
-            <h3>MultiView Optimizer Metrics</h3>
+            <h3>Sparse MultiView Optimizer Metrics</h3>
             <div className="mvo_sub_container">
                 <div className="metrics_container">
                     <p className="mvo_header">Rotation Averaging Angle Metrics</p>

--- a/rtf_vis_tool/src/Components/MVOSummary.js
+++ b/rtf_vis_tool/src/Components/MVOSummary.js
@@ -12,11 +12,15 @@ function MVOSummary(props) {
     /*
     Args:
         props.json.rotation_averaging_angle_deg.median_error (float): Median error of rotation averaging.
-        props.json.rotation_averaging_angle_deg.min_error (float): Min error of rotation averaging.
-        props.json.rotation_averaging_angle_deg.max_error (float): Max error of rotation averaging.
+        props.json.rotation_averaging_angle_deg.min_error (float): Min angular error on global rotation for any frame 
+                                                                   after rotation averaging (pre-BA).
+        props.json.rotation_averaging_angle_deg.max_error (float): Max angular error on global rotation for any frame 
+                                                                   after rotation averaging (pre-BA).
         props.json.translation_averaging_distance.median_error (float): Median error of translation averaging.
-        props.json.translation_averaging_distance.min_error (float): Min error of translation averaging.
-        props.json.translation_averaging_distance.max_error (float): Max error of translation averaging.
+        props.json.translation_averaging_distance.min_error (float): Min Euclidean error on global translation for 
+                                                                    any frame after translation averaging (pre-BA).
+        props.json.translation_averaging_distance.max_error (float): Max Euclidean error on global translation for 
+                                                                    any frame after translation averaging (pre-BA).
         props.json.translation_to_direction_angle_deg.median_error (float): Median error of translation to direction.
         props.json.translation_to_direction_angle_deg.min_error (float): Min error of translation to direction.
         props.json.translation_to_direction_angle_deg.max_error (float): Max error of tranlation to direction.
@@ -30,49 +34,49 @@ function MVOSummary(props) {
             <h3>MultiView Optimizer Metrics</h3>
             <div className="mvo_sub_container">
                 <div className="metrics_container">
-                    <p className="mvo-header">Rotation Averaging Angle Metrics</p>
+                    <p className="mvo_header">Rotation Averaging Angle Metrics</p>
 
-                    <p className="mvo-text">
+                    <p className="mvo_text">
                         Median Error: {props.json.rotation_averaging_angle_deg.median_error.toFixed(5)}
                     </p>
 
-                    <p className="mvo-text">
+                    <p className="mvo_text">
                         Min Error: {props.json.rotation_averaging_angle_deg.min_error.toFixed(5)}
                     </p>
 
-                    <p className="mvo-text">
+                    <p className="mvo_text">
                         Max Error: {props.json.rotation_averaging_angle_deg.max_error.toFixed(5)}
                     </p>
                 </div>
 
                 <div className="metrics_container">
-                    <p className="mvo-header">Translation Averaging Metrics</p>
+                    <p className="mvo_header">Translation Averaging Metrics</p>
 
-                    <p className="mvo-text">
+                    <p className="mvo_text">
                         Median Error: {props.json.translation_averaging_distance.median_error.toFixed(5)}
                     </p>
 
-                    <p className="mvo-text">
+                    <p className="mvo_text">
                         Min Error: {props.json.translation_averaging_distance.min_error.toFixed(5)}
                     </p>
 
-                    <p className="mvo-text">
+                    <p className="mvo_text">
                         Max Error: {props.json.translation_averaging_distance.max_error.toFixed(5)}
                     </p>
                 </div>
 
                 <div className="metrics_container">
-                    <p className="mvo-header">Translation to Direction Angle Metrics</p>
+                    <p className="mvo_header">Translation to Direction Angle Metrics</p>
 
-                    <p className="mvo-text">
+                    <p className="mvo_text">
                         Median Error: {props.json.translation_to_direction_angle_deg.median_error.toFixed(5)}
                     </p>
 
-                    <p className="mvo-text">
+                    <p className="mvo_text">
                         Min Error: {props.json.translation_to_direction_angle_deg.min_error.toFixed(5)}
                     </p>
 
-                    <p className="mvo-text">
+                    <p className="mvo_text">
                         Max Error: {props.json.translation_to_direction_angle_deg.max_error.toFixed(5)}
                     </p>
                 </div>

--- a/rtf_vis_tool/src/Components/frustum_classes/se3.js
+++ b/rtf_vis_tool/src/Components/frustum_classes/se3.js
@@ -1,4 +1,4 @@
-/* Contains the Pose Matrix used to convert points from camera coordinate system to world coordinate system.
+/*Contains the Pose Matrix used to convert points from camera coordinate system to world coordinate system.
 
 Author: Adi Singh
 */
@@ -10,8 +10,7 @@ class SE3 {
     // An SE3 class allows point cloud rotation and translation operations.
 
     constructor(rotation, translation) {
-        /*
-            Initialize an SE3 instance and pose matrix with its rotation and translation matrices.
+        /*Initialize an SE3 instance and pose matrix with its rotation and translation matrices.
 
             Args:
                 rotation: Matrix of shape 3x3
@@ -37,8 +36,7 @@ class SE3 {
     }
 
     tranform_frustum_vertex(point_cam_coords) {
-        /*
-            Apply the SE3 transformation to the point.
+        /*Apply the SE3 transformation to the point.
 
             Args:
                 point_cam_coords: Array of shape (1,3) representing the point in camera coordinates.

--- a/rtf_vis_tool/src/Components/frustum_classes/se3.js
+++ b/rtf_vis_tool/src/Components/frustum_classes/se3.js
@@ -12,9 +12,9 @@ class SE3 {
     constructor(rotation, translation) {
         /*Initialize an SE3 instance and pose matrix with its rotation and translation matrices.
 
-            Args:
-                rotation: Matrix of shape 3x3
-                translation: Array of length 3
+        Args:
+            rotation: Matrix of shape 3x3
+            translation: Array of length 3
         */
         if (rotation.shape[0] != 3 || rotation.shape[1] != 3) throw 'Invalid Rotation Matrix';
         if (translation.shape[0] != [3]) throw 'Invalid Translation Matrix';
@@ -35,16 +35,16 @@ class SE3 {
         }
     }
 
-    tranform_frustum_vertex(point_cam_coords) {
+    transform_from(point) {
         /*Apply the SE3 transformation to the point.
 
-            Args:
-                point_cam_coords: Array of shape (1,3) representing the point in camera coordinates.
-            Returns:
-                Array, shape (1,3), representing the point in world coordinates.
+        Args:
+            point: Array of shape (1,3) representing the point in the c frame.
+        Returns:
+            Array, shape (1,3), representing the point in the w frame.
         */
         var ones = nj.ones([1, 1]);
-        var homogeneous_pt = nj.concatenate(point_cam_coords, ones);
+        var homogeneous_pt = nj.concatenate(point, ones);
 
         var point_world_coords = homogeneous_pt.dot(this.transform_matrix.T);
 

--- a/rtf_vis_tool/src/Components/frustum_classes/se3.js
+++ b/rtf_vis_tool/src/Components/frustum_classes/se3.js
@@ -1,0 +1,60 @@
+/* Contains the Pose Matrix used to convert points from camera coordinate system to world coordinate system.
+
+Author: Adi Singh
+*/
+
+// Third-Party Package Imports.
+var nj = require('numjs');
+
+class SE3 {
+    // An SE3 class allows point cloud rotation and translation operations.
+
+    constructor(rotation, translation) {
+        /*
+            Initialize an SE3 instance and pose matrix with its rotation and translation matrices.
+
+            Args:
+                rotation: Matrix of shape 3x3
+                translation: Array of length 3
+        */
+        if (rotation.shape[0] != 3 || rotation.shape[1] != 3) throw 'Invalid Rotation Matrix';
+        if (translation.shape[0] != [3]) throw 'Invalid Translation Matrix';
+        this.rotation = rotation;
+        this.translation = translation;
+        this.transform_matrix = nj.identity(4);
+
+        //set upper left 3x3 to rotation matrix
+        for (var row = 0; row < 3; row++) {
+            for (var col = 0; col < 3; col++) {
+                this.transform_matrix.set(row, col, rotation.get(row,col));
+            }
+        }
+
+        //set last column to translation array
+        for (var row = 0; row < 3; row++) {
+            this.transform_matrix.set(row, 3, this.translation.get(row));
+        }
+    }
+
+    tranform_frustum_vertex(point_cam_coords) {
+        /*
+            Apply the SE3 transformation to the point.
+
+            Args:
+                point_cam_coords: Array of shape (1,3) representing the point in camera coordinates.
+            Returns:
+                Array, shape (1,3), representing the point in world coordinates.
+        */
+        var ones = nj.ones([1, 1]);
+        var homogeneous_pt = nj.concatenate(point_cam_coords, ones);
+
+        var point_world_coords = homogeneous_pt.dot(this.transform_matrix.T);
+
+        point_world_coords = nj.array([[point_world_coords.get(0,0),
+                            point_world_coords.get(0,1),
+                            point_world_coords.get(0,2)]])
+        return point_world_coords;
+    }
+}
+
+module.exports = SE3;

--- a/rtf_vis_tool/src/Components/frustum_classes/view_frustum.js
+++ b/rtf_vis_tool/src/Components/frustum_classes/view_frustum.js
@@ -12,11 +12,11 @@ class ViewFrustum {
     constructor(fx, img_w, img_h, ray_len) {
         /*Initializes the ViewFrustum Object.
 
-            Args:
-                fx (float): Focal length in x-direction.
-                img_w (float): Image width (in pixels).
-                img_h (float): Image height (in pixels).
-                ray_len (float): Extent to which frustum rays extend away from optical center.
+        Args:
+            fx (float): Focal length in x-direction (in pixels).
+            img_w (float): Image width (in pixels).
+            img_h (float): Image height (in pixels).
+            ray_len (float): Extent to which frustum rays extend away from optical center.
         */
 
         this.fx_ = fx;
@@ -28,10 +28,10 @@ class ViewFrustum {
     normalize_ray_dirs(ray_dirs) {
         /*Normalizes the 5 ray directions of the frustum vertices to be of unit length.
 
-            Args:
-                ray_dirs: Array of shape (5,3) representing ray directions in camera frame.
-            Returns:
-                An array of shape (5,3) with normalized ray directions.
+        Args:
+            ray_dirs: Array of shape (5,3) representing ray directions in camera frame.
+        Returns:
+            An array of shape (5,3) with normalized ray directions.
         */
 
         for (var row = 0; row < ray_dirs.shape[0]; row++) {
@@ -47,12 +47,12 @@ class ViewFrustum {
         /*Given (u,v) coordinates and intrinsics, generate pixels rays in camera coord frame. Assume +z points out of
         the camera, +y is downwards, and +x is across the imager.
 
-            Args:
-                uv: Array of shape (5,2) with (u,v) coordinates.
-                img_w (float): Image width (in pixels).
-                img_h (height): Image height (in pixels).
-            Returns:
-                ray_dirs: Array of shape (5,3) with normalized ray vectors in camera frame
+        Args:
+            uv: Array of shape (5,2) with (u,v) coordinates.
+            img_w (float): Image width (in pixels).
+            img_h (height): Image height (in pixels).
+        Returns:
+            ray_dirs: Array of shape (5,3) with normalized ray vectors in camera frame
         */
 
         // Assume principal point is at center of images.
@@ -94,8 +94,8 @@ class ViewFrustum {
                         O PINHOLE                                 \\ //
                                                                     O PINHOLE
             
-            Returns:
-                Array, size 5, of frustum vertex coordinates in the camera coordinate system.                                                                
+        Returns:
+            Array, shape (5,3), of frustum vertex coordinates in the camera frame.                                                                
         */
 
         var uv = nj.array([
@@ -114,12 +114,13 @@ class ViewFrustum {
     get_mesh_vertices_worldframe(wTc) {
         /*Obtains 5 vertices defining the frustum mesh, in the world/global frame.
 
-            Args:
-                wTc: camera pose in world frame
-            Returns:
-                An array, length 5, of the frustum vertices.
+        Args:
+            wTc (SE3): camera pose in world frame
+        Returns:
+            An array, length 5, where each entry represents the 3d coordinate of a frustum vertex.
         */
         var vList = this.get_frustum_vertices_camfr();
+        console.log(vList);
 
         var v0_camframe = vList[0].reshape(1,3);
         var v1_camframe = vList[1].reshape(1,3);
@@ -127,11 +128,11 @@ class ViewFrustum {
         var v3_camframe = vList[3].reshape(1,3);
         var v4_camframe = vList[4].reshape(1,3);
 
-        var v0_worldframe = wTc.tranform_frustum_vertex(v0_camframe);
-        var v1_worldframe = wTc.tranform_frustum_vertex(v1_camframe);
-        var v2_worldframe = wTc.tranform_frustum_vertex(v2_camframe);
-        var v3_worldframe = wTc.tranform_frustum_vertex(v3_camframe);
-        var v4_worldframe = wTc.tranform_frustum_vertex(v4_camframe);
+        var v0_worldframe = wTc.transform_from(v0_camframe);
+        var v1_worldframe = wTc.transform_from(v1_camframe);
+        var v2_worldframe = wTc.transform_from(v2_camframe);
+        var v3_worldframe = wTc.transform_from(v3_camframe);
+        var v4_worldframe = wTc.transform_from(v4_camframe);
 
         return [v0_worldframe.tolist(), 
             v1_worldframe.tolist(), 
@@ -143,11 +144,11 @@ class ViewFrustum {
     calculate_scaled_ray_dirs(ray_dirs, frustum_ray_len) {
         /*Given frustum vertex ray directions and length, scale the rays to desired length.
 
-            Args:
-                ray_dirs: Array of shape (5,3) containing normalized vertex vectors.
-                frustum_ray_len (float): Amount to scale vectors by.
-            Returns:
-                A list, size 5, of the scaled frustum vertex vectors in camera coordinate frame.
+        Args:
+            ray_dirs: Array of shape (5,3) containing normalized vertex vectors.
+            frustum_ray_len (float): Amount to scale vectors by.
+        Returns:
+            An array, shape (5,3), of the scaled frustum vertex vectors in camera coordinate frame.
         */
 
         // Center v0 at the origin.

--- a/rtf_vis_tool/src/Components/frustum_classes/view_frustum.js
+++ b/rtf_vis_tool/src/Components/frustum_classes/view_frustum.js
@@ -74,7 +74,6 @@ class ViewFrustum {
             [this.fx_]
         ]);
         var ray_dirs = nj.concatenate(center_offsets, fx_broadcasted);
-
         ray_dirs = this.normalize_ray_dirs(ray_dirs);
         return ray_dirs
     }
@@ -150,10 +149,7 @@ class ViewFrustum {
         */
 
         // Center v0 at the origin.
-        var v0_scaled = nj.array([ray_dirs.get(0,0) * 0, 
-                                ray_dirs.get(0,1) * 0, 
-                                ray_dirs.get(0,2) * 0]);
-        
+        var v0_scaled = nj.array([0,0,0]);
         var vectors_list = [v0_scaled];
 
         // Scale v1...v4 by scalar: frustum_ray_len

--- a/rtf_vis_tool/src/Components/frustum_classes/view_frustum.js
+++ b/rtf_vis_tool/src/Components/frustum_classes/view_frustum.js
@@ -1,4 +1,4 @@
-/* Contains functions to transform camera instrinsic variables into a frustum consisting of 5 vertices.
+/*Contains functions to transform camera instrinsic variables into a frustum consisting of 5 vertices.
 
 Author: Adi Singh
 */
@@ -12,11 +12,11 @@ class ViewFrustum {
     constructor(fx, img_w, img_h, ray_len) {
         /*Initializes the ViewFrustum Object.
 
-        Args:
-            fx (float): Focal length in x-direction.
-            img_w (float): Image width (in pixels).
-            img_h (float): Image height (in pixels).
-            ray_len (float): Extent to which frustum rays extend away from optical center.
+            Args:
+                fx (float): Focal length in x-direction.
+                img_w (float): Image width (in pixels).
+                img_h (float): Image height (in pixels).
+                ray_len (float): Extent to which frustum rays extend away from optical center.
         */
 
         this.fx_ = fx;
@@ -80,6 +80,7 @@ class ViewFrustum {
 
     get_frustum_vertices_camfr() {
         /*Obtain 3d positions of all 5 frustum vertices in the camera frame
+
           (x,y,z)               (x,y,z)                (x,y,z)              (x,y,z)
               \\=================//                      \\                   //
                \\               //                        \\ 1-------------2 //
@@ -112,6 +113,7 @@ class ViewFrustum {
 
     get_mesh_vertices_worldframe(wTc) {
         /*Obtains 5 vertices defining the frustum mesh, in the world/global frame.
+
             Args:
                 wTc: camera pose in world frame
             Returns:

--- a/rtf_vis_tool/src/Components/frustum_classes/view_frustum.js
+++ b/rtf_vis_tool/src/Components/frustum_classes/view_frustum.js
@@ -1,0 +1,170 @@
+/* Contains functions to transform camera instrinsic variables into a frustum consisting of 5 vertices.
+
+Author: Adi Singh
+*/
+
+// Third-Party Package Imports.
+var nj = require('numjs');
+
+class ViewFrustum {
+    // Generates vertices of a 5-face mesh for drawing a pinhole camera in 3d.
+
+    constructor(fx, img_w, img_h, ray_len) {
+        /*Initializes the ViewFrustum Object.
+
+        Args:
+            fx (float): Focal length in x-direction.
+            img_w (float): Image width (in pixels).
+            img_h (float): Image height (in pixels).
+            ray_len (float): Extent to which frustum rays extend away from optical center.
+        */
+
+        this.fx_ = fx;
+        this.img_w_ = img_w;
+        this.img_h_ = img_h;
+        this.frustum_ray_len_ = ray_len;
+    }
+
+    normalize_ray_dirs(ray_dirs) {
+        /*Normalizes the 5 ray directions of the frustum vertices to be of unit length.
+
+            Args:
+                ray_dirs: Array of shape (5,3) representing ray directions in camera frame.
+            Returns:
+                An array of shape (5,3) with normalized ray directions.
+        */
+
+        for (var row = 0; row < ray_dirs.shape[0]; row++) {
+            var vector_mag = Math.sqrt(Math.pow(ray_dirs.get(row,0),2) + Math.pow(ray_dirs.get(row,1),2) + Math.pow(ray_dirs.get(row,2),2));
+            for (var col = 0; col < ray_dirs.shape[1]; col++) {
+                ray_dirs.set(row, col, (ray_dirs.get(row,col)/vector_mag));
+            }
+        }
+        return ray_dirs;
+    }
+
+    compute_pixel_ray_directions_vectorized(uv, img_w, img_h) {
+        /*Given (u,v) coordinates and intrinsics, generate pixels rays in camera coord frame. Assume +z points out of
+        the camera, +y is downwards, and +x is across the imager.
+
+            Args:
+                uv: Array of shape (5,2) with (u,v) coordinates.
+                img_w (float): Image width (in pixels).
+                img_h (height): Image height (in pixels).
+            Returns:
+                ray_dirs: Array of shape (5,3) with normalized ray vectors in camera frame
+        */
+
+        // Assume principal point is at center of images.
+        var px = img_w / 2;
+        var py = img_h / 2;
+
+        //uv - [px,py] gives each vertex's pixel offset from the center of image plane.
+        var center_offsets = nj.zeros([5,2]);
+        for (var row = 0; row < 5; row++) {
+            center_offsets.set(row, 0, uv.get(row, 0) - px);
+            center_offsets.set(row, 1, uv.get(row, 1) - py);
+        }
+
+        var fx_broadcasted = nj.array([
+            [this.fx_],
+            [this.fx_],
+            [this.fx_],
+            [this.fx_],
+            [this.fx_]
+        ]);
+        var ray_dirs = nj.concatenate(center_offsets, fx_broadcasted);
+
+        ray_dirs = this.normalize_ray_dirs(ray_dirs);
+        return ray_dirs
+    }
+
+    get_frustum_vertices_camfr() {
+        /*Obtain 3d positions of all 5 frustum vertices in the camera frame
+          (x,y,z)               (x,y,z)                (x,y,z)              (x,y,z)
+              \\=================//                      \\                   //
+               \\               //                        \\ 1-------------2 //
+        (-w/2,-h/2,fx)       (w/2,-h/2,fx)                 \\| IMAGE PLANE |//
+                 1-------------2                             |             |/
+                 |\\         //| IMAGE PLANE  (-w/2, h/2,fx) 4-------------3 (w/2, h/2,fx)
+                 | \\       // | IMAGE PLANE                  \\         //
+                 4--\\-----//--3                               \\       //
+                     \\   //                                    \\     //
+                      \\ //                                      \\   //
+                        O PINHOLE                                 \\ //
+                                                                    O PINHOLE
+            
+            Returns:
+                Array, size 5, of frustum vertex coordinates in the camera coordinate system.                                                                
+        */
+
+        var uv = nj.array([
+            [Math.floor(this.img_w_ / 2), Math.floor(this.img_h_ / 2)],  //v0 = optical center
+            [0, 0],                              //v1 = top-left
+            [this.img_w_ - 1, 0],                //v2 = top-right
+            [this.img_w_ - 1, this.img_h_ - 1],  //v3 = bottom-right
+            [0, this.img_h_ - 1],                //v4 = bottom-left
+        ]);
+
+        var ray_dirs = this.compute_pixel_ray_directions_vectorized(uv, this.img_w_, this.img_h_);
+        var scaled_ray_dirs = this.calculate_scaled_ray_dirs(ray_dirs, this.frustum_ray_len_);
+        return scaled_ray_dirs
+    }
+
+    get_mesh_vertices_worldframe(wTc) {
+        /*Obtains 5 vertices defining the frustum mesh, in the world/global frame.
+            Args:
+                wTc: camera pose in world frame
+            Returns:
+                An array, length 5, of the frustum vertices.
+        */
+        var vList = this.get_frustum_vertices_camfr();
+
+        var v0_camframe = vList[0].reshape(1,3);
+        var v1_camframe = vList[1].reshape(1,3);
+        var v2_camframe = vList[2].reshape(1,3);
+        var v3_camframe = vList[3].reshape(1,3);
+        var v4_camframe = vList[4].reshape(1,3);
+
+        var v0_worldframe = wTc.tranform_frustum_vertex(v0_camframe);
+        var v1_worldframe = wTc.tranform_frustum_vertex(v1_camframe);
+        var v2_worldframe = wTc.tranform_frustum_vertex(v2_camframe);
+        var v3_worldframe = wTc.tranform_frustum_vertex(v3_camframe);
+        var v4_worldframe = wTc.tranform_frustum_vertex(v4_camframe);
+
+        return [v0_worldframe.tolist(), 
+            v1_worldframe.tolist(), 
+            v2_worldframe.tolist(), 
+            v3_worldframe.tolist(), 
+            v4_worldframe.tolist()];
+    }
+
+    calculate_scaled_ray_dirs(ray_dirs, frustum_ray_len) {
+        /*Given frustum vertex ray directions and length, scale the rays to desired length.
+
+            Args:
+                ray_dirs: Array of shape (5,3) containing normalized vertex vectors.
+                frustum_ray_len (float): Amount to scale vectors by.
+            Returns:
+                A list, size 5, of the scaled frustum vertex vectors in camera coordinate frame.
+        */
+
+        // Center v0 at the origin.
+        var v0_scaled = nj.array([ray_dirs.get(0,0) * 0, 
+                                ray_dirs.get(0,1) * 0, 
+                                ray_dirs.get(0,2) * 0]);
+        
+        var vectors_list = [v0_scaled];
+
+        // Scale v1...v4 by scalar: frustum_ray_len
+        for (var row = 1; row < 5; row++) {
+            const vector_scaled = nj.array([ray_dirs.get(row,0)*frustum_ray_len,
+                                        ray_dirs.get(row,1)*frustum_ray_len,
+                                        ray_dirs.get(row,2)*frustum_ray_len]);
+            vectors_list.push(vector_scaled);
+        }
+        return vectors_list;
+    }
+}
+
+module.exports = ViewFrustum;

--- a/rtf_vis_tool/src/stylesheets/Bundle_Adj_PC.css
+++ b/rtf_vis_tool/src/stylesheets/Bundle_Adj_PC.css
@@ -5,7 +5,7 @@ Author: Adi Singh
 
 /*  Makes the Bundle Adjustment Point Cloud window occupy a majority of the screen. White 
     background with black curved border. Z-index of 2 makes it lay on top of other components 
-    which have z-index of 1
+    which have z-index of 1.
 */
 .ba-container {
     position: absolute;
@@ -39,29 +39,4 @@ Author: Adi Singh
     top: 5%;
     cursor: pointer;
     font-size: large;
-}
-
-/* Positions the 'Adjust Point Radius' Slider Input to upper right of the bundle adjustment 
-   container 
-*/
-.point_size_slider {
-    position: absolute;
-    right: 1%;
-    top: 10%;
-}
-
-/* Positions the 'Small' Label of the Point Radius Slider to the left. */
-.slider_small_label {
-    position: absolute;
-    left: 0px;
-    bottom: -25px;
-    font-size: small;
-}
-
-/* Positions the 'Large' Label of the Point Radius Slider to the left. */
-.slider_large_label {
-    position: absolute;
-    right: 0px;
-    bottom: -25px;
-    font-size: small;
 }

--- a/rtf_vis_tool/src/stylesheets/Bundle_Adj_PC.css
+++ b/rtf_vis_tool/src/stylesheets/Bundle_Adj_PC.css
@@ -7,7 +7,7 @@ Author: Adi Singh
     background with black curved border. Z-index of 2 makes it lay on top of other components 
     which have z-index of 1.
 */
-.ba-container {
+.ba_container {
     position: absolute;
     top: 5%;
     left: 3%;

--- a/rtf_vis_tool/src/stylesheets/FrontendSummary.css
+++ b/rtf_vis_tool/src/stylesheets/FrontendSummary.css
@@ -12,7 +12,7 @@ Author: Adi Singh
     right: 10%;
     z-index: 3;
     border: 3px solid black;
-    background-color: #e3d9bc;
+    background-color: #fcaf3e;
     width: 20%;
     height: 40%;
     border-radius: 5px;

--- a/rtf_vis_tool/src/stylesheets/FrontendSummary.css
+++ b/rtf_vis_tool/src/stylesheets/FrontendSummary.css
@@ -1,0 +1,48 @@
+/* Stylings for FrontendSummary.js Component.
+
+Author: Adi Singh
+*/
+
+/* Styles the div containing all the frontend summary metrics text. Gives a tan background with surrounding black
+   border. Located in the first quadrant of the screen. 
+*/
+.fs_container {
+    position: absolute;
+    top: 20%;
+    right: 10%;
+    z-index: 3;
+    border: 3px solid black;
+    background-color: #e3d9bc;
+    width: 20%;
+    height: 40%;
+    border-radius: 5px;
+    padding: 1%;
+}
+
+/* Styles subcontainer div to take all the space within .fs_container. Has relative positioning. */
+.fs_sub_container {
+    position: relative;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+}
+
+/* Sets the font size for the format hint. */
+.format_hint {
+    font-size: 80%;
+    margin-bottom: 5%;
+}
+
+/* Positinos the 'Go Back' button to be 10px away from the right. When hovered over, the mouse changes to a 
+   pointer.
+*/
+.go_back_btn {
+    position: absolute;
+    right: 10px;
+    cursor: pointer;
+}
+
+/* Gives the text a bold weight. */
+.fs-text {
+    font-weight: 600;
+}

--- a/rtf_vis_tool/src/stylesheets/FrontendSummary.css
+++ b/rtf_vis_tool/src/stylesheets/FrontendSummary.css
@@ -42,7 +42,7 @@ Author: Adi Singh
     cursor: pointer;
 }
 
-/* Gives any text with the tag className="fs-text" a bold weight. Specically, Rotation Success, Translation Success,
+/* Gives any text with the tag className="fs_text" a bold weight. Specically, Rotation Success, Translation Success,
 Pose Success, and Correspondence Inliers. 
 */
 .fs_text {

--- a/rtf_vis_tool/src/stylesheets/FrontendSummary.css
+++ b/rtf_vis_tool/src/stylesheets/FrontendSummary.css
@@ -3,7 +3,7 @@
 Author: Adi Singh
 */
 
-/* Styles the div containing all the frontend summary metrics text. Gives a tan background with surrounding black
+/* Styles the div containing all the frontend summary metrics text. Gives a light tango background with surrounding black
    border. Located in the first quadrant of the screen. 
 */
 .fs_container {
@@ -33,7 +33,7 @@ Author: Adi Singh
     margin-bottom: 5%;
 }
 
-/* Positinos the 'Go Back' button to be 10px away from the right. When hovered over, the mouse changes to a 
+/* Positions the 'Go Back' button to be 10px away from the right. When hovered over, the mouse changes to a 
    pointer.
 */
 .go_back_btn {
@@ -42,7 +42,9 @@ Author: Adi Singh
     cursor: pointer;
 }
 
-/* Gives the text a bold weight. */
-.fs-text {
+/* Gives any text with the tag className="fs-text" a bold weight. Specically, Rotation Success, Translation Success,
+Pose Success, and Correspondence Inliers. 
+*/
+.fs_text {
     font-weight: 600;
 }

--- a/rtf_vis_tool/src/stylesheets/MVOSummary.css
+++ b/rtf_vis_tool/src/stylesheets/MVOSummary.css
@@ -34,7 +34,7 @@ Author: Adi Singh
     font-weight: 600;
 }
 
-/* Gives any text with the tag className="mvo-text" a lighter weight. Specically: Median Error, Min Error, and Max
+/* Gives any text with the tag className="mvo_text" a lighter weight. Specically: Median Error, Min Error, and Max
 Error.
 */
 .mvo_text {

--- a/rtf_vis_tool/src/stylesheets/MVOSummary.css
+++ b/rtf_vis_tool/src/stylesheets/MVOSummary.css
@@ -12,7 +12,7 @@ Author: Adi Singh
     left: 10%;
     z-index: 2;
     border: 3px solid black;
-    background-color: #e3d9bc;
+    background-color: #fcaf3e;
     width: 55%;
     height: 40%;
     border-radius: 5px;

--- a/rtf_vis_tool/src/stylesheets/MVOSummary.css
+++ b/rtf_vis_tool/src/stylesheets/MVOSummary.css
@@ -3,7 +3,7 @@
 Author: Adi Singh
 */
 
-/* Styles the div containing all the multiview optimizer metrics text. Gives a tan background
+/* Styles the div containing all the multiview optimizer metrics text. Gives a light tango background
    with surrounding black border. Located in the second/third quadrant of the screen. 
 */
 .mvo_container {
@@ -30,12 +30,14 @@ Author: Adi Singh
 }
 
 /* Makes each metrics header bold. */
-.mvo-header {
+.mvo_header {
     font-weight: 600;
 }
 
-/* Makes each metrics text less bold than the header. */
-.mvo-text {
+/* Gives any text with the tag className="mvo-text" a lighter weight. Specically: Median Error, Min Error, and Max
+Error.
+*/
+.mvo_text {
     font-weight: 400;
 }
 

--- a/rtf_vis_tool/src/stylesheets/MVOSummary.css
+++ b/rtf_vis_tool/src/stylesheets/MVOSummary.css
@@ -1,0 +1,55 @@
+/* Stylings for MVOSummary.js Component.
+
+Author: Adi Singh
+*/
+
+/* Styles the div containing all the multiview optimizer metrics text. Gives a tan background
+   with surrounding black border. Located in the second/third quadrant of the screen. 
+*/
+.mvo_container {
+    position: absolute;
+    top: 20%;
+    left: 10%;
+    z-index: 2;
+    border: 3px solid black;
+    background-color: #e3d9bc;
+    width: 55%;
+    height: 40%;
+    border-radius: 5px;
+    padding: 1%;
+}
+
+/* Styles subcontainer div to take all the space within .mvo_container. Has relative positioning. */
+.mvo_sub_container {
+    position: relative;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: row;
+}
+
+/* Makes each metrics header bold. */
+.mvo-header {
+    font-weight: 600;
+}
+
+/* Makes each metrics text less bold than the header. */
+.mvo-text {
+    font-weight: 400;
+}
+
+/* Makes each block of metrics text have spacing on its right side. */
+.metrics_container {
+    margin-right: 8%;
+}
+
+/* Positions the "Go Back" button in the bottom right corner. When hovered over, the mouse
+   changes to a pointer.
+*/
+.go_back_btn {
+    position: absolute;
+    right: 0%;
+    bottom: 15%;
+    cursor: pointer;
+}

--- a/rtf_vis_tool/src/stylesheets/PointSizeSlider.css
+++ b/rtf_vis_tool/src/stylesheets/PointSizeSlider.css
@@ -9,7 +9,7 @@ Author: Adi Singh
 .point_size_slider_container {
     position: absolute;
     right: 1%;
-    top: 10%;
+    top: 12%;
 }
 
 /* Positions the 'Small' Label of the Point Radius Slider to the left. */

--- a/rtf_vis_tool/src/tests/BlueNode.test.js
+++ b/rtf_vis_tool/src/tests/BlueNode.test.js
@@ -30,5 +30,5 @@ describe('BlueNode.js Test', () => {
         const div = wrapper.find('GtsfmNode');
         expect(div.props().backgroundColor).toEqual('#2255e0');
         expect(div.props().textColor).toEqual('white');
-    })
+    });
 })

--- a/rtf_vis_tool/src/tests/FrontendSummary.test.js
+++ b/rtf_vis_tool/src/tests/FrontendSummary.test.js
@@ -1,0 +1,63 @@
+/* Unit Test for the FrontendSummary.js Component.
+
+Author: Adi Singh
+*/
+import React from 'react';
+
+// Third-Party Package Imports.
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+// Local Imports.
+import FrontendSummary from '../Components/FrontendSummary';
+
+// Configure enzyme for current React version.
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('FrontendSummary.js Test', () => {
+
+    /* Creates a sample FrontendSummary.js component to check if it renders the correct numbet of h3, p, and button 
+       tags.
+    */
+    it('Frontend Summary has 1 <h3> tag, 5 <p> tags, and 1 <button>.', () => {
+        const fs_summary = {
+            "angular_err_threshold_deg": 10,
+            "num_valid_entries": 66,
+            "num_total_entries": 66,
+            "rotation": {
+                "success_count": 66
+            },
+            "translation": {
+                "success_count": 66
+            },
+            "pose": {
+                "success_count": 66
+            },
+            "correspondences": {
+                "all_inliers": 66
+            }
+        };
+    
+        const wrapper = shallow(<FrontendSummary json={fs_summary}/>);
+        const div = wrapper.find('div[className="fs_container"]');
+        const tagList = div.props().children.props.children;
+
+        var num_h3 = 0;
+        var num_p = 0;
+        var num_button = 0;
+
+        for (var i = 0; i < tagList.length; i++) {
+            if (tagList[i].type == 'h3') {
+                num_h3++;
+            } else if (tagList[i].type == 'p') {
+                num_p++;
+            } else if (tagList[i].type == 'button') {
+                num_button++;
+            }
+        }
+
+        expect(num_h3).toEqual(1);
+        expect(num_p).toEqual(5);
+        expect(num_button).toEqual(1);
+    })
+})

--- a/rtf_vis_tool/src/tests/MVOSummary.test.js
+++ b/rtf_vis_tool/src/tests/MVOSummary.test.js
@@ -1,0 +1,45 @@
+/* Unit Test for the MVOSummary.js Component.
+
+Author: Adi Singh
+*/
+import React from 'react';
+
+// Third-Party Package Imports.
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+// Local Imports.
+import MVOSummary from '../Components/MVOSummary';
+
+// Configure enzyme for current React version.
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('MVOSummary.js Test', () => {
+
+    /* Creates a sample MVOSummary.js component to check if it renders the correct number of p tags.
+    */
+    it('MVOSummary has 12 <p> tags.', () => {
+        const mvo_summary = {
+            "rotation_averaging_angle_deg": {
+                "median_error": 0.09,
+                "min_error": 0.01,
+                "max_error": 0.18
+            },
+            "translation_averaging_distance": {
+                "median_error": 0.04,
+                "min_error": 0.01,
+                "max_error": 0.09
+            },
+            "translation_to_direction_angle_deg": {
+                "median_error": 0.2,
+                "min_error": 0.04,
+                "max_error": 1.2
+            }
+        };
+    
+        const wrapper = shallow(<MVOSummary json={mvo_summary}/>);
+        const p_tags = wrapper.find('p');
+        
+        expect(p_tags.length).toEqual(12);
+    })
+})

--- a/rtf_vis_tool/src/tests/ViewFrustum.test.js
+++ b/rtf_vis_tool/src/tests/ViewFrustum.test.js
@@ -1,0 +1,110 @@
+/* Unit Test for the ViewFrustum Class.
+
+Author: Adi Singh
+*/
+
+// Third-Party Package Imports.
+var nj = require('numjs');
+
+// Local Imports.
+var ViewFrustum = require('../Components/frustum_classes/view_frustum');
+
+describe('ViewFrustum Class Unit Tests', () => {
+
+    /* Creates sample frustum rays and checks if they are normalized properly. */
+    it ('Test normalize_ray_dirs.', () => {
+        const fx = 5;
+        const img_w = 4;
+        const img_h = 4;
+        const ray_len = 0.5;
+        const testFrustum = new ViewFrustum(fx, img_w, img_h, ray_len);
+        
+        var ray_dirs = nj.array([[0,0,2],
+                                 [3,0,0],
+                                 [0,4,0],
+                                 [0,3,4],
+                                 [4,4,2]]);
+        const ray_dirs_normalized = testFrustum.normalize_ray_dirs(ray_dirs);
+
+        const expected_ray_dirs = nj.array([[0,0,1],
+                                           [1,0,0],
+                                           [0,1,0],
+                                           [0,0.6,0.8],
+                                           [(2/3),(2/3),(1/3)]]);
+        expect(expected_ray_dirs).toEqual(ray_dirs_normalized);
+    });
+    
+    /* Creates a sample uv matrix and checks if the correct ray directions are outputted in normalized form. */
+    it('Test compute_pixel_ray_directions_vectorized.', () => {
+        const uv = nj.array([[0,0], [1,1], [2,2], [3,3], [4,4]]);
+        const img_w = 4;
+        const img_h = 4;
+        const fx = 5;
+        const ray_len = 0.5;
+
+        const testFrustum = new ViewFrustum(fx, img_w, img_h, ray_len);
+
+        const ray_dirs = testFrustum.compute_pixel_ray_directions_vectorized(uv, img_w, img_h);
+
+        // Ray dirs not normalized.
+        var expected_ray_dirs = nj.array([[-2,-2,5],
+                                          [-1,-1,5],
+                                          [0,0,5],
+                                          [1,1,5],
+                                          [2,2,5]]);
+        
+        // Normalizing ray dirs.
+        for (var row = 0; row < expected_ray_dirs.shape[0]; row++) {
+            var vector_mag = Math.sqrt(Math.pow(expected_ray_dirs.get(row,0),2) + 
+                                        Math.pow(expected_ray_dirs.get(row,1),2) + 
+                                        Math.pow(expected_ray_dirs.get(row,2),2));
+            for (var col = 0; col < ray_dirs.shape[1]; col++) {
+                expected_ray_dirs.set(row, col, (expected_ray_dirs.get(row,col)/vector_mag));
+            }
+        }
+        expect(expected_ray_dirs).toEqual(ray_dirs);
+    });
+
+    /* Initializes a test ViewFrustum object and checks if the outputted vertices in the camera coordinate
+       frame are correct.
+     */
+    it ('Test get_frustum_vertices_camfr.', () => {
+        const img_w = 4;
+        const img_h = 4;
+        const fx = 5;
+        const ray_len = 0.5;
+
+        const testFrustum = new ViewFrustum(fx, img_w, img_h, ray_len);
+        const vertices = testFrustum.get_frustum_vertices_camfr(); 
+        
+        const expected_vertices = [nj.array([0,0,0]),
+                                   nj.array([(-1/Math.sqrt(33)), (-1/Math.sqrt(33)), (5/(2*Math.sqrt(33)))]),
+                                   nj.array([(1/(2*Math.sqrt(30))), (-1/Math.sqrt(30)), (5/(2*Math.sqrt(30)))]),
+                                   nj.array([(1/(2*Math.sqrt(27))), (1/(2*Math.sqrt(27))), (5/(2*Math.sqrt(27)))]),
+                                   nj.array([(-1/Math.sqrt(30)), (1/(2*Math.sqrt(30))), (5/(2*Math.sqrt(30)))])];
+        
+        expect(expected_vertices).toEqual(vertices);
+    });
+
+    /* Creates some sample ray directions and checks if they are scaled properly according to the scalar: ray_len. */
+    it ('Test calculate_scaled_ray_dirs.', () => {
+        const img_w = 4;
+        const img_h = 4;
+        const fx = 5;
+        const ray_len = 0.5;
+
+        const testFrustum = new ViewFrustum(fx, img_w, img_h, ray_len);
+        const ray_dirs = nj.array([[1,1,1],
+                                  [2,2,2],
+                                  [3,3,3],
+                                  [4,4,4],
+                                  [5,5,5]]);
+        const scaled_ray_dirs = testFrustum.calculate_scaled_ray_dirs(ray_dirs, ray_len);
+        const expected_scaled_ray_dirs = [nj.array([0,0,0]), 
+                                          nj.array([1,1,1]),
+                                          nj.array([1.5,1.5,1.5]),
+                                          nj.array([2,2,2]),
+                                          nj.array([2.5,2.5,2.5])];
+        expect(expected_scaled_ray_dirs).toEqual(scaled_ray_dirs);
+    })
+})


### PR DESCRIPTION
This is part 3 of the React Pull Requests. In this, I have added some more components which enable the user to see some summary metrics related to the frontend and multiview optimizer portions of the pipeline. I have also added components that enable the camera frustums to be rendered alongside the lund door pointcloud. (These components depend on the `se3` and `view_frustum` classes, which I have reimplemented in JS). This is what can be displayed now:
![image](https://user-images.githubusercontent.com/40643713/114251388-cd9cf500-996e-11eb-87f1-6091606a3ae7.png)

![image](https://user-images.githubusercontent.com/40643713/114251415-ef967780-996e-11eb-9add-183c8e1c27ca.png)

