### PR TITLE
make runner for colmap loader configurable from CLI

### DIFF
--- a/gtsfm/runner/run_scene_optimizer_colmaploader.py
+++ b/gtsfm/runner/run_scene_optimizer_colmaploader.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
         "--colmap_files_dirpath",
         type=str,
         required=True,
-        help="path to directory containing images.txt, points3D.txt, and cameras.txt (optional)",
+        help="path to directory containing images.txt, points3D.txt, and cameras.txt",
     )
     parser.add_argument(
         "--max_frame_lookahead",


### PR DESCRIPTION
Allowing passing parameters like number of workers and desired config file to the runner that ingests COLMAP-formatted data.