### PR TITLE
Produce report from each two-view estimation result to allow in analysis

### DIFF
--- a/gtsfm/configs/deep_front_end.yaml
+++ b/gtsfm/configs/deep_front_end.yaml
@@ -1,7 +1,7 @@
 SceneOptimizer:
   _target_: gtsfm.scene_optimizer.SceneOptimizer
   save_gtsfm_data: True
-  save_two_view_correspondences_viz: False
+  save_two_view_correspondences_viz: True
   save_3d_viz: True
   pose_angular_error_thresh: 5 # degrees
 
@@ -25,6 +25,7 @@ SceneOptimizer:
       _target_: gtsfm.frontend.verifier.ransac.Ransac
       use_intrinsics_in_verification: True
       estimation_threshold_px: 4
+      min_allowed_inlier_ratio_est_model: 0.1
 
   multiview_optimizer:
     _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer

--- a/gtsfm/configs/deep_front_end.yaml
+++ b/gtsfm/configs/deep_front_end.yaml
@@ -1,7 +1,7 @@
 SceneOptimizer:
   _target_: gtsfm.scene_optimizer.SceneOptimizer
   save_gtsfm_data: True
-  save_two_view_correspondences_viz: True
+  save_two_view_correspondences_viz: False
   save_3d_viz: True
   pose_angular_error_thresh: 5 # degrees
 
@@ -14,7 +14,6 @@ SceneOptimizer:
   two_view_estimator:
     _target_: gtsfm.two_view_estimator.TwoViewEstimator
     eval_threshold_px: 3 # in px
-    estimation_threshold_px: 4 # for homography estimator
     min_num_inliers_acceptance: 15
 
     matcher:
@@ -24,7 +23,7 @@ SceneOptimizer:
     verifier:
       _target_: gtsfm.frontend.verifier.ransac.Ransac
       use_intrinsics_in_verification: True
-      estimation_threshold_px: 4
+      estimation_threshold_px: 4 # for H/E/F estimators
       min_allowed_inlier_ratio_est_model: 0.1
 
   multiview_optimizer:

--- a/gtsfm/configs/deep_front_end.yaml
+++ b/gtsfm/configs/deep_front_end.yaml
@@ -1,7 +1,7 @@
 SceneOptimizer:
   _target_: gtsfm.scene_optimizer.SceneOptimizer
   save_gtsfm_data: True
-  save_two_view_correspondences_viz: True
+  save_two_view_correspondences_viz: False
   save_3d_viz: True
   pose_angular_error_thresh: 5 # degrees
 

--- a/gtsfm/configs/deep_front_end.yaml
+++ b/gtsfm/configs/deep_front_end.yaml
@@ -1,7 +1,7 @@
 SceneOptimizer:
   _target_: gtsfm.scene_optimizer.SceneOptimizer
   save_gtsfm_data: True
-  save_two_view_correspondences_viz: False
+  save_two_view_correspondences_viz: True
   save_3d_viz: True
   pose_angular_error_thresh: 5 # degrees
 
@@ -13,14 +13,18 @@ SceneOptimizer:
 
   two_view_estimator:
     _target_: gtsfm.two_view_estimator.TwoViewEstimator
-    corr_metric_dist_threshold: 3 # in px
+    eval_threshold_px: 3 # in px
+    estimation_threshold_px: 4 # for homography estimator
+    min_num_inliers_acceptance: 15
+
     matcher:
       _target_: gtsfm.frontend.matcher.superglue_matcher.SuperGlueMatcher
+      use_outdoor_model: True
 
     verifier:
       _target_: gtsfm.frontend.verifier.ransac.Ransac
       use_intrinsics_in_verification: True
-    
+      estimation_threshold_px: 4
 
   multiview_optimizer:
     _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer

--- a/gtsfm/configs/scene_optimizer_unit_test_config.yaml
+++ b/gtsfm/configs/scene_optimizer_unit_test_config.yaml
@@ -13,14 +13,15 @@ SceneOptimizer:
 
   two_view_estimator:
     _target_: gtsfm.two_view_estimator.TwoViewEstimator
-    corr_metric_dist_threshold: 3 # in px
+    eval_threshold_px: 3 # in px
+    estimation_threshold_px: 0.5 # for homography estimator
     matcher:
       _target_: gtsfm.frontend.matcher.twoway_matcher.TwoWayMatcher
 
     verifier:
       _target_: gtsfm.frontend.verifier.ransac.Ransac
       use_intrinsics_in_verification: False
-    
+      estimation_threshold_px: 0.5
 
   multiview_optimizer:
     _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer

--- a/gtsfm/configs/scene_optimizer_unit_test_config.yaml
+++ b/gtsfm/configs/scene_optimizer_unit_test_config.yaml
@@ -3,7 +3,7 @@ SceneOptimizer:
   save_gtsfm_data: True
   save_two_view_correspondences_viz: False
   save_3d_viz: True
-  pose_angular_error_thresh: 10 # degrees
+  pose_angular_error_thresh: 5 # degrees
 
   feature_extractor:
     _target_: gtsfm.feature_extractor.FeatureExtractor
@@ -15,6 +15,8 @@ SceneOptimizer:
     _target_: gtsfm.two_view_estimator.TwoViewEstimator
     eval_threshold_px: 3 # in px
     estimation_threshold_px: 0.5 # for homography estimator
+    min_num_inliers_acceptance: 15
+    
     matcher:
       _target_: gtsfm.frontend.matcher.twoway_matcher.TwoWayMatcher
 
@@ -22,6 +24,7 @@ SceneOptimizer:
       _target_: gtsfm.frontend.verifier.ransac.Ransac
       use_intrinsics_in_verification: False
       estimation_threshold_px: 0.5
+      min_allowed_inlier_ratio_est_model: 0.1
 
   multiview_optimizer:
     _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer

--- a/gtsfm/configs/scene_optimizer_unit_test_config.yaml
+++ b/gtsfm/configs/scene_optimizer_unit_test_config.yaml
@@ -14,7 +14,6 @@ SceneOptimizer:
   two_view_estimator:
     _target_: gtsfm.two_view_estimator.TwoViewEstimator
     eval_threshold_px: 3 # in px
-    estimation_threshold_px: 0.5 # for homography estimator
     min_num_inliers_acceptance: 15
     
     matcher:
@@ -23,7 +22,7 @@ SceneOptimizer:
     verifier:
       _target_: gtsfm.frontend.verifier.ransac.Ransac
       use_intrinsics_in_verification: False
-      estimation_threshold_px: 0.5
+      estimation_threshold_px: 0.5 # for H/E/F estimators
       min_allowed_inlier_ratio_est_model: 0.1
 
   multiview_optimizer:

--- a/gtsfm/configs/sift_front_end.yaml
+++ b/gtsfm/configs/sift_front_end.yaml
@@ -1,9 +1,9 @@
 SceneOptimizer:
   _target_: gtsfm.scene_optimizer.SceneOptimizer
   save_gtsfm_data: True
