### PR TITLE
bump hydra-core version bc of new release

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -36,7 +36,7 @@ dependencies:
   - h5py
   - pip:
     - pydegensac
-    - hydra-core==1.1.0dev6
+    - hydra-core==1.1.0
     - argoverse @ git+https://github.com/argoai/argoverse-api.git@master
 
 

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -37,7 +37,7 @@ dependencies:
   # io
   - h5py
   - pip:
-    - hydra-core==1.1.0dev6
+    - hydra-core==1.1.0
     - argoverse @ git+https://github.com/argoai/argoverse-api.git@master
 
 


### PR DESCRIPTION
Hydra's pre-release 1.1.0dev6 is now deprecated, since 1.1.0 was released