### PR TITLE
Reverting NodeJS to Latest Version

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -24,7 +24,7 @@ dependencies:
   - matplotlib==3.4.2
   - networkx
   - numpy
-  - nodejs==13.13.0 # will be updated to version 16.16.1 when numjs issue #81 is fixed
+  - nodejs
   - pandas
   - pillow>=8.0.1
   - scikit-learn

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -27,7 +27,7 @@ dependencies:
   - matplotlib==3.4.2
   - networkx
   - numpy
-  - nodejs==13.13.0 # will be updated to version 16.16.1 when numjs issue #81 is fixed
+  - nodejs
   - pandas
   - pillow>=8.0.1
   - scikit-learn


### PR DESCRIPTION
Neha, Pratyusha, and I were able to figure out an alternate solution to the `numjs` and `sharp` dependency issue by fixing an issue with the conda libtool. They are both able to properly run the React Application on their machines now.