-  save_two_view_correspondences_viz: False
+  save_two_view_correspondences_viz: True
   save_3d_viz: True
-  pose_angular_error_thresh: 10 # degrees
+  pose_angular_error_thresh: 5 # degrees
 
   feature_extractor:
     _target_: gtsfm.feature_extractor.FeatureExtractor
@@ -13,13 +13,17 @@ SceneOptimizer:
 
   two_view_estimator:
     _target_: gtsfm.two_view_estimator.TwoViewEstimator
-    corr_metric_dist_threshold: 3 # in px
+    eval_threshold_px: 3 # in px
+    estimation_threshold_px: 0.5 # for homography estimator
+    min_num_inliers_acceptance: 15
+    
     matcher:
       _target_: gtsfm.frontend.matcher.twoway_matcher.TwoWayMatcher
 
     verifier:
       _target_: gtsfm.frontend.verifier.ransac.Ransac
-      use_intrinsics_in_verification: False
+      use_intrinsics_in_verification: True
+      estimation_threshold_px: 4.0
     
 
   multiview_optimizer:

--- a/gtsfm/configs/sift_front_end.yaml
+++ b/gtsfm/configs/sift_front_end.yaml
@@ -1,7 +1,7 @@
 SceneOptimizer:
   _target_: gtsfm.scene_optimizer.SceneOptimizer
   save_gtsfm_data: True
-  save_two_view_correspondences_viz: False
+  save_two_view_correspondences_viz: True
   save_3d_viz: True
   pose_angular_error_thresh: 5 # degrees
 
@@ -24,7 +24,7 @@ SceneOptimizer:
       _target_: gtsfm.frontend.verifier.ransac.Ransac
       use_intrinsics_in_verification: True
       estimation_threshold_px: 4.0
-    
+      min_allowed_inlier_ratio_est_model: 0.1
 
   multiview_optimizer:
     _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer

--- a/gtsfm/configs/sift_front_end.yaml
+++ b/gtsfm/configs/sift_front_end.yaml
@@ -1,7 +1,7 @@
 SceneOptimizer:
   _target_: gtsfm.scene_optimizer.SceneOptimizer
   save_gtsfm_data: True
-  save_two_view_correspondences_viz: True
+  save_two_view_correspondences_viz: False
   save_3d_viz: True
   pose_angular_error_thresh: 5 # degrees
 
@@ -14,7 +14,6 @@ SceneOptimizer:
   two_view_estimator:
     _target_: gtsfm.two_view_estimator.TwoViewEstimator
     eval_threshold_px: 3 # in px
-    estimation_threshold_px: 0.5 # for homography estimator
     min_num_inliers_acceptance: 15
     
     matcher:
@@ -23,7 +22,7 @@ SceneOptimizer:
     verifier:
       _target_: gtsfm.frontend.verifier.ransac.Ransac
       use_intrinsics_in_verification: True
-      estimation_threshold_px: 4.0
+      estimation_threshold_px: 4 # for H/E/F estimators
       min_allowed_inlier_ratio_est_model: 0.1
 
   multiview_optimizer:

--- a/gtsfm/configs/sift_front_end.yaml
+++ b/gtsfm/configs/sift_front_end.yaml
@@ -1,7 +1,7 @@
 SceneOptimizer:
   _target_: gtsfm.scene_optimizer.SceneOptimizer
   save_gtsfm_data: True
-  save_two_view_correspondences_viz: True
+  save_two_view_correspondences_viz: False
   save_3d_viz: True
   pose_angular_error_thresh: 5 # degrees
 

--- a/gtsfm/frontend/verifier/degensac.py
+++ b/gtsfm/frontend/verifier/degensac.py
@@ -9,7 +9,7 @@ References:
 - http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.466.2719&rep=rep1&type=pdf
 - https://github.com/ducha-aiki/pyransac
 
-Authors: Ayush Baid
+Authors: Ayush Baid, John Lambert
 """
 
 from typing import Optional, Tuple
@@ -37,12 +37,13 @@ class Degensac(VerifierBase):
 
         Args:
             use_intrinsics_in_verification: Flag to perform keypoint normalization and compute the essential matrix
-                                            instead of fundamental matrix. This should be preferred when the exact
-                                            intrinsics are known as opposed to approximating them from exif data.
-            estimation_threshold_px: maximum distance (in pixels) to consider a match an inlier, under squared Sampson distance.
+                instead of fundamental matrix. This should be preferred when the exact intrinsics are known as opposed
+                to approximating them from exif data.
+            estimation_threshold_px: maximum distance (in pixels) to consider a match an inlier, under squared
+                Sampson distance.
             min_allowed_inlier_ratio_est_model: minimum allowed inlier ratio w.r.t. the estimated model to accept
-                the verification result and use the image pair, i.e. the lowest allowed ratio of #final RANSAC inliers/ #putatives.
-                A lower fraction indicates less consistency among the result.
+                the verification result and use the image pair, i.e. the lowest allowed ratio of
+                #final RANSAC inliers/ #putatives. A lower fraction indicates less agreement among the result.
         Raises:
             NotImplementedError: when configured to compute essential matrices.
         """
@@ -85,7 +86,6 @@ class Degensac(VerifierBase):
             keypoints_i2.coordinates[match_indices[:, 1]],
             px_th=self._estimation_threshold_px,
         )
-
         inlier_idxs = np.where(inlier_mask.ravel() == 1)[0]
 
         v_corr_idxs = match_indices[inlier_idxs]

--- a/gtsfm/frontend/verifier/degensac.py
+++ b/gtsfm/frontend/verifier/degensac.py
@@ -25,23 +25,29 @@ from gtsfm.frontend.verifier.verifier_base import VerifierBase
 
 logger = logger_utils.get_logger()
 
-MAX_TOLERATED_POLLUTION_INLIER_RATIO_EST_MODEL = 0.1
-
 
 class Degensac(VerifierBase):
-    def __init__(self, use_intrinsics_in_verification: bool, estimation_threshold_px: float) -> None:
+    def __init__(
+        self,
+        use_intrinsics_in_verification: bool,
+        estimation_threshold_px: float,
+        min_allowed_inlier_ratio_est_model: float,
+    ) -> None:
         """Initializes the verifier.
 
         Args:
-            use_intrinsics_in_verification: Flag to perform keypoint normalization and compute the essential matrix 
+            use_intrinsics_in_verification: Flag to perform keypoint normalization and compute the essential matrix
                                             instead of fundamental matrix. This should be preferred when the exact
                                             intrinsics are known as opposed to approximating them from exif data.
             estimation_threshold_px: maximum distance (in pixels) to consider a match an inlier, under squared Sampson distance.
-
+            min_allowed_inlier_ratio_est_model: minimum allowed inlier ratio w.r.t. the estimated model to accept
+                the verification result and use the image pair, i.e. the lowest allowed ratio of #final RANSAC inliers/ #putatives.
+                A lower fraction indicates less consistency among the result.
         Raises:
             NotImplementedError: when configured to compute essential matrices.
         """
         self._estimation_threshold_px = estimation_threshold_px
