### PR TITLE
convert None entries to Nan before passing as input to GtsfmMetric

### DIFF
--- a/gtsfm/data_association/data_assoc.py
+++ b/gtsfm/data_association/data_assoc.py
@@ -153,7 +153,11 @@ class DataAssociation(NamedTuple):
                     plot_type=GtsfmMetric.PlotType.HISTOGRAM,
                 ),
                 GtsfmMetric("accepted_track_avg_errors_px", per_accepted_track_avg_errors, store_full_data=False),
-                GtsfmMetric("rejected_track_avg_errors_px", per_rejected_track_avg_errors, store_full_data=False),
+                GtsfmMetric(
+                    "rejected_track_avg_errors_px",
+                    np.array(per_rejected_track_avg_errors).astype(np.float32),
+                    store_full_data=False,
+                ),
             ],
         )
 


### PR DESCRIPTION

GtsfmMetric currently cannot support an input argument that contains None entries. This PR solves this by casting Nones to NaNs, which are then gracefully handled

Without the fix, we see the folliowing error:

```
[2021-09-01 01:27:08,550 DEBUG data_assoc.py line 135 4091] [Data association] output avg. track length: 2.44
per_rejected_track_avg_errors [0.4943377406921827, 0.07750727215807857, None, 50.555624633887966, 0.4105653459580154, None, None, 0.9000904523273447, 0.15871712683215253, 0.15871712683215253, None, 59.3105749901508, None, None, 51.9263925451782, 0.43754308753149673, None, None, None, 14.6315526920527, 0.21327828059175513, None, 0.9918309430987753, 56.119727462062144, None, 0.3621078266499683, 0.4472408970491756, None, 58.22164813611213, 0.3006139727821833, 14.261747655390911, 0.0671259818866646, None, None, 0.5664233549647623, None, None, None, 148.0883061815312, 12.91579810943746, 0.7360540870336185, 17.466692579267853, None, None, 0.3819295377487452, None, None, None, None, None, None, None, 83.09188463926506, 132.1501107697091, 61.95121409942072, None, None, 0.8222581405138006, None, 13.870623909694004, 2.3944521928979157, 1.0233763046419453, 0.5530423137260041, None, 0.6370692774459146, 52.60742424439034, 76.49839361884142, None, 0.015624169349058772, 0.21313872058968922, 63.56032366636337, 44.590997477954126, 1.360514959048976, None, None, None, 0.8176972123560743, 1.7802700119952475, 50.83076687024327, 0.9443750223562086, None, 202.97745202897553, None, None, 55.983760841138086, None, 1.302481423890915, 40.5853296607991, 48.42931630879821, None, None, None, None, None, None, None, None, 0.033959743154501135, 12.9681951765307, 59.42115611552481, None, None, None, None, None, 61.091701437662984, 1.2437783462313932, None, None, 1.240393629977256, 1.651192162791904, 40.17396605086019, None, None, None, None, None, 49.801235828014114, None, None, None, None, 50.03677057534568, 0.5075587943615103, 10.469703770781683, None, 0.08808336230590988, 16.153933793811515, None, None, None, None, 1.586955293605011, None, None, None, 68.03680428815329, None, None, 15.61341378263616, None, None, 1.5588061165025615, None, None, None, 0.8248050265929598, None, None, 0.9535105707447128, 65.35440574210394, None, None, None, None, None, 26.413890455853974, None, None, None, None, None, None, None, 0.7792212046059535, 1.0127438965328188, 30.35567191409832, 1.1853470965752986, 1.1327289766656823, 1.1327289766656823, None, None, 0.42001167737529194, 43.168979909097644, 0.3642699379899129, None, None, None, None, None, 0.4261163184497169, 0.16415585103475988, 1.8602169640364163, None, None, 1.13233231583566, None, None, None, 49.58969698727923, None, 1.0519967746086047, None, None, None, None, None, None, 9.59263054694744, None, 0.30806994360876555, None, None, None, 1.0437588974020489, None, None, 58.78194046423858, None, None, None, None, None, 0.9874643561474854, None, None, 0.6131299784143841, None, None, None, None, None, None, None, None, None, None, None, None, None, None, 66.46401037099093, None, 66.6955274609439, 54.669822067745486, 55.17922651462939, 69.87349434202932, 57.759502723432, 77.86671094388306, 63.332476527915084, 67.46438960663443, 68.04055952245828, 63.8183238347731, 61.995788004439056, 57.06676503719942, 117.34364801340809, 54.38664691039051, 48.796188421425114, 54.89732058977566, 94.00860838321012, 59.0200093750054, 59.0200093750054, 69.34760266811942, 64.79997392101124, 84.41607280868489, 58.36297124399549, 168.79449299132395, 65.63034137441863, 59.357135716984565, 67.1993421410266, 165.513021980967, 66.06800326382204, 66.74712871699721, 69.35305799630743, 62.91264113157705, 60.573526293358086, 62.559662127564, 75.28845267460494, 78.69054745115363, 52.024653091842, 66.25064831275029, 90.71494123478597, 61.40723026534052, 72.16403743783756, 64.88160899077072, 60.51516366299165, 77.29749162397363, 65.27902999640833, 77.20329897784379, 77.20329897784379, 66.49081389499872, 82.33645045675817, 82.33645045675817, 58.65133076776472, 133.97987102335523, 50.47608281217831, 63.521288139444025, 72.4023678255227, 78.90154077634892, 119.5793620474521, 77.69101347493815, 48.03075700997626, 66.22373950538287, 67.35151841452496, 58.577541118242024, 74.02249636838114, 65.24717087545461, 60.07683624148301, 72.96818748880266, 72.96818748880266, 67.27636740749027, 67.28206613585273, 65.74015407237015, 66.52494646857765, 56.23454470104585, 78.32687431048359, 67.06280783456234, 70.66722739039422, 66.2771477046032, 63.51513242622042, 59.448951639963774, 60.15790922475607, 72.35065703652525, 81.01768505504633, 69.32571654247353, 80.06376575162106, 55.27681477310521, 66.08158555618016, 70.61484138279407, 59.138890712201864, 51.78146471756806, 71.93163080820003, 72.36927659559582, 63.30583544290206, 62.83273308938842, 82.69501610675087, 56.389601159341645, 72.7481894734897, 75.96670522073885, 111.70917409697644, 51.697936791223356, 66.89623260038638, 68.62706887381286, 66.09997275625621, 102.63885953676669, 64.1644364774806, 74.936675628081, 75.29507328938584, 228.6755326553307, 89.74304647560503, 64.86054899681288, 121.51143406751599, 56.83633830846588, 81.89165871625944, 81.90315809855448, 61.70851904394595, 48.185344531491886, 68.47136692217632, 63.2162352926918, 55.4524720464402, 54.76547313998529, 70.39501189663703, 79.30251499788227, 72.91173310992036, 70.53569339077895, 65.28546015553816, 82.83618652798602, 80.83172393466307, 66.40564770487826, 254.64207315496236, 83.08876187437372, 94.99338162555573, 167.60005904213136, 54.46975197282207, 95.50829929231524, 149.09894641442233, 113.76080029479617, 84.36069469089453, 101.24582869004921, 69.85244282889329]
[2021-09-01 01:27:08,551 INFO data_assoc.py line 138 4091] per_rejected_track_avg_errors[0.4943377406921827, 0.07750727215807857, None, 50.555624633887966, 0.4105653459580154, None, None, 0.9000904523273447, 0.15871712683215253, 0.15871712683215253, None, 59.3105749901508, None, None, 51.9263925451782, 0.43754308753149673, None, None, None, 14.6315526920527, 0.21327828059175513, None, 0.9918309430987753, 56.119727462062144, None, 0.3621078266499683, 0.4472408970491756, None, 58.22164813611213, 0.3006139727821833, 14.261747655390911, 0.0671259818866646, None, None, 0.5664233549647623, None, None, None, 148.0883061815312, 12.91579810943746, 0.7360540870336185, 17.466692579267853, None, None, 0.3819295377487452, None, None, None, None, None, None, None, 83.09188463926506, 132.1501107697091, 61.95121409942072, None, None, 0.8222581405138006, None, 13.870623909694004, 2.3944521928979157, 1.0233763046419453, 0.5530423137260041, None, 0.6370692774459146, 52.60742424439034, 76.49839361884142, None, 0.015624169349058772, 0.21313872058968922, 63.56032366636337, 44.590997477954126, 1.360514959048976, None, None, None, 0.8176972123560743, 1.7802700119952475, 50.83076687024327, 0.9443750223562086, None, 202.97745202897553, None, None, 55.983760841138086, None, 1.302481423890915, 40.5853296607991, 48.42931630879821, None, None, None, None, None, None, None, None, 0.033959743154501135, 12.9681951765307, 59.42115611552481, None, None, None, None, None, 61.091701437662984, 1.2437783462313932, None, None, 1.240393629977256, 1.651192162791904, 40.17396605086019, None, None, None, None, None, 49.801235828014114, None, None, None, None, 50.03677057534568, 0.5075587943615103, 10.469703770781683, None, 0.08808336230590988, 16.153933793811515, None, None, None, None, 1.586955293605011, None, None, None, 68.03680428815329, None, None, 15.61341378263616, None, None, 1.5588061165025615, None, None, None, 0.8248050265929598, None, None, 0.9535105707447128, 65.35440574210394, None, None, None, None, None, 26.413890455853974, None, None, None, None, None, None, None, 0.7792212046059535, 1.0127438965328188, 30.35567191409832, 1.1853470965752986, 1.1327289766656823, 1.1327289766656823, None, None, 0.42001167737529194, 43.168979909097644, 0.3642699379899129, None, None, None, None, None, 0.4261163184497169, 0.16415585103475988, 1.8602169640364163, None, None, 1.13233231583566, None, None, None, 49.58969698727923, None, 1.0519967746086047, None, None, None, None, None, None, 9.59263054694744, None, 0.30806994360876555, None, None, None, 1.0437588974020489, None, None, 58.78194046423858, None, None, None, None, None, 0.9874643561474854, None, None, 0.6131299784143841, None, None, None, None, None, None, None, None, None, None, None, None, None, None, 66.46401037099093, None, 66.6955274609439, 54.669822067745486, 55.17922651462939, 69.87349434202932, 57.759502723432, 77.86671094388306, 63.332476527915084, 67.46438960663443, 68.04055952245828, 63.8183238347731, 61.995788004439056, 57.06676503719942, 117.34364801340809, 54.38664691039051, 48.796188421425114, 54.89732058977566, 94.00860838321012, 59.0200093750054, 59.0200093750054, 69.34760266811942, 64.79997392101124, 84.41607280868489, 58.36297124399549, 168.79449299132395, 65.63034137441863, 59.357135716984565, 67.1993421410266, 165.513021980967, 66.06800326382204, 66.74712871699721, 69.35305799630743, 62.91264113157705, 60.573526293358086, 62.559662127564, 75.28845267460494, 78.69054745115363, 52.024653091842, 66.25064831275029, 90.71494123478597, 61.40723026534052, 72.16403743783756, 64.88160899077072, 60.51516366299165, 77.29749162397363, 65.27902999640833, 77.20329897784379, 77.20329897784379, 66.49081389499872, 82.33645045675817, 82.33645045675817, 58.65133076776472, 133.97987102335523, 50.47608281217831, 63.521288139444025, 72.4023678255227, 78.90154077634892, 119.5793620474521, 77.69101347493815, 48.03075700997626, 66.22373950538287, 67.35151841452496, 58.577541118242024, 74.02249636838114, 65.24717087545461, 60.07683624148301, 72.96818748880266, 72.96818748880266, 67.27636740749027, 67.28206613585273, 65.74015407237015, 66.52494646857765, 56.23454470104585, 78.32687431048359, 67.06280783456234, 70.66722739039422, 66.2771477046032, 63.51513242622042, 59.448951639963774, 60.15790922475607, 72.35065703652525, 81.01768505504633, 69.32571654247353, 80.06376575162106, 55.27681477310521, 66.08158555618016, 70.61484138279407, 59.138890712201864, 51.78146471756806, 71.93163080820003, 72.36927659559582, 63.30583544290206, 62.83273308938842, 82.69501610675087, 56.389601159341645, 72.7481894734897, 75.96670522073885, 111.70917409697644, 51.697936791223356, 66.89623260038638, 68.62706887381286, 66.09997275625621, 102.63885953676669, 64.1644364774806, 74.936675628081, 75.29507328938584, 228.6755326553307, 89.74304647560503, 64.86054899681288, 121.51143406751599, 56.83633830846588, 81.89165871625944, 81.90315809855448, 61.70851904394595, 48.185344531491886, 68.47136692217632, 63.2162352926918, 55.4524720464402, 54.76547313998529, 70.39501189663703, 79.30251499788227, 72.91173310992036, 70.53569339077895, 65.28546015553816, 82.83618652798602, 80.83172393466307, 66.40564770487826, 254.64207315496236, 83.08876187437372, 94.99338162555573, 167.60005904213136, 54.46975197282207, 95.50829929231524, 149.09894641442233, 113.76080029479617, 84.36069469089453, 101.24582869004921, 69.85244282889329]
distributed.worker - WARNING - Compute Failed
Function:  execute_task
args:      ((<bound method DataAssociation.run of DataAssociation(reproj_error_thresh=100, min_track_len=2, mode=<TriangulationParam.NO_RANSAC: 0>, num_ransac_hypotheses=20, save_track_patches_viz=False)>, 8, {1: .pose R: [
	-0.666108, -0.550273, 0.503487;
	0.552477, -0.817521, -0.162567;
	0.501068, 0.169878, 0.848571
]
t: -1.42454  1.02067 0.120821
.calibration.K[583.1175; 0; 0; 507; 380];
, 2: .pose R: [
	-0.797680111, -0.558884097, 0.226616431;
	0.583932899, -0.809687116, 0.0585588913;
	0.150760771, 0.179040053, 0.972222119
]
t:  -0.800568819   0.572387209 -0.0664739823
.calibration.K[583.1175; 0; 0; 507; 380];
, 3: .pose R: [
	-0.82444263, -0.550926242, 0.129516889;
	0.564574657, -0.816538202, 0.120502368;
	0.0393675711, 0.172469242, 0.984227898
]
t: -0.794390669  0.567679952 -0.067297119
.calibration.K[583.1175; 0; 0; 507; 380];
, 4: .pose R: [
	-0.819192511, -0.548180012, 0.16858916;
	0.565370194, -0.821250678, 0.076836626;
	0.0963336591, 0.158259274, 0.982687045
]
t: -1.98453271e-05  -0.00
kwargs:    {}
Exception: TypeError("'<=' not supported between instances of 'float' and 'NoneType'")

Traceback (most recent call last):
  File "gtsfm/runner/run_scene_optimizer_colmaploader.py", line 80, in <module>
    run_scene_optimizer(args)
  File "gtsfm/runner/run_scene_optimizer_colmaploader.py", line 42, in run_scene_optimizer
    sfm_result = sfm_result_graph.compute()
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/dask/base.py", line 286, in compute
    (result,) = compute(self, traverse=False, **kwargs)
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/dask/base.py", line 568, in compute
    results = schedule(dsk, keys, **kwargs)
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 2671, in get
    results = self.gather(packed, asynchronous=asynchronous, direct=direct)
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 1948, in gather
    return self.sync(
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 845, in sync
    return sync(
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/utils.py", line 326, in sync
    raise exc.with_traceback(tb)
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/utils.py", line 309, in f
    result[0] = yield future
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/tornado/gen.py", line 762, in run
    value = future.result()
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 1813, in _gather
    raise exception.with_traceback(traceback)
  File "/home/runner/work/gtsfm/gtsfm/gtsfm/data_association/data_assoc.py", line 158, in run
    GtsfmMetric("rejected_track_avg_errors_px", per_rejected_track_avg_errors, store_full_data=False),
  File "/home/runner/work/gtsfm/gtsfm/gtsfm/evaluation/metrics.py", line 113, in __init__
    self._summary = self._create_summary(data)
  File "/home/runner/work/gtsfm/gtsfm/gtsfm/evaluation/metrics.py", line 174, in _create_summary
    "min": np.nanmin(data).tolist(),
  File "<__array_function__ internals>", line 5, in nanmin
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/numpy/lib/nanfunctions.py", line 326, in nanmin
    res = np.amin(a, axis=axis, out=out, **kwargs)
  File "<__array_function__ internals>", line 5, in amin
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/numpy/core/fromnumeric.py", line 2879, in amin
    return _wrapreduction(a, np.minimum, 'min', axis, None, out,
  File "/usr/share/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/numpy/core/fromnumeric.py", line 86, in _wrapreduction
    return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
TypeError: '<=' not supported between instances of 'float' and 'NoneType'
Error: Process completed with exit code 1.

```