### PR TITLE
Enable manual trigger of CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,12 +1,7 @@
 name: Benchmark GTSFM on select datasets
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
-  
+
+on: [pull_request, workflow_dispatch]
+
 jobs:
   benchmark:
     name: Run GTSFM on the select dataset using SIFT front-end

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,5 +1,12 @@
 name: Benchmark GTSFM on select datasets
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  
 jobs:
   benchmark:
     name: Run GTSFM on the select dataset using SIFT front-end

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -1,7 +1,6 @@
 name: Unit tests and python checks
 
-# Run this workflow every time a new commit pushed to your repository
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   run-unit-tests:


### PR DESCRIPTION
This change adds `workflow-dispatch` as a trigger for the CI. This enables us to run CI manually from the website/CLI.

An immediate use-case is that we can trigger runs on master to cache conda env for all other branches, and to download the metrics.