### PR TITLE
React Part 3b: Saving duplicate results and result_metrics directories

### DIFF
--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -27,6 +27,7 @@ dependencies:
   - matplotlib>=3.3.3
   - networkx
   - numpy
+  - nodejs
   - pandas
   - pillow>=8.0.1
   - scikit-learn

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Tuple
 
 import dask
 import os
+from pathlib import Path
 from dask.delayed import Delayed
 from gtsam import (
     Cal3Bundler,
@@ -25,7 +26,7 @@ from gtsfm.bundle.bundle_adjustment import BundleAdjustmentOptimizer
 from gtsfm.data_association.data_assoc import DataAssociation
 
 # Paths to Save Output in React Folders.
-REACT_METRICS_PATH = "rtf_vis_tool/src/result_metrics"
+REACT_METRICS_PATH = Path(__file__).resolve().parent.parent / "rtf_vis_tool" / "src" / "result_metrics"
 
 class MultiViewOptimizer:
     def __init__(

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -83,13 +83,13 @@ class MultiViewOptimizer:
         auxiliary_graph_list = [
             dask.delayed(io.save_json_file)(
                 os.path.join("result_metrics", "data_association_metrics.json"), data_assoc_metrics_graph
+            ),
+
+            # duplicate dask variable to save data_association_metrics within React directory
+            dask.delayed(io.save_json_file)(
+                os.path.join(REACT_METRICS_PATH, "data_association_metrics.json"), data_assoc_metrics_graph
             )
         ]
-
-        # Save duplicate copy of 'data_association_metrics.json' to React Folder
-        dask.delayed(io.save_json_file)(
-            os.path.join(REACT_METRICS_PATH, "data_association_metrics.json"), data_assoc_metrics_graph
-        )
 
         # dummy graph to force an immediate dump of data association metrics
         ba_input_graph = dask.delayed(lambda x, y: (x, y))(ba_input_graph, auxiliary_graph_list)[0]
@@ -106,12 +106,12 @@ class MultiViewOptimizer:
             "result_metrics/multiview_optimizer_metrics.json", metrics_graph
         )
 
-        # Save duplicate copy of 'multiview_optimizer_metrics.json' to React Folder
-        dask.delayed(io.save_json_file)(
+        # duplicate dask variable to save optimizer_metrics within React directory
+        react_saved_metrics_graph = dask.delayed(io.save_json_file)(
             os.path.join(REACT_METRICS_PATH, "multiview_optimizer_metrics.json"), metrics_graph
         )
 
-        return ba_input_graph, ba_result_graph, saved_metrics_graph
+        return ba_input_graph, ba_result_graph, saved_metrics_graph, react_saved_metrics_graph
 
 
 def prune_to_largest_connected_component(

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -87,7 +87,7 @@ class MultiViewOptimizer:
 
         # Save duplicate copy of 'data_association_metrics.json' to React Folder
         dask.delayed(io.save_json_file)(
-            REACT_METRICS_PATH, data_assoc_metrics_graph
+            os.path.join(REACT_METRICS_PATH, "data_association_metrics.json"), data_assoc_metrics_graph
         )
 
         # dummy graph to force an immediate dump of data association metrics
@@ -107,7 +107,7 @@ class MultiViewOptimizer:
 
         # Save duplicate copy of 'multiview_optimizer_metrics.json' to React Folder
         dask.delayed(io.save_json_file)(
-            REACT_METRICS_PATH, metrics_graph
+            os.path.join(REACT_METRICS_PATH, "multiview_optimizer_metrics.json"), metrics_graph
         )
 
         return ba_input_graph, ba_result_graph, saved_metrics_graph

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -28,6 +28,7 @@ from gtsfm.data_association.data_assoc import DataAssociation
 # Paths to Save Output in React Folders.
 REACT_METRICS_PATH = Path(__file__).resolve().parent.parent / "rtf_vis_tool" / "src" / "result_metrics"
 
+
 class MultiViewOptimizer:
     def __init__(
         self,

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -24,6 +24,8 @@ from gtsfm.averaging.translation.translation_averaging_base import TranslationAv
 from gtsfm.bundle.bundle_adjustment import BundleAdjustmentOptimizer
 from gtsfm.data_association.data_assoc import DataAssociation
 
+# Paths to Save Output in React Folders.
+REACT_METRICS_PATH = "rtf_vis_tool/src/result_metrics"
 
 class MultiViewOptimizer:
     def __init__(
@@ -83,6 +85,11 @@ class MultiViewOptimizer:
             )
         ]
 
+        # Save duplicate copy of 'data_association_metrics.json' to React Folder
+        dask.delayed(io.save_json_file)(
+            REACT_METRICS_PATH, data_assoc_metrics_graph
+        )
+
         # dummy graph to force an immediate dump of data association metrics
         ba_input_graph = dask.delayed(lambda x, y: (x, y))(ba_input_graph, auxiliary_graph_list)[0]
 
@@ -97,6 +104,12 @@ class MultiViewOptimizer:
         saved_metrics_graph = dask.delayed(io.save_json_file)(
             "result_metrics/multiview_optimizer_metrics.json", metrics_graph
         )
+
+        # Save duplicate copy of 'multiview_optimizer_metrics.json' to React Folder
+        dask.delayed(io.save_json_file)(
+            REACT_METRICS_PATH, metrics_graph
+        )
+
         return ba_input_graph, ba_result_graph, saved_metrics_graph
 
 

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -34,8 +34,8 @@ METRICS_PATH = "result_metrics"
 RESULTS_PATH = "results"
 
 # Paths to Save Output in React Folders.
-REACT_METRICS_PATH = "rtf_vis_tool/src/result_metrics"
-REACT_RESULTS_PATH = "rtf_vis_tool/public/results"
+REACT_METRICS_PATH = Path(__file__).resolve().parent.parent / "rtf_vis_tool" / "src" / "result_metrics"
+REACT_RESULTS_PATH = Path(__file__).resolve().parent.parent / "rtf_vis_tool" / "public" / "results"
 
 """
 data type for frontend metrics on a pair of images, containing:

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -183,7 +183,12 @@ class SceneOptimizer:
         keypoints_graph_list = dask.delayed(lambda x, y: (x, y))(keypoints_graph_list, auxiliary_graph_list)[0]
         auxiliary_graph_list = []
 
-        (ba_input_graph, ba_output_graph, optimizer_metrics_graph, react_metrics_graph) = self.multiview_optimizer.create_computation_graph(
+        (
+            ba_input_graph,
+            ba_output_graph,
+            optimizer_metrics_graph,
+            react_metrics_graph,
+        ) = self.multiview_optimizer.create_computation_graph(
             image_graph,
             num_images,
             keypoints_graph_list,

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -33,6 +33,10 @@ PLOT_CORRESPONDENCE_PATH = os.path.join(PLOT_PATH, "correspondences")
 METRICS_PATH = "result_metrics"
 RESULTS_PATH = "results"
 
+# Paths to Save Output in React Folders.
+REACT_METRICS_PATH = "rtf_vis_tool/src/result_metrics"
+REACT_RESULTS_PATH = "rtf_vis_tool/public/results"
+
 """
 data type for frontend metrics on a pair of images, containing:
 1. rotation angular error
@@ -81,6 +85,10 @@ class SceneOptimizer:
         os.makedirs(PLOT_CORRESPONDENCE_PATH, exist_ok=True)
         os.makedirs(METRICS_PATH, exist_ok=True)
         os.makedirs(RESULTS_PATH, exist_ok=True)
+
+        # Save duplicate directories within React folders.
+        os.makedirs(REACT_RESULTS_PATH, exist_ok=True)
+        os.makedirs(REACT_METRICS_PATH, exist_ok=True)
 
     def create_computation_graph(
         self,
@@ -210,6 +218,8 @@ class SceneOptimizer:
         if self._save_gtsfm_data:
             # save the input to Bundle Adjustment (from data association)
             ba_input_save_dir = os.path.join(RESULTS_PATH, "ba_input")
+            react_ba_input_save_dir = os.path.join(REACT_RESULTS_PATH, "ba_input")
+
             auxiliary_graph_list.append(
                 dask.delayed(io_utils.write_cameras)(ba_input_graph, image_graph, save_dir=ba_input_save_dir)
             )
@@ -218,8 +228,15 @@ class SceneOptimizer:
                 dask.delayed(io_utils.write_points)(ba_input_graph, image_graph, save_dir=ba_input_save_dir)
             )
 
+            # Save duplicate copies of input to Bundle Adjustment to React Folder
+            dask.delayed(io_utils.write_cameras)(ba_input_graph, image_graph, save_dir=react_ba_input_save_dir)
+            dask.delayed(io_utils.write_images)(ba_input_graph, save_dir=react_ba_input_save_dir)
+            dask.delayed(io_utils.write_points)(ba_input_graph, image_graph, save_dir=react_ba_input_save_dir)
+
             # save the output of Bundle Adjustment (after optimization)
             ba_output_save_dir = os.path.join(RESULTS_PATH, "ba_output")
+            react_ba_output_save_dir = os.path.join(REACT_RESULTS_PATH, "ba_output")
+
             auxiliary_graph_list.append(
                 dask.delayed(io_utils.write_cameras)(ba_output_graph, image_graph, save_dir=ba_output_save_dir)
             )
@@ -229,6 +246,11 @@ class SceneOptimizer:
             auxiliary_graph_list.append(
                 dask.delayed(io_utils.write_points)(ba_output_graph, image_graph, save_dir=ba_output_save_dir)
             )
+
+            # Save duplicate copies of output to Bundle Adjustment to React Folder
+            dask.delayed(io_utils.write_cameras)(ba_output_graph, image_graph, save_dir=react_ba_output_save_dir)
+            dask.delayed(io_utils.write_images)(ba_output_graph, save_dir=react_ba_output_save_dir)
+            dask.delayed(io_utils.write_points)(ba_output_graph, image_graph, save_dir=react_ba_output_save_dir)
 
         # as visualization tasks are not to be provided to the user, we create a
         # dummy computation of concatenating viz tasks with the output graph,
@@ -357,6 +379,9 @@ def persist_frontend_metrics_full(metrics: Dict[Tuple[int, int], FRONTEND_METRIC
 
     io_utils.save_json_file(os.path.join(METRICS_PATH, "frontend_full.json"), metrics_list)
 
+    # Save duplicate copy of 'frontend_full.json' within React Folder.
+    io_utils.save_json_file(os.path.join(REACT_METRICS_PATH, "frontend_full.json"), metrics_list)
+
 
 def aggregate_frontend_metrics(
     metrics: Dict[Tuple[int, int], FRONTEND_METRICS_FOR_PAIR], angular_err_threshold_deg: float
@@ -413,3 +438,6 @@ def aggregate_frontend_metrics(
     }
 
     io_utils.save_json_file(os.path.join(METRICS_PATH, "frontend_summary.json"), front_end_result_info)
+
+    # Save duplicate copy of 'frontend_summary.json' within React Folder.
+    io_utils.save_json_file(os.path.join(REACT_METRICS_PATH, "frontend_summary.json"), front_end_result_info)


### PR DESCRIPTION
In order for the React application to work on anyone else's machine, I've added some lines of python code to save duplicate copies of the `results` and `result_metrics` directories within my React app source code (in order for the web app to read the json and txt files internally and display the correct information).