### PR TITLE
Fix CI failures on unit tests and python checks

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -43,9 +43,10 @@ jobs:
         flake8 --max-line-length 120 --ignore E201,E202,E203,E231,W291,W293,E303,W391,E402,W503,E731 gtsfm
     - name: Unit tests
       run: |
-        pytest tests --cov gtsfm
+        pytest tests --cov gtsfm \
+          --ignore tests/frontend/test_frontend_argoverse.py \
+          --ignore tests/loader/test_argoverse_dataset_loader.py
         coverage report
     - name: React-Three-Fiber app tests
       run: |
         cd rtf_vis_tool && npm install && npm test a
-        

--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -39,7 +39,6 @@ dependencies:
   - tabulate
   - pip:
     - pydegensac
-    - argoverse @ git+https://github.com/argoai/argoverse-api.git@master
 
 
 

--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -16,6 +16,7 @@ dependencies:
   - mypy
   - pylint
   - pytest
+  - flake8
   # dask and related
   - dask # same as dask[complete] pip distribution
   - python-graphviz

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -19,6 +19,7 @@ dependencies:
   - mypy
   - pylint
   - pytest
+  - flake8
   # dask and related
   - dask # same as dask[complete] pip distribution
   - python-graphviz

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -39,7 +39,5 @@ dependencies:
   - h5py
   - plotly=4.14.3
   - tabulate
-  - pip:
-    - argoverse @ git+https://github.com/argoai/argoverse-api.git@master
 
 

--- a/gtsfm/common/keypoints.py
+++ b/gtsfm/common/keypoints.py
@@ -163,7 +163,7 @@ class Keypoints:
                     cv.KeyPoint(
                         x=keypoints.coordinates[idx, 0],
                         y=keypoints.coordinates[idx, 1],
-                        _size=OPENCV_DEFAULT_SIZE,
+                        size=OPENCV_DEFAULT_SIZE,
                     )
                 )
         elif keypoints.responses is None:
@@ -172,7 +172,7 @@ class Keypoints:
                     cv.KeyPoint(
                         x=keypoints.coordinates[idx, 0],
                         y=keypoints.coordinates[idx, 1],
-                        _size=keypoints.scales[idx],
+                        size=keypoints.scales[idx],
                     )
                 )
         elif keypoints.scales is None:
@@ -181,8 +181,8 @@ class Keypoints:
                     cv.KeyPoint(
                         x=keypoints.coordinates[idx, 0],
                         y=keypoints.coordinates[idx, 1],
-                        _size=OPENCV_DEFAULT_SIZE,
-                        _response=keypoints.responses[idx],
+                        size=OPENCV_DEFAULT_SIZE,
+                        response=keypoints.responses[idx],
                     )
                 )
         else:
@@ -191,8 +191,8 @@ class Keypoints:
                     cv.KeyPoint(
                         x=keypoints.coordinates[idx, 0],
                         y=keypoints.coordinates[idx, 1],
-                        _size=keypoints.scales[idx],
-                        _response=keypoints.responses[idx],
+                        size=keypoints.scales[idx],
+                        response=keypoints.responses[idx],
                     )
                 )
 

--- a/gtsfm/common/keypoints.py
+++ b/gtsfm/common/keypoints.py
@@ -163,7 +163,7 @@ class Keypoints:
                     cv.KeyPoint(
                         x=keypoints.coordinates[idx, 0],
                         y=keypoints.coordinates[idx, 1],
-                        size=OPENCV_DEFAULT_SIZE,
+                        _size=OPENCV_DEFAULT_SIZE,
                     )
                 )
         elif keypoints.responses is None:
@@ -172,7 +172,7 @@ class Keypoints:
                     cv.KeyPoint(
                         x=keypoints.coordinates[idx, 0],
                         y=keypoints.coordinates[idx, 1],
-                        size=keypoints.scales[idx],
+                        _size=keypoints.scales[idx],
                     )
                 )
         elif keypoints.scales is None:
@@ -181,8 +181,8 @@ class Keypoints:
                     cv.KeyPoint(
                         x=keypoints.coordinates[idx, 0],
                         y=keypoints.coordinates[idx, 1],
-                        size=OPENCV_DEFAULT_SIZE,
-                        response=keypoints.responses[idx],
+                        _size=OPENCV_DEFAULT_SIZE,
+                        _response=keypoints.responses[idx],
                     )
                 )
         else:
@@ -191,8 +191,8 @@ class Keypoints:
                     cv.KeyPoint(
                         x=keypoints.coordinates[idx, 0],
                         y=keypoints.coordinates[idx, 1],
-                        size=keypoints.scales[idx],
-                        response=keypoints.responses[idx],
+                        _size=keypoints.scales[idx],
+                        _response=keypoints.responses[idx],
                     )
                 )
 

--- a/gtsfm/data_association/data_assoc.py
+++ b/gtsfm/data_association/data_assoc.py
@@ -10,7 +10,7 @@ References:
 Authors: Sushmita Warrier, Xiaolong Wu, John Lambert
 """
 import os
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple
+from typing import Dict, List, NamedTuple, Optional, Tuple
 
 import dask
 import numpy as np

--- a/gtsfm/data_association/data_assoc.py
+++ b/gtsfm/data_association/data_assoc.py
@@ -62,7 +62,7 @@ class DataAssociation(NamedTuple):
         corr_idxs_dict: Dict[Tuple[int, int], np.ndarray],
         keypoints_list: List[Keypoints],
         images: Optional[List[Image]] = None,
-    ) -> Tuple[GtsfmData, Dict[str, Any]]:
+    ) -> Tuple[GtsfmData, GtsfmMetricsGroup]:
         """Perform the data association.
 
         Args:

