### PR TITLE
Switching from conda to mamba

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,7 +26,7 @@ jobs:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{hashFiles('environment_linux.yml') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          miniconda-version: "latest"
+          mamba-version: "*"
           activate-environment: gtsfm-v1
           environment-file: environment_linux.yml
           python-version: 3.8

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -27,7 +27,7 @@ jobs:
           ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{hashFiles('environment_linux.yml') }}
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        miniconda-version: "latest"
+        mamba-version: "*"
         activate-environment: gtsfm-v1
         environment-file: environment_linux.yml
         python-version: 3.8


### PR DESCRIPTION
Switch should allow super-quick setup in the CI jobs.