### PR TITLE
Upgrade hydra to 1.1.0dev6

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -36,7 +36,7 @@ dependencies:
   - h5py
   - pip:
     - pydegensac
-    - hydra-core==1.1.0dev3
+    - hydra-core==1.1.0dev6
     - argoverse @ git+https://github.com/argoai/argoverse-api.git@master
 
 

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -37,6 +37,6 @@ dependencies:
   # io
   - h5py
   - pip:
-    - hydra-core==1.1.0dev3
+    - hydra-core==1.1.0dev6
 
 

--- a/gtsfm/runner/run_scene_optimizer.py
+++ b/gtsfm/runner/run_scene_optimizer.py
@@ -1,8 +1,8 @@
 import os
 from pathlib import Path
 
+import hydra
 from dask.distributed import Client, LocalCluster, performance_report
-from hydra.experimental import compose, initialize_config_module
 from hydra.utils import instantiate
 
 import gtsfm.utils.logger as logger_utils
@@ -17,9 +17,9 @@ logger = logger_utils.get_logger()
 
 def run_scene_optimizer() -> None:
     """ """
-    with initialize_config_module(config_module="gtsfm.configs"):
+    with hydra.initialize_config_module(config_module="gtsfm.configs"):
         # config is relative to the gtsfm module
-        cfg = compose(config_name="default_lund_door_set1_config.yaml")
+        cfg = hydra.compose(config_name="default_lund_door_set1_config.yaml")
         scene_optimizer: SceneOptimizer = instantiate(cfg.SceneOptimizer)
 
         loader = OlssonLoader(os.path.join(DATA_ROOT, "set1_lund_door"), image_extension="JPG")

--- a/gtsfm/runner/run_scene_optimizer_argoverse.py
+++ b/gtsfm/runner/run_scene_optimizer_argoverse.py
@@ -1,8 +1,8 @@
 import argparse
 
+import hydra
 import numpy as np
 from dask.distributed import Client, LocalCluster, performance_report
-from hydra.experimental import compose, initialize_config_module
 from hydra.utils import instantiate
 
 from gtsfm.common.gtsfm_data import GtsfmData
@@ -16,9 +16,9 @@ logger = get_logger()
 
 def run_scene_optimizer(args) -> None:
     """ Run GTSFM over images from an Argoverse vehicle log"""
-    with initialize_config_module(config_module="gtsfm.configs"):
+    with hydra.initialize_config_module(config_module="gtsfm.configs"):
         # config is relative to the gtsfm module
-        cfg = compose(config_name="default_lund_door_set1_config.yaml")
+        cfg = hydra.compose(config_name="default_lund_door_set1_config.yaml")
         scene_optimizer: SceneOptimizer = instantiate(cfg.SceneOptimizer)
 
         loader = ArgoverseDatasetLoader(


### PR DESCRIPTION
Currently CI fails to create the conda environment, because `argoverse-api` now uses "hydra-core==1.1.0dev6",, whereas gtsfm uses "hydra-core==1.1.0dev3",