+        self._min_allowed_inlier_ratio_est_model = min_allowed_inlier_ratio_est_model
         if use_intrinsics_in_verification is True:
             raise NotImplementedError("DEGENSAC cannot estimate essential matrices")
 
@@ -69,6 +75,7 @@ class Degensac(VerifierBase):
             Estimated rotation i2Ri1, or None if it cannot be estimated.
             Estimated unit translation i2Ui1, or None if it cannot be estimated.
             Indices of verified correspondences, of shape (N, 2) with N <= N3. These are subset of match_indices.
+            Inlier ratio of w.r.t. the estimated model, i.e. the #final RANSAC inliers/ #putatives.
         """
         if match_indices.shape[0] < self._min_matches:
             return self._failure_result
@@ -83,8 +90,11 @@ class Degensac(VerifierBase):
 
         v_corr_idxs = match_indices[inlier_idxs]
         inlier_ratio_est_model = np.mean(inlier_mask)
-        if inlier_ratio_est_model < MAX_TOLERATED_POLLUTION_INLIER_RATIO_EST_MODEL:
-            logger.info("Discarding image pair, as inlier ratio w.r.t. estimated model was too low: %.2f", inlier_ratio_est_model)
+        if inlier_ratio_est_model < self._min_allowed_inlier_ratio_est_model:
+            logger.info(
+                "Discarding image pair, as inlier ratio w.r.t. estimated model was too low: %.2f",
+                inlier_ratio_est_model,
+            )
             i2Ri1 = None
             i2Ui1 = None
             v_corr_idxs = np.array([], dtype=np.uint64)

--- a/gtsfm/frontend/verifier/degensac.py
+++ b/gtsfm/frontend/verifier/degensac.py
@@ -51,7 +51,7 @@ class Degensac(VerifierBase):
         if use_intrinsics_in_verification is True:
             raise NotImplementedError("DEGENSAC cannot estimate essential matrices")
 
-        super().__init__(use_intrinsics_in_verification)
+        super().__init__(use_intrinsics_in_verification, estimation_threshold_px, min_allowed_inlier_ratio_est_model)
 
     def verify(
         self,

--- a/gtsfm/frontend/verifier/degensac.py
+++ b/gtsfm/frontend/verifier/degensac.py
@@ -36,7 +36,7 @@ class Degensac(VerifierBase):
             use_intrinsics_in_verification: Flag to perform keypoint normalization and compute the essential matrix 
                                             instead of fundamental matrix. This should be preferred when the exact
                                             intrinsics are known as opposed to approximating them from exif data.
-            estimation_threshold_px
+            estimation_threshold_px: maximum distance (in pixels) to consider a match an inlier, under squared Sampson distance.
 
         Raises:
             NotImplementedError: when configured to compute essential matrices.

--- a/gtsfm/frontend/verifier/ransac.py
+++ b/gtsfm/frontend/verifier/ransac.py
@@ -24,8 +24,8 @@ from gtsfm.common.keypoints import Keypoints
 from gtsfm.frontend.verifier.verifier_base import VerifierBase, NUM_MATCHES_REQ_E_MATRIX, NUM_MATCHES_REQ_F_MATRIX
 
 
-RANSAC_SUCCESS_PROB = 0.99999
-RANSAC_MAX_ITERS = 20000
+RANSAC_SUCCESS_PROB = 0.9999
+RANSAC_MAX_ITERS = 10000
 
 logger = logger_utils.get_logger()
 

--- a/gtsfm/frontend/verifier/ransac.py
+++ b/gtsfm/frontend/verifier/ransac.py
@@ -41,12 +41,13 @@ class Ransac(VerifierBase):
 
         Args:
             use_intrinsics_in_verification: Flag to perform keypoint normalization and compute the essential matrix
-                                            instead of fundamental matrix. This should be preferred when the exact
-                                            intrinsics are known as opposed to approximating them from exif data.
-            estimation_threshold_px: maximum distance (in pixels) to consider a match an inlier, under squared Sampson distance.
+                instead of fundamental matrix. This should be preferred when the exact intrinsics are known as opposed
+                to approximating them from exif data.
+            estimation_threshold_px: maximum distance (in pixels) to consider a match an inlier, under squared
+                Sampson distance.
             min_allowed_inlier_ratio_est_model: minimum allowed inlier ratio w.r.t. the estimated model to accept
-                the verification result and use the image pair, i.e. the lowest allowed ratio of #final RANSAC inliers/ #putatives.
-                A lower fraction indicates less consistency among the result.
+                the verification result and use the image pair, i.e. the lowest allowed ratio of
+                #final RANSAC inliers/ #putatives. A lower fraction indicates less agreement among the result.
         """
         self._use_intrinsics_in_verification = use_intrinsics_in_verification
         self._estimation_threshold_px = estimation_threshold_px

--- a/gtsfm/frontend/verifier/ransac.py
+++ b/gtsfm/frontend/verifier/ransac.py
@@ -49,14 +49,14 @@ class Ransac(VerifierBase):
                 A lower fraction indicates less consistency among the result.
         """
         self._use_intrinsics_in_verification = use_intrinsics_in_verification
-        self._px_threshold = estimation_threshold_px
+        self._estimation_threshold_px = estimation_threshold_px
         self._min_allowed_inlier_ratio_est_model = min_allowed_inlier_ratio_est_model
         self._min_matches = (
             NUM_MATCHES_REQ_E_MATRIX if self._use_intrinsics_in_verification else NUM_MATCHES_REQ_F_MATRIX
         )
 
         # for failure, i2Ri1 = None, and i2Ui1 = None, and no verified correspondences, and inlier_ratio_est_model = 0
-        self._failure_result = (None, None, np.array([], dtype=np.uint64), 0)
+        self._failure_result = (None, None, np.array([], dtype=np.uint64), 0.0)
 
     def verify(
         self,
@@ -100,7 +100,7 @@ class Ransac(VerifierBase):
                 uv_norm_i2[match_indices[:, 1]],
                 K,
                 method=cv2.RANSAC,
-                threshold=self._px_threshold / fx,
+                threshold=self._estimation_threshold_px / fx,
                 prob=RANSAC_SUCCESS_PROB,
             )
         else:
@@ -108,7 +108,7 @@ class Ransac(VerifierBase):
                 keypoints_i1.extract_indices(match_indices[:, 0]).coordinates,
                 keypoints_i2.extract_indices(match_indices[:, 1]).coordinates,
                 method=cv2.FM_RANSAC,
-                ransacReprojThreshold=self._px_threshold,
+                ransacReprojThreshold=self._estimation_threshold_px,
                 confidence=RANSAC_SUCCESS_PROB,
                 maxIters=RANSAC_MAX_ITERS,
             )

--- a/gtsfm/frontend/verifier/ransac.py
+++ b/gtsfm/frontend/verifier/ransac.py
@@ -24,15 +24,15 @@ from gtsfm.common.keypoints import Keypoints
 from gtsfm.frontend.verifier.verifier_base import VerifierBase, NUM_MATCHES_REQ_E_MATRIX, NUM_MATCHES_REQ_F_MATRIX
 
 
-DEFAULT_RANSAC_SUCCESS_PROB = 0.99999
-DEFAULT_RANSAC_MAX_ITERS = 20000
+RANSAC_SUCCESS_PROB = 0.99999
+RANSAC_MAX_ITERS = 20000
 MAX_TOLERATED_POLLUTION_INLIER_RATIO_EST_MODEL = 0.1
 
 logger = logger_utils.get_logger()
 
 
 class Ransac(VerifierBase):
-    def __init__(self, use_intrinsics_in_verification: bool, estimation_threshold_px: float) -> None:
+    def __init__(self, use_intrinsics_in_verification: bool, estimation_threshold_px: float, min_allowed_inlier_ratio_est_model: float) -> None:
         """Initializes the verifier.
 
         Args:
