### PR TITLE
Reorder indices for input to Shonan so that N keys are consecutive [0,...,N-1]

### DIFF
--- a/gtsfm/averaging/rotation/shonan.py
+++ b/gtsfm/averaging/rotation/shonan.py
@@ -30,20 +30,33 @@ class ShonanRotationAveraging(RotationAveragingBase):
     """Performs Shonan rotation averaging."""
 
     def __init__(self) -> None:
+        """
+        Note: `p_min` and `p_max` describe the minimum and maximum relaxation rank.
+        """
         self._p_min = 5
         self._p_max = 30
 
-    def run(self, num_images: int, i2Ri1_dict: Dict[Tuple[int, int], Optional[Rot3]]) -> List[Optional[Rot3]]:
-        """Run the rotation averaging.
+    def run_w_consecutive_ordering(
+        self, num_connected_nodes: int, i2Ri1_dict: Dict[Tuple[int, int], Optional[Rot3]]
+    ) -> List[Optional[Rot3]]:
+        """Run the rotation averaging on a connected graph w/ N keys ordered consecutively [0,...,N-1].
+
+        Note: the assumption that Shonan keys are ordered as [0,...,N-1] goes deeper than ShonanAveraging::NrUnknowns(),
+        which just checks the assumption. Several other functions that construct matrices related to the
+        convergence certificate also use the fact that the graph is connected and keys are 0..N-1.
+        There are about 10 places where nrUnknowns is used to dimension a sparse or dense matrix.
+        Modifying GTSAM would require a major philosophical overhaul, so we perform the re-ordering
+        here in a sort of "wrapper". See: https://github.com/borglab/gtsam/issues/784
 
         Args:
-            num_images: number of poses.
-            i2Ri1_dict: relative rotations as dictionary (i1, i2): i2Ri1.
+            num_connected_nodes: number of unique connected nodes in the graph (can be far less the number of images in the dataset)
+            i2Ri1_dict: relative rotations for each image pair-edge as dictionary (i1, i2): i2Ri1.
 
         Returns:
