### PR TITLE
Pass --no-check-certificate flag to wget, for patchmatchnet weights

### DIFF
--- a/download_model_weights.sh
+++ b/download_model_weights.sh
@@ -27,4 +27,4 @@ mkdir -p $PATCHMATCHNET_WEIGHTS_DIR
 
 PATCHMATCHNET_URL="https://github.com/FangjinhuaWang/PatchmatchNet/raw/main/checkpoints/model_000007.ckpt"
 
-wget -O $PATCHMATCHNET_WEIGHTS_DIR/model_000007.ckpt $PATCHMATCHNET_URL
+wget -c --no-check-certificate -O $PATCHMATCHNET_WEIGHTS_DIR/model_000007.ckpt $PATCHMATCHNET_URL


### PR DESCRIPTION
Needed for downloading raw files from github.