### PR TITLE
Reverting Node Version to v13

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -24,7 +24,7 @@ dependencies:
   - matplotlib==3.4.2
   - networkx
   - numpy
-  - nodejs
+  - nodejs==13.13.0
   - pandas
   - pillow>=8.0.1
   - scikit-learn

--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -24,7 +24,7 @@ dependencies:
   - matplotlib==3.4.2
   - networkx
   - numpy
-  - nodejs==13.13.0
+  - nodejs==13.13.0 # will be updated to version 16.16.1 when numjs issue #81 is fixed
   - pandas
   - pillow>=8.0.1
   - scikit-learn

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -27,7 +27,7 @@ dependencies:
   - matplotlib==3.4.2
   - networkx
   - numpy
-  - nodejs
+  - nodejs==13.13.0 # will be updated to version 16.16.1 when numjs issue #81 is fixed
   - pandas
   - pillow>=8.0.1
   - scikit-learn

--- a/rtf_vis_tool/src/Components/AllFrustums.js
+++ b/rtf_vis_tool/src/Components/AllFrustums.js
@@ -58,7 +58,10 @@ function AllFrustums() {
         var ex_cameraList = ex_data.split('\n');
         ex_cameraList = ex_cameraList.slice(4); // Remove the 4 lines of comments in images.txt.
         ex_cameraList.pop() // remove the last empty string from list.
-        ex_cameraList = ex_cameraList.filter(line => line !== "TODO"); // remove any lines with text "TODO"
+
+        // remove any dummy lines from images.txt that contain the string "TODO", until gtsfm.utils.io.write_images is
+        // updated
+        ex_cameraList = ex_cameraList.filter(line => line !== "TODO"); 
 
         if (in_cameraList.length !== ex_cameraList.length) {
             alert('Camera count mismatch between images.txt and cameras.txt');

--- a/rtf_vis_tool/src/Components/AllFrustums.js
+++ b/rtf_vis_tool/src/Components/AllFrustums.js
@@ -58,6 +58,7 @@ function AllFrustums() {
         var ex_cameraList = ex_data.split('\n');
         ex_cameraList = ex_cameraList.slice(4); // Remove the 4 lines of comments in images.txt.
         ex_cameraList.pop() // remove the last empty string from list.
+        ex_cameraList = ex_cameraList.filter(line => line !== "TODO"); // remove any lines with text "TODO"
 
         if (in_cameraList.length !== ex_cameraList.length) {
             alert('Camera count mismatch between images.txt and cameras.txt');


### PR DESCRIPTION
`numjs` is not compatible with the newer versions of Nodejs. However, it is compatible with v13. So to preserve the camera frustum rendering functionality, I have updated the `environment_linux.yml` to ensure that node v13.13.0 is intalled when the conda environment is built.