@@ -40,9 +40,13 @@ class Ransac(VerifierBase):
                                             instead of fundamental matrix. This should be preferred when the exact
                                             intrinsics are known as opposed to approximating them from exif data.
             estimation_threshold_px: maximum distance (in pixels) to consider a match an inlier, under squared Sampson distance.
+            min_allowed_inlier_ratio_est_model: minimum allowed inlier ratio w.r.t. the estimated model to accept
+                the verification result and use the image pair, i.e. the lowest allowed ratio of #final RANSAC inliers/ #putatives.
+                A lower fraction indicates less consistency among the result.
         """
         self._use_intrinsics_in_verification = use_intrinsics_in_verification
         self._px_threshold = estimation_threshold_px
+        self._min_allowed_inlier_ratio_est_model = min_allowed_inlier_ratio_est_model
         self._min_matches = (
             NUM_MATCHES_REQ_E_MATRIX if self._use_intrinsics_in_verification else NUM_MATCHES_REQ_F_MATRIX
         )
@@ -93,7 +97,7 @@ class Ransac(VerifierBase):
                 K,
                 method=cv2.RANSAC,
                 threshold=self._px_threshold / fx,
-                prob=DEFAULT_RANSAC_SUCCESS_PROB
+                prob=RANSAC_SUCCESS_PROB
             )
         else:
             i2Fi1, inlier_mask = cv2.findFundamentalMat(
@@ -101,8 +105,8 @@ class Ransac(VerifierBase):
                 keypoints_i2.extract_indices(match_indices[:, 1]).coordinates,
                 method=cv2.FM_RANSAC,
                 ransacReprojThreshold=self._px_threshold,
-                confidence=DEFAULT_RANSAC_SUCCESS_PROB,
-                maxIters=DEFAULT_RANSAC_MAX_ITERS
+                confidence=RANSAC_SUCCESS_PROB,
+                maxIters=RANSAC_MAX_ITERS
             )
 
             i2Ei1 = verification_utils.fundamental_to_essential_matrix(
@@ -114,7 +118,7 @@ class Ransac(VerifierBase):
         v_corr_idxs = match_indices[inlier_idxs]
         inlier_ratio_est_model = np.mean(inlier_mask)
 
-        if inlier_ratio_est_model < MAX_TOLERATED_POLLUTION_INLIER_RATIO_EST_MODEL:
+        if inlier_ratio_est_model < self._min_allowed_inlier_ratio_est_model:
             i2Ri1 = None
             i2Ui1 = None
             v_corr_idxs = np.array([], dtype=np.uint64)

--- a/gtsfm/frontend/verifier/ransac.py
+++ b/gtsfm/frontend/verifier/ransac.py
@@ -39,7 +39,7 @@ class Ransac(VerifierBase):
             use_intrinsics_in_verification: Flag to perform keypoint normalization and compute the essential matrix
                                             instead of fundamental matrix. This should be preferred when the exact
                                             intrinsics are known as opposed to approximating them from exif data.
-            estimation_threshold_px: epipolar distance threshold (measured in pixels)
+            estimation_threshold_px: maximum distance (in pixels) to consider a match an inlier, under squared Sampson distance.
         """
         self._use_intrinsics_in_verification = use_intrinsics_in_verification
         self._px_threshold = estimation_threshold_px
@@ -71,6 +71,7 @@ class Ransac(VerifierBase):
             Estimated rotation i2Ri1, or None if it cannot be estimated.
             Estimated unit translation i2Ui1, or None if it cannot be estimated.
             Indices of verified correspondences, of shape (N, 2) with N <= N3. These are subset of match_indices.
+            Inlier ratio w.r.t. the estimated model, i.e. #ransac inliers / # putative matches.
         """
         if match_indices.shape[0] < self._min_matches:
             return self._failure_result

--- a/gtsfm/frontend/verifier/ransac.py
+++ b/gtsfm/frontend/verifier/ransac.py
@@ -26,13 +26,17 @@ from gtsfm.frontend.verifier.verifier_base import VerifierBase, NUM_MATCHES_REQ_
 
 RANSAC_SUCCESS_PROB = 0.99999
 RANSAC_MAX_ITERS = 20000
-MAX_TOLERATED_POLLUTION_INLIER_RATIO_EST_MODEL = 0.1
 
 logger = logger_utils.get_logger()
 
 
 class Ransac(VerifierBase):
-    def __init__(self, use_intrinsics_in_verification: bool, estimation_threshold_px: float, min_allowed_inlier_ratio_est_model: float) -> None:
+    def __init__(
+        self,
+        use_intrinsics_in_verification: bool,
+        estimation_threshold_px: float,
+        min_allowed_inlier_ratio_est_model: float,
+    ) -> None:
         """Initializes the verifier.
 
         Args:
@@ -97,7 +101,7 @@ class Ransac(VerifierBase):
                 K,
                 method=cv2.RANSAC,
                 threshold=self._px_threshold / fx,
