### PR TITLE
Fix for small loransac bug

### DIFF
--- a/gtsfm/frontend/verifier/loransac.py
+++ b/gtsfm/frontend/verifier/loransac.py
@@ -73,6 +73,10 @@ class LoRansac(VerifierBase):
             Indices of verified correspondences, of shape (N, 2) with N <= N3. These are subset of match_indices.
             Inlier ratio of w.r.t. the estimated model, i.e. the #final RANSAC inliers/ #putatives.
         """
+        if match_indices.shape[0] < self._min_matches:
+            logger.info('[LORANSAC] Not enough correspondences for verification.')
+            return self._failure_result
+
         uv_i1 = keypoints_i1.coordinates
         uv_i2 = keypoints_i2.coordinates
 
@@ -107,6 +111,9 @@ class LoRansac(VerifierBase):
         )
 
         success = result_dict["success"]
+        if not success:
+            logger.info('[LORANSAC] Essential matrix estimation unsuccessful.')
+            return self._failure_result
         E = result_dict["E"]
         # See https://github.com/colmap/colmap/blob/dev/src/base/pose.h#L72
         qw, qx, qy, qz = result_dict["qvec"]


### PR DESCRIPTION
## What

The [`verify`](https://github.com/borglab/gtsfm/blob/32f4ec98a93b7cf9ac7630424804b87fd91a1ff6/gtsfm/frontend/verifier/loransac.py#L52) method in `loransac.py` errors out if there are an insufficient number of correspondences in `match_indices`, or if the estimation of the essential matrix fails.

## Why

If `match_indices` is empty, an `IndexError` is thrown due to incorrect number of dimensions in `match_indices`:

```
distributed.worker - WARNING - Compute Failed
Function:  verify
args:      (<gtsfm.common.keypoints.Keypoints object at 0x7f89de3bea30>, <gtsfm.common.keypoints.Keypoints object at 0x7f89e4a926d0>, array([], dtype=float64), .K[10716.2239; 0; 0; 511.5; 511.5];
, .K[10716.2239; 0; 0; 511.5; 511.5];
)
kwargs:    {}
Exception: IndexError('too many indices for array: array is 1-dimensional, but 2 were indexed')

Traceback (most recent call last):
  File "gtsfm/runner/run_scene_optimizer_astronet.py", line 100, in <module>
    run_scene_optimizer(args)
  File "gtsfm/runner/run_scene_optimizer_astronet.py", line 52, in run_scene_optimizer
    sfm_result = sfm_result_graph.compute()
  File "/home/tdriver6/anaconda3/envs/gtsfm-v1/lib/python3.8/site-packages/dask/base.py", line 285, in compute
    (result,) = compute(self, traverse=False, **kwargs)
  File "/home/tdriver6/anaconda3/envs/gtsfm-v1/lib/python3.8/site-packages/dask/base.py", line 567, in compute
    results = schedule(dsk, keys, **kwargs)
  File "/home/tdriver6/anaconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 2707, in get
    results = self.gather(packed, asynchronous=asynchronous, direct=direct)
  File "/home/tdriver6/anaconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 2021, in gather
    return self.sync(
  File "/home/tdriver6/anaconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 862, in sync
    return sync(
  File "/home/tdriver6/anaconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/utils.py", line 338, in sync
    raise exc.with_traceback(tb)
  File "/home/tdriver6/anaconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/utils.py", line 321, in f
    result[0] = yield future
  File "/home/tdriver6/anaconda3/envs/gtsfm-v1/lib/python3.8/site-packages/tornado/gen.py", line 762, in run
    value = future.result()
  File "/home/tdriver6/anaconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 1886, in _gather
    raise exception.with_traceback(traceback)
  File "/home/tdriver6/Documents/gtsfm/gtsfm/frontend/verifier/loransac.py", line 107, in verify
    points2D1 = uv_i1[match_indices[:, 0]]
IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed
```

If an insufficent number of correspondences is passed to `essential_matrix_estimation()`, or the estimation otherwise fails, a `KeyError` is thrown when trying to access the results in `result_dict` because nothing was returned:

```
Traceback (most recent call last):
  File "gtsfm/runner/run_scene_optimizer_astronet.py", line 100, in <module>
    run_scene_optimizer(args)
  File "gtsfm/runner/run_scene_optimizer_astronet.py", line 52, in run_scene_optimizer
    sfm_result = sfm_result_graph.compute()
  File "/home/tdriver6/anaconda3/envs/gtsfm-v1/lib/python3.8/site-packages/dask/base.py", line 285, in compute
    (result,) = compute(self, traverse=False, **kwargs)
  File "/home/tdriver6/anaconda3/envs/gtsfm-v1/lib/python3.8/site-packages/dask/base.py", line 567, in compute
    results = schedule(dsk, keys, **kwargs)
  File "/home/tdriver6/anaconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 2707, in get
    results = self.gather(packed, asynchronous=asynchronous, direct=direct)
  File "/home/tdriver6/anaconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 2021, in gather
    return self.sync(
  File "/home/tdriver6/anaconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 862, in sync
    return sync(
  File "/home/tdriver6/anaconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/utils.py", line 338, in sync
    raise exc.with_traceback(tb)
  File "/home/tdriver6/anaconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/utils.py", line 321, in f
    result[0] = yield future
  File "/home/tdriver6/anaconda3/envs/gtsfm-v1/lib/python3.8/site-packages/tornado/gen.py", line 762, in run
    value = future.result()
  File "/home/tdriver6/anaconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 1886, in _gather
    raise exception.with_traceback(traceback)
  File "/home/tdriver6/Documents/gtsfm/gtsfm/frontend/verifier/loransac.py", line 120, in verify
    E = result_dict["E"]
KeyError: 'E'
```

## How

Pass [`verify()`](https://github.com/borglab/gtsfm/blob/32f4ec98a93b7cf9ac7630424804b87fd91a1ff6/gtsfm/frontend/verifier/loransac.py#L52) an empty `match_indices` array or a set of correspondences such that the essential matrix is unobservable.

## Fix

Add conditional to check whether a sufficient number of matches are provided, and that the essential matrix estimation was successful and return `self._failure_result`