--- a/gtsfm/evaluation/metrics.py
+++ b/gtsfm/evaluation/metrics.py
@@ -167,6 +167,9 @@ class GtsfmMetric:
         """
         if data.ndim != 1:
             raise ValueError("Metric must be a 1D distribution to get summary.")
+        if data.size == 0:
+            return {"min": np.NaN, "max": np.NaN, "median": np.NaN, "mean": np.NaN, "stddev": np.NaN}
+
         summary = {
             "min": np.nanmin(data).tolist(),
             "max": np.nanmax(data).tolist(),

--- a/gtsfm/frontend/verifier/ransac.py
+++ b/gtsfm/frontend/verifier/ransac.py
@@ -100,7 +100,7 @@ class Ransac(VerifierBase):
                 uv_norm_i1[match_indices[:, 0]],
                 uv_norm_i2[match_indices[:, 1]],
                 K,
-                method=cv2.RANSAC,
+                method=cv2.USAC_ACCURATE,
                 threshold=self._estimation_threshold_px / fx,
                 prob=RANSAC_SUCCESS_PROB,
             )

--- a/tests/bundle/test_bundle_adjustment.py
+++ b/tests/bundle/test_bundle_adjustment.py
@@ -41,9 +41,9 @@ class TestBundleAdjustmentOptimizer(unittest.TestCase):
         """Test the simple scene as dask computation graph."""
         sfm_data_graph = dask.delayed(self.test_data)
 
-        expected_result = self.obj.run(self.test_data)
+        expected_result, _ = self.obj.run(self.test_data)
 
-        computed_result = self.obj.create_computation_graph(dask.delayed(sfm_data_graph))
+        computed_result, _ = self.obj.create_computation_graph(dask.delayed(sfm_data_graph))
 
         with dask.config.set(scheduler="single-threaded"):
             result = dask.compute(computed_result)[0]

--- a/tests/data_association/test_data_association.py
+++ b/tests/data_association/test_data_association.py
@@ -19,7 +19,7 @@ from gtsfm.data_association.data_assoc import DataAssociation, TriangulationPara
 
 
 def get_pose3_vector(num_poses: int) -> Pose3Vector:
-    """ Generate camera poses for use in triangulation tests """
+    """Generate camera poses for use in triangulation tests"""
 
     # Looking along X-axis, 1 meter above ground plane (x-y)
     upright = Rot3.Ypr(-np.pi / 2, 0.0, -np.pi / 2)
@@ -41,10 +41,8 @@ def get_pose3_vector(num_poses: int) -> Pose3Vector:
 
 
 def generate_noisy_2d_measurements(
-    world_point: Point3, calibrations: List[Cal3Bundler], per_image_noise_vecs: np.ndarray, poses: Pose3Vector,
-) -> Tuple[
-    List[Keypoints], List[Tuple[int, int]], Dict[int, PinholeCameraCal3Bundler],
-]:
+    world_point: Point3, calibrations: List[Cal3Bundler], per_image_noise_vecs: np.ndarray, poses: Pose3Vector
+) -> Tuple[List[Keypoints], List[Tuple[int, int]], Dict[int, PinholeCameraCal3Bundler]]:
     """
     Generate PinholeCameras from specified poses and calibrations, and then generate
     1 measurement per camera of a given 3d point.
@@ -259,10 +257,7 @@ class TestDataAssociation(GtsamTestCase):
         # will lead to a cheirality exception because keypoints are identical in two cameras
         # no track will be formed, and thus connected component will be empty
         sfm_data, _ = da.run(
-            num_images=3,
-            cameras=cameras,
-            corr_idxs_dict=corr_idxs_dict,
-            keypoints_list=[keypoints_shared] * 3
+            num_images=3, cameras=cameras, corr_idxs_dict=corr_idxs_dict, keypoints_list=[keypoints_shared] * 3
         )
 
         self.assertEqual(len(sfm_data.get_valid_camera_indices()), 0)
@@ -293,14 +288,17 @@ class TestDataAssociation(GtsamTestCase):
 
         # Run with computation graph
         delayed_sfm_data, delayed_metrics = da.create_computation_graph(
-            len(cameras), cameras, matches_dict, keypoints_list,
+            len(cameras),
+            cameras,
+            matches_dict,
+            keypoints_list,
         )
 
         with dask.config.set(scheduler="single-threaded"):
             dask_sfm_data, dask_metrics = dask.compute(delayed_sfm_data, delayed_metrics)
 
         assert expected_sfm_data.number_tracks() == dask_sfm_data.number_tracks(), "Dask not configured correctly"
-        self.assertDictEqual(dask_metrics, expected_metrics)
+        self.assertDictEqual(expected_metrics.get_metrics_as_dict(), dask_metrics.get_metrics_as_dict())
 
         for k in range(expected_sfm_data.number_tracks()):
             assert (


### PR DESCRIPTION
Main changes which affect performance:
- Switch from RANSAC to USAC as RANSAC in 4.5.0 has poor performance
- Remove argoverse from pip install (and hence breaking argoverse related files) to prevent reinstall of opencv using pip, which conflicts the conda install.