### PR TITLE
Adding check for pair index ordering (Closes #210)

### DIFF
--- a/gtsfm/loader/argoverse_dataset_loader.py
+++ b/gtsfm/loader/argoverse_dataset_loader.py
@@ -118,13 +118,7 @@ class ArgoverseDatasetLoader(LoaderBase):
         Returns:
             Intrinsics for the given camera.
         """
-        return Cal3Bundler(
-            fx=self._K[0, 0],
-            k1=0,
-            k2=0,
-            u0=self._K[0, 2],
-            v0=self._K[1, 2],
-        )
+        return Cal3Bundler(fx=self._K[0, 0], k1=0, k2=0, u0=self._K[0, 2], v0=self._K[1, 2],)
 
     def get_camera_pose(self, index: int) -> Optional[Pose3]:
         """Get the camera pose (in world coordinates) at the given index.
@@ -145,7 +139,7 @@ class ArgoverseDatasetLoader(LoaderBase):
         return self._world_pose.between(Pose3(Rot3(city_SE3_camera.rotation), city_SE3_camera.translation))
 
     def is_valid_pair(self, idx1: int, idx2: int) -> bool:
-        """Checks if (idx1, idx2) is a valid pair.
+        """Checks if (idx1, idx2) is a valid pair. idx1 < idx2 is required.
 
         Args:
             idx1: first index of the pair.
@@ -154,4 +148,4 @@ class ArgoverseDatasetLoader(LoaderBase):
         Returns:
             validation result.
         """
-        return (idx1 < idx2) and (idx2 < idx1 + self._max_lookahead_for_img)
+        return super().is_valid_pair(idx1, idx2) and (idx2 < idx1 + self._max_lookahead_for_img)

--- a/gtsfm/loader/colmap_loader.py
+++ b/gtsfm/loader/colmap_loader.py
@@ -96,13 +96,9 @@ class ColmapLoader(LoaderBase):
         img = io_utils.load_image(self._image_paths[0])
         sample_h, sample_w = img.height, img.width
         # no downsampling may be required, in which case scale_u and scale_v will be 1.0
-        (
-            self._scale_u,
-            self._scale_v,
-            self._target_h,
-            self._target_w,
-        ) = img_utils.get_downsampling_factor_per_axis(sample_h, sample_w, self._max_resolution)
-
+        (self._scale_u, self._scale_v, self._target_h, self._target_w,) = img_utils.get_downsampling_factor_per_axis(
+            sample_h, sample_w, self._max_resolution
+        )
 
     def __len__(self) -> int:
         """The number of images in the dataset.
@@ -178,7 +174,7 @@ class ColmapLoader(LoaderBase):
         return wTi
 
     def is_valid_pair(self, idx1: int, idx2: int) -> bool:
-        """Checks if (idx1, idx2) is a valid pair.
+        """Checks if (idx1, idx2) is a valid pair. idx1 < idx2 is required.
 
         Args:
             idx1: first index of the pair.
@@ -187,4 +183,4 @@ class ColmapLoader(LoaderBase):
         Returns:
             validation result.
         """
-        return idx1 < idx2 and abs(idx1 - idx2) <= self._max_frame_lookahead
+        return super().is_valid_pair(idx1, idx2) and abs(idx1 - idx2) <= self._max_frame_lookahead

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -69,9 +69,10 @@ class LoaderBase(metaclass=abc.ABCMeta):
             the camera pose w_P_index.
         """
 
-    @abc.abstractmethod
     def is_valid_pair(self, idx1: int, idx2: int) -> bool:
-        """Checks if (idx1, idx2) is a valid pair.
+        """Checks if (idx1, idx2) is a valid pair. idx1 < idx2 is required.
+        
+        Note: All inherited classes should call this super method to enforce this check.
 
         Args:
             idx1: first index of the pair.
@@ -80,6 +81,7 @@ class LoaderBase(metaclass=abc.ABCMeta):
         Returns:
             validation result.
         """
+        return idx1 < idx2
 
     def get_image_shape(self, idx: int) -> Tuple[int, int]:
         """Return a (H,W) tuple for each image"""

--- a/gtsfm/loader/olsson_loader.py
+++ b/gtsfm/loader/olsson_loader.py
@@ -35,7 +35,7 @@ class OlssonLoader(LoaderBase):
         image_extension: str = "jpg",
         use_gt_intrinsics: bool = True,
         use_gt_extrinsics: bool = True,
-        max_frame_lookahead: int = 20
+        max_frame_lookahead: int = 20,
     ) -> None:
         """Initializes to load from a specified folder on disk.
 
@@ -71,17 +71,16 @@ class OlssonLoader(LoaderBase):
 
         # M = K [R | t]
         # in GTSAM notation, M = K @ cTw
-        M_list = [data['P'][0][i] for i in range(self._num_imgs)]
+        M_list = [data["P"][0][i] for i in range(self._num_imgs)]
 
         # first pose is identity, so K is immediate given
-        self._K = M_list[0][:3,:3]
+        self._K = M_list[0][:3, :3]
         Kinv = np.linalg.inv(self._K)
 
-        # decode camera poses as: 
+        # decode camera poses as:
         #    K^{-1} @ M = cTw
-        iTw_list = [ Kinv @ M_list[i] for i in range(self._num_imgs)]
-        self._wTi_list = [Pose3(Rot3(iTw[:3,:3]), iTw[:,3]).inverse() for iTw in iTw_list ]
-
+        iTw_list = [Kinv @ M_list[i] for i in range(self._num_imgs)]
+        self._wTi_list = [Pose3(Rot3(iTw[:3, :3]), iTw[:, 3]).inverse() for iTw in iTw_list]
 
     def __len__(self) -> int:
         """The number of images in the dataset.
@@ -109,7 +108,6 @@ class OlssonLoader(LoaderBase):
 
         return io_utils.load_image(self._image_paths[index])
 
-
     def get_camera_intrinsics(self, index: int) -> Cal3Bundler:
         """Get the camera intrinsics at the given index.
 
@@ -125,14 +123,9 @@ class OlssonLoader(LoaderBase):
 
         else:
             intrinsics = Cal3Bundler(
-                fx=min(self._K[0, 0], self._K[1, 1]),
-                k1=0,
-                k2=0,
-                u0=self._K[0, 2],
-                v0=self._K[1, 2],
+                fx=min(self._K[0, 0], self._K[1, 1]), k1=0, k2=0, u0=self._K[0, 2], v0=self._K[1, 2],
             )
         return intrinsics
-
 
     def get_camera_pose(self, index: int) -> Optional[Pose3]:
         """Get the camera pose (in world coordinates) at the given index.
@@ -149,9 +142,8 @@ class OlssonLoader(LoaderBase):
         wTi = self._wTi_list[index]
         return wTi
 
-
     def is_valid_pair(self, idx1: int, idx2: int) -> bool:
-        """Checks if (idx1, idx2) is a valid pair.
+        """Checks if (idx1, idx2) is a valid pair. idx1 < idx2 is required.
 
         Args:
             idx1: first index of the pair.
@@ -160,5 +152,5 @@ class OlssonLoader(LoaderBase):
         Returns:
             validation result.
         """
-        return idx1 < idx2 and abs(idx1 - idx2) <= self._max_frame_lookahead
+        return super().is_valid_pair(idx1, idx2) and abs(idx1 - idx2) <= self._max_frame_lookahead
 

--- a/gtsfm/loader/yfcc_imb_loader.py
+++ b/gtsfm/loader/yfcc_imb_loader.py
@@ -34,11 +34,7 @@ class YfccImbLoader(LoaderBase):
 
         # load all the image pairs according to the covisibility threshold used
         # in IMB's reporting
-        visibility_file = osp.join(
-            self._folder,
-            "new-vis-pairs",
-            "keys-th-{:0.1f}.npy".format(coviz_thresh),
-        )
+        visibility_file = osp.join(self._folder, "new-vis-pairs", "keys-th-{:0.1f}.npy".format(coviz_thresh),)
 
         image_pairs = list()  # list of image pairs
         image_names = set()  # set of image names (for uniqueness)
@@ -120,7 +116,7 @@ class YfccImbLoader(LoaderBase):
         return self._cameras[index].pose()
 
     def is_valid_pair(self, idx1: int, idx2: int) -> bool:
-        """Checks if (idx1, idx2) is a valid pair.
+        """Checks if (idx1, idx2) is a valid pair. idx1 < idx2 is required.
 
         Args:
             idx1: first index of the pair.
@@ -129,7 +125,10 @@ class YfccImbLoader(LoaderBase):
         Returns:
             validation result.
         """
-        return (idx1, idx2) in self._image_pairs
+        if not super().is_valid_pair(idx1, idx2):
+            return False
+
+        return (idx1, idx2) in self._image_pairs or (idx2, idx1) in self._image_pairs
 
     def __read_calibrations(self) -> List[PinholeCameraCal3Bundler]:
         """Read camera params from the calibration stored as h5 files.


### PR DESCRIPTION
This PR introduces the check of idx1 < idx2 in an (idx1, idx2) pair. This is already being enforced by all loader implementations, and now will be introduced in the base class too.