-                prob=RANSAC_SUCCESS_PROB
+                prob=RANSAC_SUCCESS_PROB,
             )
         else:
             i2Fi1, inlier_mask = cv2.findFundamentalMat(
@@ -106,7 +110,7 @@ class Ransac(VerifierBase):
                 method=cv2.FM_RANSAC,
                 ransacReprojThreshold=self._px_threshold,
                 confidence=RANSAC_SUCCESS_PROB,
-                maxIters=RANSAC_MAX_ITERS
+                maxIters=RANSAC_MAX_ITERS,
             )
 
             i2Ei1 = verification_utils.fundamental_to_essential_matrix(

--- a/gtsfm/frontend/verifier/verifier_base.py
+++ b/gtsfm/frontend/verifier/verifier_base.py
@@ -1,6 +1,6 @@
 """Base class for the V (verification) stage of the frontend.
 
-Authors: Ayush Baid
+Authors: Ayush Baid, John Lambert
 """
 import abc
 from typing import Optional, Tuple
@@ -34,12 +34,13 @@ class VerifierBase(metaclass=abc.ABCMeta):
 
         Args:
             use_intrinsics_in_verification: Flag to perform keypoint normalization and compute the essential matrix
-                                            instead of fundamental matrix. This should be preferred when the exact
-                                            intrinsics are known as opposed to approximating them from exif data.
-            estimation_threshold_px
+                instead of fundamental matrix. This should be preferred when the exact intrinsics are known as opposed
+                to approximating them from exif data.
+            estimation_threshold_px: maximum distance (in pixels) to consider a match an inlier, under squared
+                Sampson distance.
             min_allowed_inlier_ratio_est_model: minimum allowed inlier ratio w.r.t. the estimated model to accept
-                the verification result and use the image pair, i.e. the lowest allowed ratio of #final RANSAC inliers/ #putatives.
-                A lower fraction indicates less consistency among the result.
+                the verification result and use the image pair, i.e. the lowest allowed ratio of
+                #final RANSAC inliers/ #putatives. A lower fraction indicates less agreement among the result.
         """
         self._use_intrinsics_in_verification = use_intrinsics_in_verification
         self._estimation_threshold_px = estimation_threshold_px
@@ -47,8 +48,8 @@ class VerifierBase(metaclass=abc.ABCMeta):
         self._min_matches = (
             NUM_MATCHES_REQ_E_MATRIX if self._use_intrinsics_in_verification else NUM_MATCHES_REQ_F_MATRIX
         )
-        # represents i2Ri1=None, i2Ui1=None, and v_corr_idxs is an empty array.
-        self._failure_result = (None, None, np.array([], dtype=np.uint64))
+        # represents i2Ri1=None, i2Ui1=None, v_corr_idxs is an empty array, and inlier_ratio_est_model is 0.0
+        self._failure_result = (None, None, np.array([], dtype=np.uint64), 0.0)
 
     @abc.abstractmethod
     def verify(

--- a/gtsfm/frontend/verifier/verifier_base.py
+++ b/gtsfm/frontend/verifier/verifier_base.py
@@ -92,5 +92,6 @@ class VerifierBase(metaclass=abc.ABCMeta):
         i2Ri1_graph = result[0]
         i2Ui1_graph = result[1]
         v_corr_idxs_graph = result[2]
+        inlier_ratio_est_model = result[3]
 
-        return i2Ri1_graph, i2Ui1_graph, v_corr_idxs_graph
+        return i2Ri1_graph, i2Ui1_graph, v_corr_idxs_graph, inlier_ratio_est_model

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -424,7 +424,7 @@ def aggregate_frontend_metrics(
     num_valid_entries = np.count_nonzero(~np.isnan(rot3_angular_errors))
 
     # compute pose errors by picking the max error from rot3 and unit3 errors
-    pose_errors = np.maximum(trans_angular_errors, trans_angular_errors)
+    pose_errors = np.maximum(rot3_angular_errors, trans_angular_errors)
 
     # check errors against the threshold
     success_count_rot3 = np.sum(rot3_angular_errors < angular_err_threshold_deg)

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -168,14 +168,6 @@ class SceneOptimizer:
         keypoints_graph_list = dask.delayed(lambda x, y: (x, y))(keypoints_graph_list, auxiliary_graph_list)[0]
         auxiliary_graph_list = []
 
-        # ensure cycle consistency in triplets
-        cycle_consistent_graph = dask.delayed(cycle_utils.filter_to_cycle_consistent_edges)(
-            i2Ri1_graph_dict, i2Ui1_graph_dict, two_view_reports_dict
-        )
-
-        i2Ri1_graph_dict = cycle_consistent_graph[0]
-        i2Ui1_graph_dict = cycle_consistent_graph[1]
-
         (
             ba_input_graph,
             ba_output_graph,

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -17,7 +17,6 @@ import numpy as np
 from dask.delayed import Delayed
 from gtsam import Pose3
 
-import gtsfm.averaging.rotation.cycle_consistency as cycle_utils
 import gtsfm.utils.geometry_comparisons as comp_utils
 import gtsfm.utils.metrics as metric_utils
 import gtsfm.utils.io as io_utils

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -380,7 +380,6 @@ def persist_frontend_metrics_full(two_view_report_dict: Dict[Tuple[int, int], Tw
         else:
             i2Ri1_coefficients = None
             i2ti1 = None
-            euler_xyz = None
 
         # Note: if GT is unknown, then R_error_deg and U_error_deg will be None
         metrics_list.append(
@@ -399,9 +398,7 @@ def persist_frontend_metrics_full(two_view_report_dict: Dict[Tuple[int, int], Tw
                 else None,
                 "inlier_ratio_est_model": round(report.inlier_ratio_est_model, PRINT_NUM_SIG_FIGS),
                 "num_inliers_est_model": report.num_inliers_est_model,
-                "num_H_inliers": int(report.num_H_inliers),
-                "H_inlier_ratio": round(report.H_inlier_ratio, PRINT_NUM_SIG_FIGS),
-                
+
                 "i2Ri1": i2Ri1_coefficients,
                 "i2Ui1": i2ti1
             }

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -167,12 +167,6 @@ class TwoViewEstimator:
             pose_error_graphs = (None, None)
             number_correct, inlier_ratio = None, None
 
-        result = dask.delayed(self._homography_estimator.estimate)(
-            keypoints_i1_graph,
-            keypoints_i2_graph,
-            match_indices=corr_idxs_graph,
-        )
-
         R_error_deg, U_error_deg = pose_error_graphs[0], pose_error_graphs[1]
 
         two_view_report_graph = dask.delayed(generate_two_view_report)(

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -196,20 +196,11 @@ class TwoViewEstimator:
         """ """
         insufficient_inliers = two_view_report.num_inliers_est_model < self._min_num_inliers_acceptance
 
-        H_EF_inlier_ratio = two_view_report.num_H_inliers / (two_view_report.num_inliers_est_model + EPSILON)
-        is_planar_or_panoramic = H_EF_inlier_ratio > MAX_H_INLIER_RATIO
-
         # TODO: technically this should almost always be non-zero, just need to move up to earlier
         valid_model = two_view_report.num_inliers_est_model > 0
-        if valid_model:
-            logger.info("H_EF_inlier_ratio: %.2f", H_EF_inlier_ratio)
 
-        if (valid_model and is_planar_or_panoramic) or (valid_model and insufficient_inliers):
-
-            if is_planar_or_panoramic:
-                logger.info("Planar or panoramic; pose from homography currently not supported.")
-            if insufficient_inliers:
-                logger.info("Insufficient number of inliers.")
+        if valid_model and insufficient_inliers:
+            logger.info("Insufficient number of inliers.")
 
             i2Ri1 = None
             i2Ui1 = None
@@ -217,7 +208,6 @@ class TwoViewEstimator:
             # remove mention of errors in the report
             two_view_report.R_error_deg = None
             two_view_report.U_error_deg = None
-
 
         two_view_report.i2Ri1 = i2Ri1
         two_view_report.i2Ui1 = i2Ui1

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -71,7 +71,6 @@ class TwoViewEstimator:
         matcher: MatcherBase,
         verifier: VerifierBase,
         eval_threshold_px: float,
-        estimation_threshold_px: float,
         min_num_inliers_acceptance: int,
     ) -> None:
         """Initializes the two-view estimator from matcher and verifier.
@@ -80,12 +79,13 @@ class TwoViewEstimator:
             matcher: matcher to use.
             verifier: verifier to use.
             eval_threshold_px: distance threshold for marking a correspondence pair as inlier during evaluation (not estimation).
-            estimation_threshold_px: distance threshold for marking a correspondence pair as inlier during estimation
             min_num_inliers_acceptance: minimum number of inliers that must agree w/ estimated model, to use image pair.
         """
         self._matcher = matcher
         self._verifier = verifier
         self._corr_metric_dist_threshold = eval_threshold_px
+        # Note: homography estimation threshold must match the E / F thresholds for #inliers to be comparable
+        self._homography_estimator = HomographyEstimator(verifier._estimation_threshold_px)
         self._min_num_inliers_acceptance = min_num_inliers_acceptance
 
     def get_corr_metric_dist_threshold(self) -> float:
@@ -196,6 +196,7 @@ class TwoViewEstimator:
 
         # TODO: technically this should almost always be non-zero, just need to move up to earlier
         valid_model = two_view_report.num_inliers_est_model > 0
+
         if valid_model and insufficient_inliers:
             logger.info("Insufficient number of inliers.")
 

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -84,8 +84,6 @@ class TwoViewEstimator:
         self._matcher = matcher
         self._verifier = verifier
         self._corr_metric_dist_threshold = eval_threshold_px
-        # Note: homography estimation threshold must match the E / F thresholds for #inliers to be comparable
-        self._homography_estimator = HomographyEstimator(verifier._estimation_threshold_px)
         self._min_num_inliers_acceptance = min_num_inliers_acceptance
 
     def get_corr_metric_dist_threshold(self) -> float:

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -78,8 +78,10 @@ class TwoViewEstimator:
         Args:
             matcher: matcher to use.
             verifier: verifier to use.
-            eval_threshold_px: distance threshold for marking a correspondence pair as inlier during evaluation (not estimation).
-            min_num_inliers_acceptance: minimum number of inliers that must agree w/ estimated model, to use image pair.
+            eval_threshold_px: distance threshold for marking a correspondence pair as inlier during evaluation
+                (not during estimation).
+            min_num_inliers_acceptance: minimum number of inliers that must agree w/ estimated model, to use
+                image pair.
         """
         self._matcher = matcher
         self._verifier = verifier

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -26,30 +26,31 @@ mpl_logger.setLevel(logging.WARNING)
 pil_logger = logging.getLogger("PIL")
 pil_logger.setLevel(logging.INFO)
 
-
-# In case an epipolar geometry can be verified, it is checked whether
-# the geometry describes a planar scene or panoramic view (pure rotation)
-# described by a homography. This is a degenerate case, since epipolar
-# geometry is only defined for a moving camera. If the inlier ratio of
-# a homography comes close to the inlier ratio of the epipolar geometry,
-# a planar or panoramic configuration is assumed.
-# Based on COLMAP's front-end logic here:
-#    https://github.com/colmap/colmap/blob/dev/src/estimators/two_view_geometry.cc#L230
-MAX_H_INLIER_RATIO = 0.8
-
 EPSILON = 1e-6
+
 
 
 @dataclass(frozen=False)
 class TwoViewEstimationReport:
-    """
+    """Information about verifier result on an edge between two nodes (i1,i2).
+
+    In the spirit of COLMAP's Report class:
+    https://github.com/colmap/colmap/blob/dev/src/optim/ransac.h#L82
+
+    Inlier ratio is defined in Heinly12eccv: https://www.cs.unc.edu/~jheinly/publications/eccv2012-heinly.pdf
+    or in Slide 59: https://www.cc.gatech.edu/~afb/classes/CS4495-Fall2014/slides/CS4495-Ransac.pdf
+
     Args:
+        v_corr_idxs: verified correspondence indices.
         num_inliers_est_model: #correspondences consistent with estimated model (not necessarily "correct")
-        inlier_ratio_est_model: measures how polluted the putative matches were
+        inlier_ratio_est_model: #matches consistent with est. model / # putative matches, i.e.
+           measures how consistent the model is with the putative matches.
         num_inliers_gt_model: measures how well the verification worked, w.r.t. GT
-        inlier_ratio_gt_model: Only defined if GT relative pose provided
-        R_error_deg: relative pose error. Only defined if GT poses provided
-        U_error_deg
+        inlier_ratio_gt_model: #correct matches/#putative matches. Only defined if GT relative pose provided.
+        R_error_deg: relative pose error w.r.t. GT. Only defined if GT poses provided.
+        U_error_deg: relative translation error w.r.t. GT. Only defined if GT poses provided.
+        i2Ri1: relative rotation
+        i2Ui1: relative translation direction
     """
 
     v_corr_idxs: np.ndarray

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -4,7 +4,7 @@ Authors: Ayush Baid, John Lambert
 """
 import logging
 from dataclasses import dataclass
-from typing import NamedTuple, Tuple, Optional
+from typing import Tuple, Optional
 
 import dask
 import numpy as np

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -159,10 +159,10 @@ class TwoViewEstimator:
                 i2Ti1_expected_graph,
                 self._corr_metric_dist_threshold,
             )
