### PR TITLE
increasing max keypoints to 8192

### DIFF
--- a/gtsfm/frontend/detector/detector_base.py
+++ b/gtsfm/frontend/detector/detector_base.py
@@ -10,16 +10,17 @@ from dask.delayed import Delayed
 from gtsfm.common.image import Image
 from gtsfm.common.keypoints import Keypoints
 
+DEFAULT_MAX_KEYPOINTS = 8192
+
 
 class DetectorBase(metaclass=abc.ABCMeta):
     """Base class for all the feature detectors."""
 
-    def __init__(self, max_keypoints: int = 5000) -> None:
+    def __init__(self, max_keypoints: int = DEFAULT_MAX_KEYPOINTS) -> None:
         """Initialize the detector.
 
         Args:
-            max_keypoints: Maximum number of keypoints to detect. Defaults to
-                           5000.
+            max_keypoints: Maximum number of keypoints to detect. Defaults to 8192.
         """
         self.max_keypoints = max_keypoints
 

--- a/gtsfm/frontend/detector_descriptor/detector_descriptor_base.py
+++ b/gtsfm/frontend/detector_descriptor/detector_descriptor_base.py
@@ -10,6 +10,7 @@ import dask
 import numpy as np
 from dask.delayed import Delayed
 
+import gtsfm.frontend.detector.detector_base as detector_base
 from gtsfm.common.image import Image
 from gtsfm.common.keypoints import Keypoints
 
@@ -20,11 +21,11 @@ class DetectorDescriptorBase(metaclass=abc.ABCMeta):
     This class serves as a combination of individual detector and descriptor.
     """
 
-    def __init__(self, max_keypoints: int = 5000):
+    def __init__(self, max_keypoints: int = detector_base.DEFAULT_MAX_KEYPOINTS):
         """Initialize the detector-descriptor.
 
         Args:
-            max_keypoints: Maximum number of keypoints to detect. Defaults to 5000.
+            max_keypoints: Maximum number of keypoints to detect. Defaults to 8192.
         """
         self.max_keypoints = max_keypoints
 


### PR DESCRIPTION
On comparing GTSFM's SIFT with Colmap's, we notice that the maximum number of keypoints is 8192 (compared to our 5000). This is a significant difference, and having more keypoints can improve the performance of our systems.

