### PR TITLE
Support for Sim(3) alignment with missing poses

### DIFF
--- a/gtsfm/utils/geometry_comparisons.py
+++ b/gtsfm/utils/geometry_comparisons.py
@@ -40,6 +40,52 @@ def align_rotations(aRi_list: List[Rot3], bRi_list: List[Rot3]) -> List[Rot3]:
     return [aRb.compose(bRi) for bRi in bRi_list]
 
 
+def align_poses_sim3_wrapper(aTi_list: List[Optional[Pose3]], bTi_list: List[Optional[Pose3]]) -> List[Optional[Pose3]]:
+    """Align by similarity transformation, but allow missing estimated poses in the input.
+
+    Note: this is a wrapper for align_poses_sim3() that allows for missing poses/dropped cameras.
+    This is necessary, as align_poses_sim3() requires a valid pose for every input pair.
+
+    We force SIM(3) alignment rather than SE(3) alignment.
+    We assume the two trajectories are of the exact same length.
+
+    Args:
+        aTi_list: reference poses in frame "a" which are the targets for alignment
+        bTi_list: input poses which need to be aligned to frame "a"
+
+    Returns:
+        aTi_list_: transformed input poses previously "bTi_list" but now which
+            have the same origin and scale as reference (now living in "a" frame)
+    """
+    assert len(aTi_list) == len(bTi_list)
+
+    # only choose target poses for which there is a corresponding estimated pose
+    corresponding_aTi_list = []
+    valid_camera_idxs = []
+    dropped_camera_idxs = []
+    valid_bTi_list = []
+    for i, bTi in enumerate(bTi_list):
+        if bTi is None:
+            dropped_camera_idxs.append(i)
+        else:
+            valid_camera_idxs.append(i)
+            valid_bTi_list.append(bTi)
+            corresponding_aTi_list.append(aTi_list[i])
+
+    if len(dropped_camera_idxs) > 0:
+        logger.info("Estimating Sim(3) without missing poses at %s", str(dropped_camera_idxs))
+    valid_aTi_list_ = align_poses_sim3(aTi_list=corresponding_aTi_list, bTi_list=valid_bTi_list)
+
+    num_cameras = len(aTi_list)
+    # now at valid indices
+    aTi_list_ = [None] * num_cameras
+    for i in range(num_cameras):
+        if i in valid_camera_idxs:
+            aTi_list_[i] = valid_aTi_list_.pop(0)
+
+    return aTi_list_
+
+
 def align_poses_sim3(aTi_list: List[Pose3], bTi_list: List[Pose3]) -> List[Pose3]:
     """Align by similarity transformation.
 
@@ -82,9 +128,9 @@ def align_poses_sim3(aTi_list: List[Pose3], bTi_list: List[Pose3]) -> List[Pose3
     aRb = aSb.rotation().matrix()
     atb = aSb.translation()
     rz, ry, rx = Rotation.from_matrix(aRb).as_euler("zyx", degrees=True)
-    logger.info(f"Sim(3) Rotation `aRb`: rz={rz:.2f} deg., ry={ry:.2f} deg., rx={rx:.2f} deg.",)
+    logger.info("Sim(3) Rotation `aRb`: rz=%.2f deg., ry=%.2f deg., rx=%.2f deg.", rz, ry, rx)
     logger.info(f"Sim(3) Translation `atb`: [tx,ty,tz]={str(np.round(atb,2))}")
-    logger.info(f"Sim(3) Scale `asb`: {float(aSb.scale()):.2f}")
+    logger.info("Sim(3) Scale `asb`: %.2f", float(aSb.scale()))
 
     aTi_list_ = []
     for i in range(n_to_align):

--- a/gtsfm/utils/geometry_comparisons.py
+++ b/gtsfm/utils/geometry_comparisons.py
@@ -1,6 +1,6 @@
 """Utility functions for comparing different types related to geometry.
 
-Authors: Ayush Baid
+Authors: Ayush Baid, John Lambert
 """
 from typing import List, Optional
 
@@ -40,7 +40,9 @@ def align_rotations(aRi_list: List[Rot3], bRi_list: List[Rot3]) -> List[Rot3]:
     return [aRb.compose(bRi) for bRi in bRi_list]
 
 
-def align_poses_sim3_ignore_missing(aTi_list: List[Optional[Pose3]], bTi_list: List[Optional[Pose3]]) -> List[Optional[Pose3]]:
+def align_poses_sim3_ignore_missing(
+    aTi_list: List[Optional[Pose3]], bTi_list: List[Optional[Pose3]]
+) -> List[Optional[Pose3]]:
     """Align by similarity transformation, but allow missing estimated poses in the input.
 
     Note: this is a wrapper for align_poses_sim3() that allows for missing poses/dropped cameras.
