### PR TITLE
Remove underconstrained TA square unit test

### DIFF
--- a/tests/averaging/translation/test_averaging_1dsfm.py
+++ b/tests/averaging/translation/test_averaging_1dsfm.py
@@ -49,12 +49,13 @@ class TestTranslationAveraging1DSFM(unittest.TestCase):
             )
         )
 
-    def test_circle_two_edges(self):
-        """Tests for 4 poses in a circle, with a pose connected to its immediate neighborhood."""
-        wRi_list, i2Ui1_dict, wti_expected = sample_poses.convert_data_for_translation_averaging(
-            sample_poses.CIRCLE_TWO_EDGES_GLOBAL_POSES, sample_poses.CIRCLE_TWO_EDGES_RELATIVE_POSES
-        )
-        self.__execute_test(i2Ui1_dict, wRi_list, wti_expected)
+    # deprecating as underconstrained problem
+    # def test_circle_two_edges(self):
+    #     """Tests for 4 poses in a circle, with a pose connected to its immediate neighborhood."""
+    #     wRi_list, i2Ui1_dict, wti_expected = sample_poses.convert_data_for_translation_averaging(
+    #         sample_poses.CIRCLE_TWO_EDGES_GLOBAL_POSES, sample_poses.CIRCLE_TWO_EDGES_RELATIVE_POSES
+    #     )
+    #     self.__execute_test(i2Ui1_dict, wRi_list, wti_expected)
 
     def test_circle_all_edges(self):
         """Tests for 4 poses in a circle, with a pose connected all others."""


### PR DESCRIPTION
This unit test expects translation averaging to recover the translations for 4 points on a circle with only 2 edges for each point.
```
x ----- x
|       |
x ----- x
```
This is an underconstrained problem. Starting with the relative translations, we can only recover a rectangle, not a square. Deprecating this test as there is already another test for a square where each point has 3 edges. 

We could revisit this test if we fix translation averaging to explicitly fail for such degenerate cases someday. 