### PR TITLE
Add gtsfm-nonfree as subtree

### DIFF
--- a/nonfree/LICENSE
+++ b/nonfree/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2021, BORG Lab
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/nonfree/README.md
+++ b/nonfree/README.md
@@ -1,2 +1,2 @@
 # gtsfm-nonfree
-3rd party algorithms to be plugged into GTSFM which are not free for commercial use due to licensing issues
+3rd party algorithms to be plugged into GTSFM which are not free for commercial.

--- a/nonfree/README.md
+++ b/nonfree/README.md
@@ -1,0 +1,2 @@
+# gtsfm-nonfree
+3rd party algorithms to be plugged into GTSFM which are not free for commercial use due to licensing issues


### PR DESCRIPTION
Adding the [gtsfm-nonfree](https://github.com/borglab/gtsfm-nonfree) repository as a subtree.

With the subtree setup, we can just continue adding code in both the *main* gtsfm and the nonfree repo from a single place.