### PR TITLE
ignore NaNs when computing min/mean/median/max of reprojection errors

### DIFF
--- a/gtsfm/common/gtsfm_data.py
+++ b/gtsfm/common/gtsfm_data.py
@@ -257,6 +257,7 @@ class GtsfmData:
         scene_reproj_errors: List[float] = []
         for track in self._tracks:
             track_errors, _ = reproj_utils.compute_track_reprojection_errors(self._cameras, track)
+            # passing an array argument to .extend() will convert the array to a list, and append its elements
             scene_reproj_errors.extend(track_errors)
 
         return np.array(scene_reproj_errors)
@@ -285,10 +286,10 @@ class GtsfmData:
             "max": convert_to_rounded_float(track_lengths_3d.max()),
         }
         stats_dict["reprojection_errors"] = {
-            "min": convert_to_rounded_float(np.min(scene_reproj_errors)),
-            "mean": convert_to_rounded_float(np.mean(scene_reproj_errors)),
-            "median": convert_to_rounded_float(np.median(scene_reproj_errors)),
-            "max": convert_to_rounded_float(np.max(scene_reproj_errors)),
+            "min": convert_to_rounded_float(np.nanmin(scene_reproj_errors)),
+            "mean": convert_to_rounded_float(np.nanmean(scene_reproj_errors)),
+            "median": convert_to_rounded_float(np.nanmedian(scene_reproj_errors)),
+            "max": convert_to_rounded_float(np.nanmax(scene_reproj_errors)),
         }
         return stats_dict
 
@@ -299,16 +300,16 @@ class GtsfmData:
             Average of reprojection errors for every 3d point to its 2d measurements
         """
         scene_reproj_errors = self.get_scene_reprojection_errors()
-        scene_avg_reproj_error = np.mean(scene_reproj_errors)
+        scene_avg_reproj_error = np.nanmean(scene_reproj_errors)
         return scene_avg_reproj_error
 
     def log_scene_reprojection_error_stats(self) -> None:
         """Logs reprojection error stats for all 3d points in the entire scene."""
         scene_reproj_errors = self.get_scene_reprojection_errors()
-        logger.info("Min scene reproj error: %.3f", np.min(scene_reproj_errors))
-        logger.info("Avg scene reproj error: %.3f", np.mean(scene_reproj_errors))
-        logger.info("Median scene reproj error: %.3f", np.median(scene_reproj_errors))
-        logger.info("Max scene reproj error: %.3f", np.max(scene_reproj_errors))
+        logger.info("Min scene reproj error: %.3f", np.nanmin(scene_reproj_errors))
+        logger.info("Avg scene reproj error: %.3f", np.nanmean(scene_reproj_errors))
+        logger.info("Median scene reproj error: %.3f", np.nanmedian(scene_reproj_errors))
+        logger.info("Max scene reproj error: %.3f", np.nanmax(scene_reproj_errors))
 
     def __validate_track(self, track: SfmTrack, reproj_err_thresh: float) -> bool:
         """Validates a track based on reprojection errors and cheirality checks.

--- a/gtsfm/utils/reprojection.py
+++ b/gtsfm/utils/reprojection.py
@@ -41,7 +41,7 @@ def compute_track_reprojection_errors(
             errors.append(np.nan)
 
     errors = np.array(errors)
-    avg_track_reproj_error = errors.mean()
+    avg_track_reproj_error = np.nanmean(errors)
     return errors, avg_track_reproj_error
 
 
@@ -74,6 +74,6 @@ def compute_point_reprojection_errors(
             errors.append(np.nan)
 
     errors = np.array(errors)
-    avg_track_reproj_error = errors.mean()
+    avg_track_reproj_error = np.nanmean(errors)
     return errors, avg_track_reproj_error
 


### PR DESCRIPTION
Previously, min/mean/median/max were marked as NaN before filtering reprojection errors, which obscured the raw result.