-            Global rotations for each camera pose, i.e. wRi, as a list. The number of entries in the list is
-                `num_images`. The list may contain `None` where the global rotation could not be computed (either
+            Global rotations for each **CONNECTED** camera pose, i.e. wRi, as a list. The number of entries in the list is
+                `num_connected_nodes`. The list may contain `None` where the global rotation could not be computed (either
                 underconstrained system or ill-constrained system).
+
         """
         lm_params = LevenbergMarquardtParams.CeresDefaults()
         shonan_params = ShonanAveragingParameters3(lm_params)
@@ -56,23 +69,58 @@ class ShonanRotationAveraging(RotationAveragingBase):
 
         for (i1, i2), i2Ri1 in i2Ri1_dict.items():
             if i2Ri1 is not None:
-                between_factors.append(
-                    BetweenFactorPose3(
-                        i2,
-                        i1,
-                        Pose3(
-                            i2Ri1,
-                            np.zeros(
-                                3,
-                            ),
-                        ),
-                        noise_model,
-                    )
-                )
+                # ignore translation during rotation averaging
+                i2Ti1 = Pose3(i2Ri1, np.zeros(3))
+                between_factors.append(BetweenFactorPose3(i2, i1, i2Ti1, noise_model))
 
         obj = ShonanAveraging3(between_factors, shonan_params)
 
         initial = obj.initializeRandomly()
         result_values, _ = obj.run(initial, self._p_min, self._p_max)
 
-        return [result_values.atRot3(i) for i in range(num_images)]
+        return [result_values.atRot3(i) if result_values.exists(i) else None for i in range(num_connected_nodes)]
+
+    def run(self, num_images: int, i2Ri1_dict: Dict[Tuple[int, int], Optional[Rot3]]) -> List[Optional[Rot3]]:
+        """Wrapper that re-orders keys to prepare a connected graph, w/ N keys ordered [0,...,N-1].
+
+        Args:
+            num_images: number of poses.
+            i2Ri1_dict: relative rotations for each image pair-edge as dictionary (i1, i2): i2Ri1.
+
+        Returns:
+            Global rotations for each camera pose, i.e. wRi, as a list. The number of entries in the list is
+                `num_images`. The list may contain `None` where the global rotation could not be computed (either
+                underconstrained system or ill-constrained system), or where the camera pose had no valid observation
+                in the input to run().
+        """
+        connected_nodes = set()
+        for (i1, i2) in i2Ri1_dict.keys():
+            connected_nodes.add(i1)
+            connected_nodes.add(i2)
+
+        connected_nodes = sorted(list(connected_nodes))
+
+        # given original index, get back new temporary index
+        reordered_idx_map = {}
+        for i in range(num_images):
+            if i in connected_nodes:
+                reordered_idx_map[i] = connected_nodes.index(i)
+
+        # now, re-order all of the indices
+        i2Ri1_dict_reordered = {}
+        for (i1, i2), i2Ri1 in i2Ri1_dict.items():
+            i1_ = reordered_idx_map[i1]
+            i2_ = reordered_idx_map[i2]
+            i2Ri1_dict_reordered[(i1_, i2_)] = i2Ri1
+
+        wRi_list_subset = self.run_w_consecutive_ordering(
+            num_connected_nodes=len(connected_nodes), i2Ri1_dict=i2Ri1_dict_reordered
+        )
+
+        wRi_list = [None] * num_images
+        for i in range(num_images):
+            if i in connected_nodes:
+                i_ = reordered_idx_map[i]
+                wRi_list[i] = wRi_list_subset[i_]
+
+        return wRi_list

--- a/gtsfm/averaging/rotation/shonan.py
+++ b/gtsfm/averaging/rotation/shonan.py
@@ -8,7 +8,7 @@ References:
 - https://arxiv.org/abs/2008.02737
 - https://gtsam.org/
 
-Authors: Jing Wu, Ayush Baid
+Authors: Jing Wu, Ayush Baid, John Lambert
 """
 from typing import Dict, List, Optional, Tuple
 
@@ -41,22 +41,22 @@ class ShonanRotationAveraging(RotationAveragingBase):
     ) -> List[Optional[Rot3]]:
         """Run the rotation averaging on a connected graph w/ N keys ordered consecutively [0,...,N-1].
 
-        Note: the assumption that Shonan keys are ordered as [0,...,N-1] goes deeper than ShonanAveraging::NrUnknowns(),
-        which just checks the assumption. Several other functions that construct matrices related to the
-        convergence certificate also use the fact that the graph is connected and keys are 0..N-1.
-        There are about 10 places where nrUnknowns is used to dimension a sparse or dense matrix.
+        Note: the assumption that Shonan keys are ordered as [0,...,N-1] goes deeper than
+        ShonanAveraging::NrUnknowns(), which just checks the assumption. Several other functions that construct
+        matrices related to the convergence certificate also use the fact that the graph is connected and
+        keys are 0..N-1. There are about 10 places where nrUnknowns is used to dimension a sparse or dense matrix.
         Modifying GTSAM would require a major philosophical overhaul, so we perform the re-ordering
         here in a sort of "wrapper". See: https://github.com/borglab/gtsam/issues/784
 
         Args:
-            num_connected_nodes: number of unique connected nodes in the graph (can be far less the number of images in the dataset)
+            num_connected_nodes: number of unique connected nodes in the graph (can be far less than the number
+                of images in the dataset)
             i2Ri1_dict: relative rotations for each image pair-edge as dictionary (i1, i2): i2Ri1.
 
         Returns:
-            Global rotations for each **CONNECTED** camera pose, i.e. wRi, as a list. The number of entries in the list is
-                `num_connected_nodes`. The list may contain `None` where the global rotation could not be computed (either
-                underconstrained system or ill-constrained system).
-
+            Global rotations for each **CONNECTED** camera pose, i.e. wRi, as a list. The number of entries in
+                the list is num_connected_nodes`. The list may contain `None` where the global rotation could
+                not be computed (either underconstrained system or ill-constrained system).
         """
         lm_params = LevenbergMarquardtParams.CeresDefaults()
         shonan_params = ShonanAveragingParameters3(lm_params)

--- a/gtsfm/averaging/rotation/shonan.py
+++ b/gtsfm/averaging/rotation/shonan.py
@@ -49,10 +49,11 @@ class ShonanRotationAveraging(RotationAveragingBase):
             num_connected_nodes: number of unique connected nodes (i.e. images) in the graph
                 (<= the number of images in the dataset)
             i2Ri1_dict: relative rotations for each edge between nodes as dictionary (i1, i2): i2Ri1.
+                Note: i1 < num_connected_nodes, and also i2 < num_connected_nodes.
 
         Returns:
             Global rotations for each **CONNECTED** camera pose, i.e. wRi, as a list. The number of entries in
