### PR TITLE
fixed view_scene() AssertionError bug

### DIFF
--- a/gtsfm/common/gtsfm_data.py
+++ b/gtsfm/common/gtsfm_data.py
@@ -226,7 +226,7 @@ class GtsfmData:
         Returns:
             New object with the selected cameras and associated tracks.
         """
-        new_data = cls(len(camera_indices))
+        new_data = cls(number_images=len(camera_indices))
 
         for i in gtsfm_data.get_valid_camera_indices():
             if i in camera_indices:

--- a/gtsfm/common/gtsfm_data.py
+++ b/gtsfm/common/gtsfm_data.py
@@ -226,7 +226,7 @@ class GtsfmData:
         Returns:
             New object with the selected cameras and associated tracks.
         """
-        new_data = cls(gtsfm_data.number_images())
+        new_data = cls(len(camera_indices))
 
         for i in gtsfm_data.get_valid_camera_indices():
             if i in camera_indices:

--- a/gtsfm/utils/io.py
+++ b/gtsfm/utils/io.py
@@ -255,7 +255,8 @@ def read_images_txt(fpath: str) -> Tuple[Optional[List[Pose3]], Optional[List[st
 
     wTi_list = []
     img_fnames = []
-    # ignore first 4 lines of text -- they are a description of the file format
+    # ignore first 4 lines of text -- they contain a description of the file format
+    # and a record of the number of reconstructed images.
     for line in lines[4::2]:
         i, qw, qx, qy, qz, tx, ty, tz, i, img_fname = line.split()
         # Colmap provides extrinsics, so must invert
@@ -271,6 +272,9 @@ def write_images(gtsfm_data: GtsfmData, images: List[Image], save_dir: str) -> N
     """Writes the image data file in the COLMAP format.
 
     Reference: https://colmap.github.io/format.html#images-txt
+    Note: the "Number of images" saved to the .txt file is not the number of images
+    fed to the SfM algorithm, but rather the number of localized camera poses/images,
+    which COLMAP refers to as the "reconstructed cameras".
 
     Args:
         gtsfm_data: scene data to write.


### PR DESCRIPTION
# What

When printing the bundle adjustment output to `cameras.txt`, `images.txt`, and `points3D.txt`,  the number of cameras/images listed in the output header is the original number of input images from the loader, and not the actual number of cameras/images that were optimized (which is usually a subset of the original set of images). This causes `read_cameras_txt()` to throw an `AssertionError`.

# Why

The `_num_images` attribute of the `GtsfmData` objects never change throughout scene optimization, even after computing the largest connected component [here](https://github.com/borglab/gtsfm/blob/491e9958314d39c1d1f0e97becd81faa3e770710/gtsfm/common/gtsfm_data.py#L210), because [`from_selected_cameras()`](https://github.com/borglab/gtsfm/blob/491e9958314d39c1d1f0e97becd81faa3e770710/gtsfm/common/gtsfm_data.py#L219) constructs the new `GtsfmData` object using the input's `_number_images` instead of changing it to the length of the largest connected component.

This then causes [`write_cameras()`](https://github.com/borglab/gtsfm/blob/491e9958314d39c1d1f0e97becd81faa3e770710/gtsfm/utils/io.py#L195) and [`write_images()`](https://github.com/borglab/gtsfm/blob/491e9958314d39c1d1f0e97becd81faa3e770710/gtsfm/utils/io.py#L270) to print the wrong number of cameras/images because it relies on the `_num_images` attribute to be correct.

`read_cameras_txt()` throws an `AssertionError` because there is a mismatch between the expected number of cameras printed in the header and the actual number that were output to the file before/after bundle adjustment:

```
Traceback (most recent call last):
  File "visualization/view_scene.py", line 121, in <module>
    view_scene(args)
  File "visualization/view_scene.py", line 51, in view_scene
    calibrations = io_utils.read_cameras_txt(cameras_fpath)
  File "/home/tdriver6/Documents/gtsfm/gtsfm/utils/io.py", line 191, in read_cameras_txt
    assert len(calibrations) == num_cams
AssertionError
``` 

# How
 N/A

# Fix

Setting the `_num_images` attribute to the length of the new camera indices when calling [`from_selected_cameras()`](https://github.com/borglab/gtsfm/blob/491e9958314d39c1d1f0e97becd81faa3e770710/gtsfm/common/gtsfm_data.py#L219) fixes the error and causes the correct number of expected cameras to be printed on the header of the outputs.