@@ -68,7 +70,7 @@ def align_poses_sim3_ignore_missing(aTi_list: List[Optional[Pose3]], bTi_list: L
             valid_camera_idxs.append(i)
             valid_bTi_list.append(bTi)
             corresponding_aTi_list.append(aTi_list[i])
-    
+
     valid_aTi_list_ = align_poses_sim3(aTi_list=corresponding_aTi_list, bTi_list=valid_bTi_list)
 
     num_cameras = len(aTi_list)

--- a/gtsfm/utils/geometry_comparisons.py
+++ b/gtsfm/utils/geometry_comparisons.py
@@ -40,7 +40,7 @@ def align_rotations(aRi_list: List[Rot3], bRi_list: List[Rot3]) -> List[Rot3]:
     return [aRb.compose(bRi) for bRi in bRi_list]
 
 
-def align_poses_sim3_wrapper(aTi_list: List[Optional[Pose3]], bTi_list: List[Optional[Pose3]]) -> List[Optional[Pose3]]:
+def align_poses_sim3_ignore_missing(aTi_list: List[Optional[Pose3]], bTi_list: List[Optional[Pose3]]) -> List[Optional[Pose3]]:
     """Align by similarity transformation, but allow missing estimated poses in the input.
 
     Note: this is a wrapper for align_poses_sim3() that allows for missing poses/dropped cameras.
@@ -82,7 +82,7 @@ def align_poses_sim3_wrapper(aTi_list: List[Optional[Pose3]], bTi_list: List[Opt
 
 
 def align_poses_sim3(aTi_list: List[Pose3], bTi_list: List[Pose3]) -> List[Pose3]:
-    """Align by similarity transformation.
+    """Align two pose graphs via similarity transformation. Note: poses cannot be missing/invalid.
 
     We force SIM(3) alignment rather than SE(3) alignment.
     We assume the two trajectories are of the exact same length.

--- a/gtsfm/utils/geometry_comparisons.py
+++ b/gtsfm/utils/geometry_comparisons.py
@@ -62,18 +62,13 @@ def align_poses_sim3_wrapper(aTi_list: List[Optional[Pose3]], bTi_list: List[Opt
     # only choose target poses for which there is a corresponding estimated pose
     corresponding_aTi_list = []
     valid_camera_idxs = []
-    dropped_camera_idxs = []
     valid_bTi_list = []
     for i, bTi in enumerate(bTi_list):
-        if bTi is None:
-            dropped_camera_idxs.append(i)
-        else:
+        if bTi is not None:
             valid_camera_idxs.append(i)
             valid_bTi_list.append(bTi)
             corresponding_aTi_list.append(aTi_list[i])
-
-    if len(dropped_camera_idxs) > 0:
-        logger.info("Estimating Sim(3) without missing poses at %s", str(dropped_camera_idxs))
+    
     valid_aTi_list_ = align_poses_sim3(aTi_list=corresponding_aTi_list, bTi_list=valid_bTi_list)
 
     num_cameras = len(aTi_list)

--- a/tests/utils/test_geometry_comparisons.py
+++ b/tests/utils/test_geometry_comparisons.py
@@ -264,8 +264,8 @@ class TestGeometryComparisons(unittest.TestCase):
         wti2 = Point3(1, 1, -1)
         self.assertEqual(geometry_comparisons.compute_points_distance_l2(wti1, wti2), 2)
 
-    def test_align_poses_sim3_wrapper_missing_poses(self):
-        """Consider a simple cases with 3 poses in a line. Suppose SfM only recovers 1 of the 3 poses."""
+    def test_align_poses_sim3_ignore_missing(self):
+        """Consider a simple cases with 4 poses in a line. Suppose SfM only recovers 2 of the 4 poses."""
         wT0 = Pose3(Rot3(np.eye(3)), np.zeros(3))
         wT1 = Pose3(Rot3(np.eye(3)), np.ones(3))
         wT2 = Pose3(Rot3(np.eye(3)), np.ones(3) * 2)
@@ -275,7 +275,7 @@ class TestGeometryComparisons(unittest.TestCase):
         aTi_list = [wT0, wT1, wT2, wT3]
         # `b` frame contains the estimates
         bTi_list = [None, wT1, None, wT3]
-        aTi_list_ = geometry_comparisons.align_poses_sim3_wrapper(aTi_list, bTi_list)
+        aTi_list_ = geometry_comparisons.align_poses_sim3_ignore_missing(aTi_list, bTi_list)
 
         # indices 0 and 2 should still have no estimated pose, even after alignment
         assert aTi_list_[0] is None


### PR DESCRIPTION
After the MuitlviewOptimizer, we align the poses that come out of Shonan and 1dsfm to the ground truth, and measure the pose errors.

1dsfm may return None for some poses (if the Value is missing). Previous Sim(3) alignment required a valid pose for every frame, in GT and estimate.