-                the list is num_connected_nodes`. The list may contain `None` where the global rotation could
+                the list is `num_connected_nodes`. The list may contain `None` where the global rotation could
                 not be computed (either underconstrained system or ill-constrained system).
         """
         lm_params = LevenbergMarquardtParams.CeresDefaults()
@@ -83,10 +84,11 @@ class ShonanRotationAveraging(RotationAveragingBase):
         return wRi_list_consecutive
 
     def run(self, num_images: int, i2Ri1_dict: Dict[Tuple[int, int], Optional[Rot3]]) -> List[Optional[Rot3]]:
-        """Run the rotation averaging with arbitrary keys, where each key is a image/pose index.
+        """Run the rotation averaging on a connected graph with arbitrary keys, where each key is a image/pose index.
 
-        Note: run() functions as a wrapper that re-orders keys to prepare a connected graph,
-        w/ N keys ordered [0,...,N-1].
+        Note: run() functions as a wrapper that re-orders keys to prepare a graph w/ N keys ordered [0,...,N-1].
+        All input nodes must belong to a single connected component, in order to obtain an absolute pose for each
+        camera in a single, global coordinate frame.
 
         Args:
             num_images: number of images. Since we have one pose per image, it is also the number of poses.

--- a/gtsfm/averaging/rotation/shonan.py
+++ b/gtsfm/averaging/rotation/shonan.py
@@ -36,17 +36,14 @@ class ShonanRotationAveraging(RotationAveragingBase):
         self._p_min = 5
         self._p_max = 30
 
-    def run_w_consecutive_ordering(
+    def run_with_consecutive_ordering(
         self, num_connected_nodes: int, i2Ri1_dict: Dict[Tuple[int, int], Optional[Rot3]]
     ) -> List[Optional[Rot3]]:
         """Run the rotation averaging on a connected graph w/ N keys ordered consecutively [0,...,N-1].
 
-        Note: the assumption that Shonan keys are ordered as [0,...,N-1] goes deeper than
-        ShonanAveraging::NrUnknowns(), which just checks the assumption. Several other functions that construct
-        matrices related to the convergence certificate also use the fact that the graph is connected and
-        keys are 0..N-1. There are about 10 places where nrUnknowns is used to dimension a sparse or dense matrix.
+        Note: GTSAM requires the N input nodes to be connected and ordered from [0 ... N-1].
         Modifying GTSAM would require a major philosophical overhaul, so we perform the re-ordering
-        here in a sort of "wrapper". See: https://github.com/borglab/gtsam/issues/784
+        here in a sort of "wrapper". See https://github.com/borglab/gtsam/issues/784 for more details.
 
         Args:
             num_connected_nodes: number of unique connected nodes in the graph (can be far less than the number
@@ -78,13 +75,21 @@ class ShonanRotationAveraging(RotationAveragingBase):
         initial = obj.initializeRandomly()
         result_values, _ = obj.run(initial, self._p_min, self._p_max)
 
-        return [result_values.atRot3(i) if result_values.exists(i) else None for i in range(num_connected_nodes)]
+        wRi_list_consecutive = [None] * num_connected_nodes
+        for i in range(num_connected_nodes):
+            if result_values.exists(i):
+                wRi_list_consecutive[i] = result_values.atRot3(i)
+
+        return wRi_list_consecutive
 
     def run(self, num_images: int, i2Ri1_dict: Dict[Tuple[int, int], Optional[Rot3]]) -> List[Optional[Rot3]]:
-        """Wrapper that re-orders keys to prepare a connected graph, w/ N keys ordered [0,...,N-1].
+        """Run the rotation averaging with arbitrary keys, where each key is a image/pose index.
+
+        Note: run() functions as a wrapper that re-orders keys to prepare a connected graph,
+        w/ N keys ordered [0,...,N-1].
 
         Args:
-            num_images: number of poses.
+            num_images: number of images. Since we have one pose per image, it is also the number of poses.
             i2Ri1_dict: relative rotations for each image pair-edge as dictionary (i1, i2): i2Ri1.
 
         Returns:
@@ -100,11 +105,10 @@ class ShonanRotationAveraging(RotationAveragingBase):
 
         connected_nodes = sorted(list(connected_nodes))
 
-        # given original index, get back new temporary index
+        # given original index, this map gives back a new temporary index, starting at 0
         reordered_idx_map = {}
-        for i in range(num_images):
-            if i in connected_nodes:
-                reordered_idx_map[i] = connected_nodes.index(i)
+        for (new_idx, i) in enumerate(connected_nodes):
+            reordered_idx_map[i] = new_idx
 
         # now, re-order all of the indices
         i2Ri1_dict_reordered = {}
@@ -113,7 +117,7 @@ class ShonanRotationAveraging(RotationAveragingBase):
             i2_ = reordered_idx_map[i2]
             i2Ri1_dict_reordered[(i1_, i2_)] = i2Ri1
 
-        wRi_list_subset = self.run_w_consecutive_ordering(
+        wRi_list_subset = self.run_with_consecutive_ordering(
             num_connected_nodes=len(connected_nodes), i2Ri1_dict=i2Ri1_dict_reordered
         )
 

--- a/tests/averaging/rotation/test_shonan.py
+++ b/tests/averaging/rotation/test_shonan.py
@@ -127,12 +127,11 @@ class TestShonanRotationAveraging(unittest.TestCase):
         """
         num_images = 4
 
-        wTi0 = Pose3(Rot3(), np.array([1, 1, 0]))
+        # assume pose 0 is orphaned in the visibility graph
+        # Let wTi0's (R,t) be parameterized as identity Rot3(), and t = [1,1,0]
         wTi1 = Pose3(Rot3(), np.array([3, 1, 0]))
         wTi2 = Pose3(Rot3(), np.array([3, 3, 0]))
         wTi3 = Pose3(Rot3(), np.array([1, 3, 0]))
-
-        # assume pose 0 is orphaned in the visibility graph
 
         # generate i2Ri1 rotations
         # (i1,i2) -> i2Ri1

--- a/tests/averaging/rotation/test_shonan.py
+++ b/tests/averaging/rotation/test_shonan.py
@@ -1,6 +1,6 @@
 """Tests for Shonan rotation averaging.
 
-Authors: Ayush Baid
+Authors: Ayush Baid, John Lambert
 """
 import pickle
 import unittest
@@ -8,7 +8,7 @@ from typing import Dict, List, Tuple
 
 import dask
 import numpy as np
-from gtsam import Rot3
+from gtsam import Rot3, Pose3
 
 import gtsfm.utils.geometry_comparisons as geometry_comparisons
 import tests.data.sample_poses as sample_poses
@@ -118,6 +118,37 @@ class TestShonanRotationAveraging(unittest.TestCase):
             pickle.dumps(self.obj)
         except TypeError:
             self.fail("Cannot dump rotation averaging object using pickle")
+
+    def test_nonconsecutive_indices(self):
+        """Run rotation averaging on a graph with indices that are not ordered as [0,...,N-1].
+
+        Note: Test would fail if Shonan keys were not temporarily re-ordered inside the implementation.
+        See https://github.com/borglab/gtsam/issues/784
+        """
+        num_images = 4
+
+        wTi0 = Pose3(Rot3(), np.array([1, 1, 0]))
+        wTi1 = Pose3(Rot3(), np.array([3, 1, 0]))
+        wTi2 = Pose3(Rot3(), np.array([3, 3, 0]))
+        wTi3 = Pose3(Rot3(), np.array([1, 3, 0]))
+
+        # assume pose 0 is orphaned in the visibility graph
+
+        # generate i2Ri1 rotations
+        # (i1,i2) -> i2Ri1
+        i2Ri1_input = {
+            (1, 2): wTi2.between(wTi1).rotation(),
+            (2, 3): wTi3.between(wTi2).rotation(),
+            (1, 3): wTi3.between(wTi1).rotation(),
+        }
+
+        wRi_expected = [None, wTi1.rotation(), wTi2.rotation(), wTi3.rotation()]
+
+        wRi_computed = self.obj.run(num_images, i2Ri1_input)
+
+        self.assertTrue(
+            geometry_comparisons.compare_rotations(wRi_computed, wRi_expected, angular_error_threshold_degrees=0.1)
+        )
 
 
 if __name__ == "__main__":

--- a/tests/averaging/rotation/test_shonan.py
+++ b/tests/averaging/rotation/test_shonan.py
@@ -140,11 +140,9 @@ class TestShonanRotationAveraging(unittest.TestCase):
             (2, 3): wTi3.between(wTi2).rotation(),
             (1, 3): wTi3.between(wTi1).rotation(),
         }
-
-        wRi_expected = [None, wTi1.rotation(), wTi2.rotation(), wTi3.rotation()]
-
+        
         wRi_computed = self.obj.run(num_images, i2Ri1_input)
-
+        wRi_expected = [None, wTi1.rotation(), wTi2.rotation(), wTi3.rotation()]
         self.assertTrue(
             geometry_comparisons.compare_rotations(wRi_computed, wRi_expected, angular_error_threshold_degrees=0.1)
         )


### PR DESCRIPTION
GTSAM's ShonanAveraging.cpp assumes that N nodes are all connected, and are ordered consecutively from [0,...,N-1]

This assumption goes deeper than ShonanAveraging::NrUnknowns(), which just checks the assumption. Several other functions that construct matrices related to the convergence certificate also use the fact that the graph is connected and keys are 0..N-1.

There are about 10 places where nrUnknowns is used to dimension a sparse or dense matrix.

Modifying GTSAM would require a major philosophical overhaul, so we perform the re-ordering in GTSFM instead, in a sort of "wrapper".

See https://github.com/borglab/gtsam/issues/784 for more details