### PR TITLE
Improved translation averaging metrics

### DIFF
--- a/gtsfm/averaging/translation/translation_averaging_base.py
+++ b/gtsfm/averaging/translation/translation_averaging_base.py
@@ -1,6 +1,6 @@
 """Base class for the translation averaging component of the GTSFM pipeline.
 
-Authors: Ayush Baid
+Authors: Ayush Baid, Akshay Krishnan
 """
 import abc
 from typing import Dict, List, Optional, Tuple
@@ -8,6 +8,8 @@ from typing import Dict, List, Optional, Tuple
 import dask
 from dask.delayed import Delayed
 from gtsam import Point3, Rot3, Unit3
+
+from gtsfm.evaluation.metrics import GtsfmMetricsGroup
 
 
 class TranslationAveragingBase(metaclass=abc.ABCMeta):
@@ -24,7 +26,8 @@ class TranslationAveragingBase(metaclass=abc.ABCMeta):
         i2Ui1_dict: Dict[Tuple[int, int], Optional[Unit3]],
         wRi_list: List[Optional[Rot3]],
         scale_factor: float = 1.0,
-    ) -> List[Optional[Point3]]:
+        gt_wTi_list: Optional[List[Optional[Pose3]]] = None,
+    ) -> List[Optional[Point3]], Optional[GtsfmMetricsGroup]:
         """Run the translation averaging.
 
         Args:
@@ -45,7 +48,8 @@ class TranslationAveragingBase(metaclass=abc.ABCMeta):
         i2Ui1_graph: Delayed,
         wRi_graph: Delayed,
         scale_factor: float = 1.0,
-    ) -> Delayed:
+        gt_wTi_graph: Optional[Delayed] = None,
+    ) -> Delayed, Delayed:
         """Create the computation graph for performing translation averaging.
 
         Args:
@@ -53,9 +57,10 @@ class TranslationAveragingBase(metaclass=abc.ABCMeta):
             i2Ui1_graph: dictionary of relative unit translations as a delayed task.
             wRi_graph: list of global rotations wrapped up in Delayed.
             scale_factor: non-negative global scaling factor.
+            gt_poses_graph: List of ground truth poses (wTi) wrapped as Delayed for computing metrics.
 
         Returns:
-            Delayed: global unit translations wrapped using dask.delayed.
+            Global unit translations wrapped as Delayed.
+            A GtsfmMetricsGroup with translation averaging metrics wrapped as Delayed. 
         """
-
-        return dask.delayed(self.run)(num_images, i2Ui1_graph, wRi_graph, scale_factor)
+        return dask.delayed(self.run)(num_images, i2Ui1_graph, wRi_graph, scale_factor, gt_poses_graph)

--- a/gtsfm/averaging/translation/translation_averaging_base.py
+++ b/gtsfm/averaging/translation/translation_averaging_base.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Tuple
 
 import dask
 from dask.delayed import Delayed
-from gtsam import Point3, Rot3, Unit3
+from gtsam import Point3, Pose3, Rot3, Unit3
 
 from gtsfm.evaluation.metrics import GtsfmMetricsGroup
 
@@ -27,7 +27,7 @@ class TranslationAveragingBase(metaclass=abc.ABCMeta):
         wRi_list: List[Optional[Rot3]],
         scale_factor: float = 1.0,
         gt_wTi_list: Optional[List[Optional[Pose3]]] = None,
-    ) -> List[Optional[Point3]], Optional[GtsfmMetricsGroup]:
+    ) -> Tuple[List[Optional[Point3]], Optional[GtsfmMetricsGroup]]:
         """Run the translation averaging.
 
         Args:
@@ -49,7 +49,7 @@ class TranslationAveragingBase(metaclass=abc.ABCMeta):
         wRi_graph: Delayed,
         scale_factor: float = 1.0,
         gt_wTi_graph: Optional[Delayed] = None,
-    ) -> Delayed, Delayed:
+    ) -> Delayed:
         """Create the computation graph for performing translation averaging.
 
         Args:
@@ -63,4 +63,4 @@ class TranslationAveragingBase(metaclass=abc.ABCMeta):
             Global unit translations wrapped as Delayed.
             A GtsfmMetricsGroup with translation averaging metrics wrapped as Delayed. 
         """
-        return dask.delayed(self.run)(num_images, i2Ui1_graph, wRi_graph, scale_factor, gt_poses_graph)
+        return dask.delayed(self.run, nout=2)(num_images, i2Ui1_graph, wRi_graph, scale_factor, gt_wTi_graph)

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -63,7 +63,7 @@ class MultiViewOptimizer:
         pruned_i2Ui1_graph = pruned_graph[1]
 
         wRi_graph = self.rot_avg_module.create_computation_graph(num_images, pruned_i2Ri1_graph)
-        wti_graph, ta_metrics = self.trans_avg_module.create_computation_graph(num_images, pruned_i2Ui1_graph, wRi_graph, gt_poses_graph)
+        wti_graph, ta_metrics = self.trans_avg_module.create_computation_graph(num_images, pruned_i2Ui1_graph, wRi_graph, gt_wTi_graph=gt_poses_graph)
         init_cameras_graph = dask.delayed(init_cameras)(wRi_graph, wti_graph, intrinsics_graph)
 
         ba_input_graph, data_assoc_metrics_graph = self.data_association_module.create_computation_graph(

--- a/gtsfm/utils/metrics.py
+++ b/gtsfm/utils/metrics.py
@@ -131,7 +131,7 @@ def compute_translation_angle_metric(
     return GtsfmMetric("translation_angle_error_deg", np.array(angles, dtype=np.float))
 
 
-def compute_averaging_metrics(
+def compute_rotation_averaging_metrics(
     wRi_list: List[Optional[Rot3]],
     wti_list: List[Optional[Point3]],
     gt_wTi_list: List[Pose3],
@@ -170,18 +170,13 @@ def compute_averaging_metrics(
     # ground truth is the reference/target for alignment. discard 2nd return arg -- the estimated Similarity(3) object
     wTi_aligned_list, _ = comp_utils.align_poses_sim3_ignore_missing(gt_wTi_list, wTi_list)
 
-    i2Ui1_dict_gt = get_twoview_translation_directions(gt_wTi_list)
-
     wRi_aligned_list, wti_aligned_list = get_rotations_translations_from_poses(wTi_aligned_list)
     gt_wRi_list, gt_wti_list = get_rotations_translations_from_poses(gt_wTi_list)
 
     metrics = []
     metrics.append(GtsfmMetric(name="num_rotations_computed", data=len([x for x in wRi_list if x is not None])))
-    metrics.append(GtsfmMetric(name="num_translations_computed", data=len([x for x in wti_list if x is not None])))
     metrics.append(compute_rotation_angle_metric(wRi_aligned_list, gt_wRi_list))
-    metrics.append(compute_translation_distance_metric(wti_aligned_list, gt_wti_list))
-    metrics.append(compute_translation_angle_metric(i2Ui1_dict=i2Ui1_dict_gt, wTi_list=wTi_aligned_list))
-    return GtsfmMetricsGroup(name="averaging_metrics", metrics=metrics)
+    return GtsfmMetricsGroup(name="rotation_averaging_metrics", metrics=metrics)
 
 
 def compute_ba_pose_metrics(


### PR DESCRIPTION
This PR fixes the large number of outliers in the translation to direction angle after averaging. This was happening because the metric was being computed for every ground truth camera pair, but translation averaging only receives a few camera pair directions as input. 

In addition, this PR also adds some metrics for the outlier rejection step of translation averaging: the number of inliers and outliers; angle between input measurements and GT measurements (for both inliers and outliers). 