### PR TITLE
Add units to name of metric for reprojection errors

### DIFF
--- a/gtsfm/bundle/bundle_adjustment.py
+++ b/gtsfm/bundle/bundle_adjustment.py
@@ -129,7 +129,7 @@ class BundleAdjustmentOptimizer(NamedTuple):
             metrics = []
             metrics.append(GtsfmMetric("number_tracks" + suffix, sfm_data.number_tracks()))
             metrics.append(GtsfmMetric("3d_track_lengths" + suffix, sfm_data.get_track_lengths()))
-            metrics.append(GtsfmMetric("reprojection_errors" + suffix, sfm_data.get_scene_reprojection_errors()))
+            metrics.append(GtsfmMetric(f"reprojection_errors{suffix}_px", sfm_data.get_scene_reprojection_errors()))
             return metrics
 
         ba_metrics = GtsfmMetricsGroup(

--- a/gtsfm/common/gtsfm_data.py
+++ b/gtsfm/common/gtsfm_data.py
@@ -252,7 +252,7 @@ class GtsfmData:
         """Get the scene reprojection errors for all 3D points and all associated measurements.
 
         Returns:
-            Reprojection errors as a 1D numpy array.
+            Reprojection errors (measured in pixels) as a 1D numpy array.
         """
         scene_reproj_errors: List[float] = []
         for track in self._tracks:

--- a/gtsfm/utils/reprojection.py
+++ b/gtsfm/utils/reprojection.py
@@ -20,7 +20,7 @@ def compute_track_reprojection_errors(
         track: 3d point/landmark and its corresponding 2d measurements in various cameras
 
     Returns:
-        reprojection errors for each measurement.
+        reprojection errors for each measurement (measured in pixels).
         avg_track_reproj_error: average reprojection error of all meausurements in track.
     """
     errors = []
@@ -56,7 +56,7 @@ def compute_point_reprojection_errors(
         measurements: corresponding 2d measurements (of 3d point above) in various cameras
 
     Returns:
-        reprojection errors for each measurement.
+        reprojection errors for each measurement (measured in pixels).
         avg_track_reproj_error: average reprojection error of all meausurements in track.
     """
     errors = []


### PR DESCRIPTION
In bundle adjustment, name of metric was unclear without adding the unit to it.