### PR TITLE
Improve clarity of names of metrics in report

### DIFF
--- a/gtsfm/common/gtsfm_data.py
+++ b/gtsfm/common/gtsfm_data.py
@@ -285,7 +285,7 @@ class GtsfmData:
             "median": convert_to_rounded_float(np.median(track_lengths_3d)),
             "max": convert_to_rounded_float(track_lengths_3d.max()),
         }
-        stats_dict["reprojection_errors"] = {
+        stats_dict["reprojection_errors_px"] = {
             "min": convert_to_rounded_float(np.nanmin(scene_reproj_errors)),
             "mean": convert_to_rounded_float(np.nanmean(scene_reproj_errors)),
             "median": convert_to_rounded_float(np.nanmedian(scene_reproj_errors)),

--- a/gtsfm/data_association/data_assoc.py
+++ b/gtsfm/data_association/data_assoc.py
@@ -76,8 +76,8 @@ class DataAssociation(NamedTuple):
         # generate tracks for 3D points using pairwise correspondences
         tracks_2d = SfmTrack2d.generate_tracks_from_pairwise_matches(corr_idxs_dict, keypoints_list)
 
-        # if self.save_track_patches_viz and images is not None:
-        #     io_utils.save_track_visualizations(tracks_2d, images, save_dir=os.path.join("plots", "tracks_2d"))
+        if self.save_track_patches_viz and images is not None:
+            io_utils.save_track_visualizations(tracks_2d, images, save_dir=os.path.join("plots", "tracks_2d"))
 
         # metrics on tracks w/o triangulation check
         num_tracks_2d = len(tracks_2d)
@@ -85,7 +85,7 @@ class DataAssociation(NamedTuple):
         mean_2d_track_length = np.mean(track_lengths)
 
         logger.debug("[Data association] input number of tracks: %s", num_tracks_2d)
-        logger.debug("[Data association] input avg. track length: %.2f", mean_2d_track_length)
+        logger.debug("[Data association] input avg. track length: %s", mean_2d_track_length)
 
         # initializer of 3D landmark for each track
         point3d_initializer = Point3dInitializer(
@@ -104,7 +104,7 @@ class DataAssociation(NamedTuple):
             triangulated_data.add_camera(i, camera)
 
         # add valid tracks where triangulation is successful
-        for j, track_2d in enumerate(tracks_2d):
+        for track_2d in tracks_2d:
             # triangulate and filter based on reprojection error
             sfm_track, avg_track_reproj_error, is_cheirality_failure = point3d_initializer.triangulate(track_2d)
             if is_cheirality_failure:
@@ -117,13 +117,8 @@ class DataAssociation(NamedTuple):
             if sfm_track is not None and self.__validate_track(sfm_track):
                 triangulated_data.add_track(sfm_track)
                 per_accepted_track_avg_errors.append(avg_track_reproj_error)
-
-                # io_utils.save_track_visualizations(j, [track_2d], images, save_dir=os.path.join("plots", "tracks_2d", f"{int(np.round(avg_track_reproj_error))}"))
-
             else:
                 per_rejected_track_avg_errors.append(avg_track_reproj_error)
-
-
 
         track_cheirality_failure_ratio = num_tracks_w_cheirality_exceptions / len(tracks_2d)
 

--- a/gtsfm/data_association/data_assoc.py
+++ b/gtsfm/data_association/data_assoc.py
@@ -76,8 +76,8 @@ class DataAssociation(NamedTuple):
         # generate tracks for 3D points using pairwise correspondences
         tracks_2d = SfmTrack2d.generate_tracks_from_pairwise_matches(corr_idxs_dict, keypoints_list)
 
-        if self.save_track_patches_viz and images is not None:
-            io_utils.save_track_visualizations(tracks_2d, images, save_dir=os.path.join("plots", "tracks_2d"))
+        # if self.save_track_patches_viz and images is not None:
+        #     io_utils.save_track_visualizations(tracks_2d, images, save_dir=os.path.join("plots", "tracks_2d"))
 
         # metrics on tracks w/o triangulation check
         num_tracks_2d = len(tracks_2d)
@@ -85,7 +85,7 @@ class DataAssociation(NamedTuple):
         mean_2d_track_length = np.mean(track_lengths)
 
         logger.debug("[Data association] input number of tracks: %s", num_tracks_2d)
-        logger.debug("[Data association] input avg. track length: %s", mean_2d_track_length)
+        logger.debug("[Data association] input avg. track length: %.2f", mean_2d_track_length)
 
         # initializer of 3D landmark for each track
         point3d_initializer = Point3dInitializer(
@@ -104,7 +104,7 @@ class DataAssociation(NamedTuple):
             triangulated_data.add_camera(i, camera)
 
         # add valid tracks where triangulation is successful
-        for track_2d in tracks_2d:
+        for j, track_2d in enumerate(tracks_2d):
             # triangulate and filter based on reprojection error
             sfm_track, avg_track_reproj_error, is_cheirality_failure = point3d_initializer.triangulate(track_2d)
             if is_cheirality_failure:
@@ -117,8 +117,13 @@ class DataAssociation(NamedTuple):
             if sfm_track is not None and self.__validate_track(sfm_track):
                 triangulated_data.add_track(sfm_track)
                 per_accepted_track_avg_errors.append(avg_track_reproj_error)
+
+                # io_utils.save_track_visualizations(j, [track_2d], images, save_dir=os.path.join("plots", "tracks_2d", f"{int(np.round(avg_track_reproj_error))}"))
+
             else:
                 per_rejected_track_avg_errors.append(avg_track_reproj_error)
+
+
 
         track_cheirality_failure_ratio = num_tracks_w_cheirality_exceptions / len(tracks_2d)
 
@@ -151,9 +156,9 @@ class DataAssociation(NamedTuple):
                 "max": int(track_lengths_3d.max()) if track_lengths_3d.size > 0 else None,
                 "track_lengths_histogram": histogram_dict,
             },
-            "mean_accepted_track_avg_error": np.array(per_accepted_track_avg_errors).mean(),
-            "per_rejected_track_avg_errors": per_rejected_track_avg_errors,
-            "per_accepted_track_avg_errors": per_accepted_track_avg_errors,
+            "mean_accepted_track_avg_error_px": np.array(per_accepted_track_avg_errors).mean(),
+            "per_rejected_track_avg_errors_px": per_rejected_track_avg_errors,
+            "per_accepted_track_avg_errors_px": per_accepted_track_avg_errors,
         }
 
         return connected_data, data_assoc_metrics

--- a/gtsfm/runner/run_scene_optimizer_colmaploader.py
+++ b/gtsfm/runner/run_scene_optimizer_colmaploader.py
@@ -1,5 +1,4 @@
 import argparse
-from pathlib import Path
 
 import hydra
 from dask.distributed import Client, LocalCluster, performance_report

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -435,7 +435,10 @@ def aggregate_frontend_metrics(
     all_correct = np.count_nonzero([report.inlier_ratio_gt_model == 1.0 for report in two_view_reports_dict.values()])
 
     logger.debug(
-        "[Two view optimizer] [Summary] Rotation success: %d/%d/%d", success_count_rot3, num_valid_image_pairs, num_image_pairs
+        "[Two view optimizer] [Summary] Rotation success: %d/%d/%d",
+        success_count_rot3,
+        num_valid_image_pairs,
+        num_image_pairs,
     )
 
     logger.debug(
@@ -446,7 +449,10 @@ def aggregate_frontend_metrics(
     )
 
     logger.debug(
-        "[Two view optimizer] [Summary] Pose success: %d/%d/%d", success_count_pose, num_valid_image_pairs, num_image_pairs
+        "[Two view optimizer] [Summary] Pose success: %d/%d/%d",
+        success_count_pose,
+        num_valid_image_pairs,
+        num_image_pairs,
     )
 
     logger.debug(

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -442,7 +442,7 @@ def aggregate_frontend_metrics(
         "[Two view optimizer] [Summary] Translation success: %d/%d/%d",
         success_count_unit3,
         num_valid_image_pairs,
-        num_image_apirs,
+        num_image_pairs,
     )
 
     logger.debug(

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -407,7 +407,7 @@ def aggregate_frontend_metrics(
         two_view_report_dict: report containing front-end metrics for each image pair.
         angular_err_threshold_deg: threshold for classifying angular error metrics as success.
     """
-    num_entries = len(two_view_reports_dict.keys())
+    num_image_pairs = len(two_view_reports_dict.keys())
 
     # all rotational errors in degrees
     rot3_angular_errors = []
@@ -421,7 +421,7 @@ def aggregate_frontend_metrics(
     trans_angular_errors = np.array(trans_angular_errors, dtype=float)
 
     # count number of rot3 errors which are not None. Should be same in rot3/unit3
-    num_valid_entries = np.count_nonzero(~np.isnan(rot3_angular_errors))
+    num_valid_image_pairs = np.count_nonzero(~np.isnan(rot3_angular_errors))
 
     # compute pose errors by picking the max error from rot3 and unit3 errors
     pose_errors = np.maximum(rot3_angular_errors, trans_angular_errors)
@@ -435,28 +435,28 @@ def aggregate_frontend_metrics(
     all_correct = np.count_nonzero([report.inlier_ratio_gt_model == 1.0 for report in two_view_reports_dict.values()])
 
     logger.debug(
-        "[Two view optimizer] [Summary] Rotation success: %d/%d/%d", success_count_rot3, num_valid_entries, num_entries
+        "[Two view optimizer] [Summary] Rotation success: %d/%d/%d", success_count_rot3, num_valid_image_pairs, num_image_pairs
     )
 
     logger.debug(
         "[Two view optimizer] [Summary] Translation success: %d/%d/%d",
         success_count_unit3,
-        num_valid_entries,
-        num_entries,
+        num_valid_image_pairs,
+        num_image_apirs,
     )
 
     logger.debug(
-        "[Two view optimizer] [Summary] Pose success: %d/%d/%d", success_count_pose, num_valid_entries, num_entries
+        "[Two view optimizer] [Summary] Pose success: %d/%d/%d", success_count_pose, num_valid_image_pairs, num_image_pairs
     )
 
     logger.debug(
-        "[Two view optimizer] [Summary] # Image pairs with 100%% inlier ratio:: %d/%d", all_correct, num_entries
+        "[Two view optimizer] [Summary] # Image pairs with 100%% inlier ratio:: %d/%d", all_correct, num_image_pairs
     )
 
     front_end_result_info = {
         "angular_err_threshold_deg": angular_err_threshold_deg,
-        "num_valid_entries": int(num_valid_entries),
-        "num_total_entries": int(num_entries),
+        "num_valid_image_pairs": int(num_valid_image_pairs),
+        "num_total_image_pairs": int(num_image_pairs),
         "rotation": {"success_count": int(success_count_rot3)},
         "translation": {"success_count": int(success_count_unit3)},
         "pose": {"success_count": int(success_count_pose)},

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -9,7 +9,6 @@ from typing import Tuple, Optional
 import dask
 import numpy as np
 from dask.delayed import Delayed
-from dataclasses import dataclass
 from gtsam import Cal3Bundler, Pose3, Rot3, Unit3
 
 import gtsfm.utils.geometry_comparisons as comp_utils


### PR DESCRIPTION
- indicate units of reprojection error
- rename "entries" to "image pairs"