-            num_inliers_gt_model, inlier_ratio = corr_error_graph[0], corr_error_graph[1]
+            num_inliers_gt_model, inlier_ratio_gt_model = corr_error_graph[0], corr_error_graph[1]
         else:
             pose_error_graphs = (None, None)
-            num_inliers_gt_model, inlier_ratio = None, None
+            num_inliers_gt_model, inlier_ratio_gt_model = None, None
 
         R_error_deg, U_error_deg = pose_error_graphs[0], pose_error_graphs[1]
 
@@ -171,7 +171,7 @@ class TwoViewEstimator:
             R_error_deg,
             U_error_deg,
             num_inliers_gt_model,
-            inlier_ratio,
+            inlier_ratio_gt_model,
             v_corr_idxs_graph,
         )
 
@@ -205,7 +205,6 @@ class TwoViewEstimator:
             two_view_report.R_error_deg = None
             two_view_report.U_error_deg = None
 
-
         two_view_report.i2Ri1 = i2Ri1
         two_view_report.i2Ui1 = i2Ui1
 
@@ -217,7 +216,7 @@ def generate_two_view_report(
     R_error_deg: float,
     U_error_deg: float,
     num_inliers_gt_model: int,
-    inlier_ratio: float,
+    inlier_ratio_gt_model: float,
     v_corr_idxs: np.ndarray,
 ) -> TwoViewEstimationReport:
     """Wrapper around class constructor for Dask."""
