### PR TITLE
add test that should fail for the GtsfmMetric class

### DIFF
--- a/gtsfm/evaluation/metrics.py
+++ b/gtsfm/evaluation/metrics.py
@@ -92,6 +92,7 @@ class GtsfmMetric:
             # Cast to a numpy array
             if not isinstance(data, np.ndarray):
                 data = np.array(data)
+            data = data.astype(np.float32)
             if data.ndim > 1:
                 raise ValueError("Metrics must be scalars on 1D-distributions.")
 

--- a/tests/evaluation/metrics_test.py
+++ b/tests/evaluation/metrics_test.py
@@ -111,6 +111,19 @@ class TestGtsfmMetric(unittest.TestCase):
         metric = GtsfmMetric("to_be_written_metric", np.arange(10.0))
         with tempfile.TemporaryDirectory() as tempdir:
             metric.save_to_json(os.path.join(tempdir, "test_metrics.json"))
+            
+    def test_list_input_with_none_entries(self) -> None:
+        """Ensure that a GtsfmMetric can be successfully instantiated even with None entries."""
+        per_rejected_track_avg_errors = [
+            0.4943377406921827,
+            0.07750727215807857,
+            None,
+            50.555624633887966,
+            0.4105653459580154,
+            None,
+            None,
+        ]
+        metric = GtsfmMetric("rejected_track_avg_errors_px", per_rejected_track_avg_errors, store_full_data=False)
 
 
 class TestGtsfmMetricsGroup(unittest.TestCase):


### PR DESCRIPTION
By casting array to floats, the Nones are turned to NaNs, which are handled in the nanmean.

Added test that fails for the GtsfmMetric class without the float-cast fix.

error w/o:
```
distributed.worker - WARNING - Compute Failed
Function:  execute_task
args:      ((<bound method DataAssociation.run of DataAssociation(reproj_error_thresh=100, min_track_len=2, mode=<TriangulationParam.NO_RANSAC: 0>, num_ransac_hypotheses=20, save_track_patches_viz=False)>, 8, {1: .pose R: [
	-0.666108, -0.550273, 0.503487;
	0.552477, -0.817521, -0.162567;
	0.501068, 0.169878, 0.848571
]
t: -1.42454  1.02067 0.120821
.calibration.K[583.1175; 0; 0; 507; 380];
, 2: .pose R: [
	-0.797680111, -0.558884097, 0.226616431;
	0.583932899, -0.809687116, 0.0585588913;
	0.150760771, 0.179040053, 0.972222119
]
t:  -0.800568819   0.572387209 -0.0664739823
.calibration.K[583.1175; 0; 0; 507; 380];
, 3: .pose R: [
	-0.82444263, -0.550926242, 0.129516889;
	0.564574657, -0.816538202, 0.120502368;
	0.0393675711, 0.172469242, 0.984227898
]
t: -0.794390669  0.567679952 -0.067297119
.calibration.K[583.1175; 0; 0; 507; 380];
, 4: .pose R: [
	-0.819192511, -0.548180012, 0.16858916;
	0.565370194, -0.821250678, 0.076836626;
	0.0963336591, 0.158259274, 0.982687045
]
t: -1.98453271e-05  -0.00
kwargs:    {}
Exception: TypeError("'<=' not supported between instances of 'float' and 'NoneType'")

Traceback (most recent call last):
  File "gtsfm/runner/run_scene_optimizer_colmaploader.py", line 80, in <module>
    run_scene_optimizer(args)
  File "gtsfm/runner/run_scene_optimizer_colmaploader.py", line 42, in run_scene_optimizer
    sfm_result = sfm_result_graph.compute()
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/dask/base.py", line 286, in compute
    (result,) = compute(self, traverse=False, **kwargs)
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/dask/base.py", line 568, in compute
    results = schedule(dsk, keys, **kwargs)
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 2671, in get
    results = self.gather(packed, asynchronous=asynchronous, direct=direct)
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 1948, in gather
    return self.sync(
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 845, in sync
    return sync(
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/utils.py", line 326, in sync
    raise exc.with_traceback(tb)
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/utils.py", line 309, in f
    result[0] = yield future
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/tornado/gen.py", line 762, in run
    value = future.result()
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 1813, in _gather
    raise exception.with_traceback(traceback)
  File "/home/runner/work/gtsfm/gtsfm/gtsfm/data_association/data_assoc.py", line 158, in run
    GtsfmMetric("rejected_track_avg_errors_px", per_rejected_track_avg_errors, store_full_data=False),
  File "/home/runner/work/gtsfm/gtsfm/gtsfm/evaluation/metrics.py", line 113, in __init__
    self._summary = self._create_summary(data)
  File "/home/runner/work/gtsfm/gtsfm/gtsfm/evaluation/metrics.py", line 174, in _create_summary
    "min": np.nanmin(data).tolist(),
  File "<__array_function__ internals>", line 5, in nanmin
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/numpy/lib/nanfunctions.py", line 326, in nanmin
    res = np.amin(a, axis=axis, out=out, **kwargs)
  File "<__array_function__ internals>", line 5, in amin
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/numpy/core/fromnumeric.py", line 2879, in amin
    return _wrapreduction(a, np.minimum, 'min', axis, None, out,
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/numpy/core/fromnumeric.py", line 86, in _wrapreduction
    return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
TypeError: '<=' not supported between instances of 'float' and 'NoneType'
Error: Process completed with exit code 1.
0s
```