@@ -225,7 +224,7 @@ def generate_two_view_report(
         inlier_ratio_est_model=inlier_ratio_est_model,
         num_inliers_est_model=v_corr_idxs.shape[0],
         num_inliers_gt_model=num_inliers_gt_model,
-        inlier_ratio_gt_model=inlier_ratio,
+        inlier_ratio_gt_model=inlier_ratio_gt_model,
         v_corr_idxs=v_corr_idxs,
         R_error_deg=R_error_deg,
         U_error_deg=U_error_deg,

--- a/tests/frontend/test_frontend_argoverse.py
+++ b/tests/frontend/test_frontend_argoverse.py
@@ -85,7 +85,6 @@ class TestFrontend(unittest.TestCase):
                 min_allowed_inlier_ratio_est_model=0.1
             ),
             eval_threshold_px=4,
-            estimation_threshold_px=0.5,
             min_num_inliers_acceptance=15
         )
         self.__compare_frontend_result_error(
@@ -104,7 +103,6 @@ class TestFrontend(unittest.TestCase):
     #             min_allowed_inlier_ratio_est_model=0.05
     #         ),
     #         eval_threshold_px=4,
-    #         estimation_threshold_px=0.5,
     #         min_num_inliers_acceptance=15
     #     )
     #     self.__compare_frontend_result_error(

--- a/tests/frontend/verifier/test_degensac.py
+++ b/tests/frontend/verifier/test_degensac.py
@@ -17,7 +17,9 @@ class TestDegensac(test_verifier_base.TestVerifierBase):
     def setUp(self):
         super().setUp()
 
-        self.verifier = Degensac(use_intrinsics_in_verification=False)
+        self.verifier = Degensac(
+            use_intrinsics_in_verification=False, estimation_threshold_px=0.5, min_allowed_inlier_ratio_est_model=0.1
+        )
 
 
 if __name__ == "__main__":

--- a/tests/frontend/verifier/test_ransac.py
+++ b/tests/frontend/verifier/test_ransac.py
@@ -16,7 +16,9 @@ class TestRansacForEssentialMatrix(test_verifier_base.TestVerifierBase):
 
     def setUp(self):
         super().setUp()
-        self.verifier = Ransac(use_intrinsics_in_verification=True)
+        self.verifier = Ransac(
+            use_intrinsics_in_verification=True, estimation_threshold_px=0.5, min_allowed_inlier_ratio_est_model=0.1
+        )
 
 
 class TestRansacForFundamentalMatrix(test_verifier_base.TestVerifierBase):
@@ -27,7 +29,9 @@ class TestRansacForFundamentalMatrix(test_verifier_base.TestVerifierBase):
 
     def setUp(self):
         super().setUp()
-        self.verifier = Ransac(use_intrinsics_in_verification=False)
+        self.verifier = Ransac(
+            use_intrinsics_in_verification=False, estimation_threshold_px=0.5, min_allowed_inlier_ratio_est_model=0.1
+        )
 
 
 if __name__ == "__main__":

--- a/tests/frontend/verifier/test_verifier_argoverse.py
+++ b/tests/frontend/verifier/test_verifier_argoverse.py
@@ -1,3 +1,8 @@
+"""Ensure that Verifier classes can compute relative pose for Argoverse image pairs.
+
+Authors: John Lambert
+"""
+
 import pickle
 import pdb
 import random
@@ -13,6 +18,7 @@ from scipy.spatial.transform import Rotation
 from gtsfm.common.keypoints import Keypoints
 from gtsfm.frontend.verifier.degensac import Degensac
 from gtsfm.frontend.verifier.ransac import Ransac
+from gtsfm.frontend.verifier.loransac import LoRansac
 from gtsfm.frontend.verifier.verifier_base import VerifierBase
 
 
@@ -77,7 +83,7 @@ def check_verifier_output_error(verifier: VerifierBase, euler_angle_err_tol: flo
     # match keypoints row by row
     match_indices = np.vstack([np.arange(len(keypoints_i1)), np.arange(len(keypoints_i1))]).T
 
-    i2Ri1, i2ti1, _ = verifier.verify(
+    i2Ri1, i2ti1, _, _ = verifier.verify(
         keypoints_i1, keypoints_i2, match_indices, Cal3Bundler(fx, k1, k2, px, py), Cal3Bundler(fx, k1, k2, px, py)
     )
 
@@ -109,13 +115,32 @@ class TestRansacVerifierArgoverse(unittest.TestCase):
 
         np.random.seed(RANDOM_SEED)
         random.seed(RANDOM_SEED)
-        self.verifier = Ransac(use_intrinsics_in_verification=True, px_threshold=0.5)
+        self.verifier = Ransac(
+            use_intrinsics_in_verification=True, estimation_threshold_px=0.5, min_allowed_inlier_ratio_est_model=0.1
+        )
 
         self.euler_angle_err_tol = 1.0
         self.translation_err_tol = 0.01
 
     def testRecoveredPoseError(self):
         check_verifier_output_error(self.verifier, self.euler_angle_err_tol, self.translation_err_tol)
+
+    def test_5pt_algo_5correspondences(self) -> None:
+        """ """
+        fx, px, py, k1, k2 = load_log_front_center_intrinsics()
+        keypoints_i1, keypoints_i2 = load_argoverse_log_annotated_correspondences()
+
+        # match keypoints row by row
+        match_indices = np.vstack([np.arange(len(keypoints_i1)), np.arange(len(keypoints_i1))]).T
+
+        intrinsics_i1 = Cal3Bundler(fx, k1, k2, px, py)
+        intrinsics_i2 = Cal3Bundler(fx, k1, k2, px, py)
+
+        match_indices = match_indices[:5]
+
+        i2Ri1, i2ti1, _, _ = self.verifier.verify(
+            keypoints_i1, keypoints_i2, match_indices, intrinsics_i1, intrinsics_i2
+        )
 
 
 class TestDegensacVerifierArgoverse(unittest.TestCase):
@@ -124,10 +149,29 @@ class TestDegensacVerifierArgoverse(unittest.TestCase):
 
         np.random.seed(RANDOM_SEED)
         random.seed(RANDOM_SEED)
-        self.verifier = Degensac()
+        self.verifier = Degensac(
+            use_intrinsics_in_verification=False, estimation_threshold_px=0.5, min_allowed_inlier_ratio_est_model=0.1
+        )
 
         self.euler_angle_err_tol = 2.0
         self.translation_err_tol = 0.02
+
+    def testRecoveredPoseError(self):
+        check_verifier_output_error(self.verifier, self.euler_angle_err_tol, self.translation_err_tol)
+
+
+class TestLoRansacVerifierArgoverse(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        np.random.seed(RANDOM_SEED)
+        random.seed(RANDOM_SEED)
+        self.verifier = LoRansac(
+            use_intrinsics_in_verification=False, estimation_threshold_px=0.5, min_allowed_inlier_ratio_est_model=0.1
+        )
+
+        self.euler_angle_err_tol = 1.0
+        self.translation_err_tol = 0.01
 
     def testRecoveredPoseError(self):
         check_verifier_output_error(self.verifier, self.euler_angle_err_tol, self.translation_err_tol)

--- a/tests/frontend/verifier/test_verifier_argoverse.py
+++ b/tests/frontend/verifier/test_verifier_argoverse.py
@@ -18,7 +18,6 @@ from scipy.spatial.transform import Rotation
 from gtsfm.common.keypoints import Keypoints
 from gtsfm.frontend.verifier.degensac import Degensac
 from gtsfm.frontend.verifier.ransac import Ransac
-from gtsfm.frontend.verifier.loransac import LoRansac
 from gtsfm.frontend.verifier.verifier_base import VerifierBase
 
 
@@ -155,23 +154,6 @@ class TestDegensacVerifierArgoverse(unittest.TestCase):
 
         self.euler_angle_err_tol = 2.0
         self.translation_err_tol = 0.02
-
-    def testRecoveredPoseError(self):
-        check_verifier_output_error(self.verifier, self.euler_angle_err_tol, self.translation_err_tol)
-
-
-class TestLoRansacVerifierArgoverse(unittest.TestCase):
-    def setUp(self):
-        super().setUp()
-
-        np.random.seed(RANDOM_SEED)
-        random.seed(RANDOM_SEED)
-        self.verifier = LoRansac(
-            use_intrinsics_in_verification=False, estimation_threshold_px=0.5, min_allowed_inlier_ratio_est_model=0.1
-        )
-
-        self.euler_angle_err_tol = 1.0
-        self.translation_err_tol = 0.01
 
     def testRecoveredPoseError(self):
         check_verifier_output_error(self.verifier, self.euler_angle_err_tol, self.translation_err_tol)

--- a/tests/frontend/verifier/test_verifier_base.py
+++ b/tests/frontend/verifier/test_verifier_base.py
@@ -37,7 +37,9 @@ class TestVerifierBase(unittest.TestCase):
         np.random.seed(RANDOM_SEED)
         random.seed(RANDOM_SEED)
 
-        self.verifier: VerifierBase = Ransac(use_intrinsics_in_verification=True, px_threshold=0.5)
+        self.verifier: VerifierBase = Ransac(
+            use_intrinsics_in_verification=True, estimation_threshold_px=0.5, min_allowed_inlier_ratio_est_model=0.1
+        )
 
     def __execute_test(
         self,
@@ -52,7 +54,7 @@ class TestVerifierBase(unittest.TestCase):
     ) -> None:
         """Execute the verification and compute results."""
 
-        i2Ri1_computed, i2Ui1_computed, verified_indices_computed = self.verifier.verify(
+        i2Ri1_computed, i2Ui1_computed, verified_indices_computed, inlier_ratio_est_model = self.verifier.verify(
             keypoints_i1,
             keypoints_i2,
             match_indices,
@@ -149,9 +151,10 @@ class TestVerifierBase(unittest.TestCase):
         expected_i2Ri1 = expected_results[0]
         expected_i2Ui1 = expected_results[1]
         expected_v_corr_idxs = expected_results[2]
+        expected_inlier_ratio_est_model = expected_results[3]
 
         # generate the computation graph for the verifier
-        (delayed_i2Ri1, delayed_i2Ui1, delayed_v_corr_idxs,) = self.verifier.create_computation_graph(
+        (delayed_i2Ri1, delayed_i2Ui1, delayed_v_corr_idxs, delayed_inlier_ratio_est_model) = self.verifier.create_computation_graph(
             dask.delayed(keypoints_i1),
             dask.delayed(keypoints_i2),
             dask.delayed(matches_i1i2),
@@ -160,7 +163,7 @@ class TestVerifierBase(unittest.TestCase):
         )
 
         with dask.config.set(scheduler="single-threaded"):
-            i2Ri1, i2Ui1, v_corr_idxs = dask.compute(delayed_i2Ri1, delayed_i2Ui1, delayed_v_corr_idxs)
+            i2Ri1, i2Ui1, v_corr_idxs, inlier_ratio_est_model = dask.compute(delayed_i2Ri1, delayed_i2Ui1, delayed_v_corr_idxs, delayed_inlier_ratio_est_model)
 
         if expected_i2Ri1 is None:
             self.assertIsNone(i2Ri1)
@@ -171,6 +174,7 @@ class TestVerifierBase(unittest.TestCase):
         else:
             self.assertTrue(expected_i2Ui1.equals(i2Ui1, 1e-2))
         np.testing.assert_array_equal(v_corr_idxs, expected_v_corr_idxs)
+        np.testing.assert_almost_equal(inlier_ratio_est_model, expected_inlier_ratio_est_model)
 
     def test_pickleable(self) -> None:
         """Tests that the verifier object is pickleable (required for dask)."""
@@ -203,6 +207,7 @@ class TestVerifierBase(unittest.TestCase):
             i2Ri1,
             i2Ui1,
             verified_indices,
+            inlier_ratio_est_model,
         ) = self.verifier.verify(keypoints_i1, keypoints_i2, match_indices, intrinsics_i1, intrinsics_i2)
 
         return i2Ri1, i2Ui1, verified_indices, keypoints_i1, keypoints_i2


### PR DESCRIPTION
- Specify estimation threshold and evaluation threshold for epipolar distances inside the config, instead of within each file, to make experimentation easier.

- Reject two-view results where the inlier ratio is absurdly low (estimated model not consistent with much of the data)

- Create a new class called `TwoViewEstimationReport` to assist with the objectives above, in the spirit of COLMAP's `Report` struct [here](https://github.com/colmap/colmap/blob/9f3a75ae9c72188244f2403eb085e51ecf4397a8/src/optim/ransac.h#L78):

```c++
template <typename Estimator, typename SupportMeasurer = InlierSupportMeasurer,
          typename Sampler = RandomSampler>
class RANSAC {
 public:
  struct Report {
    EIGEN_MAKE_ALIGNED_OPERATOR_NEW

    // Whether the estimation was successful.
    bool success = false;

    // The number of RANSAC trials / iterations.
    size_t num_trials = 0;

    // The support of the estimated model.
    typename SupportMeasurer::Support support;

    // Boolean mask which is true if a sample is an inlier.
    std::vector<char> inlier_mask;

    // The estimated model.
    typename Estimator::M_t model;
  };
```