### PR TITLE
try requiring more inliers to accept image pair in the front end

### DIFF
--- a/gtsfm/configs/deep_front_end.yaml
+++ b/gtsfm/configs/deep_front_end.yaml
@@ -14,7 +14,7 @@ SceneOptimizer:
   two_view_estimator:
     _target_: gtsfm.two_view_estimator.TwoViewEstimator
     eval_threshold_px: 3 # in px
-    min_num_inliers_acceptance: 100
+    min_num_inliers_acceptance: 200
 
     matcher:
       _target_: gtsfm.frontend.matcher.superglue_matcher.SuperGlueMatcher
@@ -24,7 +24,7 @@ SceneOptimizer:
       _target_: gtsfm.frontend.verifier.ransac.Ransac
       use_intrinsics_in_verification: True
       estimation_threshold_px: 4 # for H/E/F estimators
-      min_allowed_inlier_ratio_est_model: 0.5
+      min_allowed_inlier_ratio_est_model: 0.6
 
   multiview_optimizer:
     _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer

--- a/gtsfm/configs/deep_front_end.yaml
+++ b/gtsfm/configs/deep_front_end.yaml
@@ -14,7 +14,7 @@ SceneOptimizer:
   two_view_estimator:
     _target_: gtsfm.two_view_estimator.TwoViewEstimator
     eval_threshold_px: 3 # in px
-    min_num_inliers_acceptance: 15
+    min_num_inliers_acceptance: 30
 
     matcher:
       _target_: gtsfm.frontend.matcher.superglue_matcher.SuperGlueMatcher

--- a/gtsfm/configs/deep_front_end.yaml
+++ b/gtsfm/configs/deep_front_end.yaml
@@ -14,7 +14,7 @@ SceneOptimizer:
   two_view_estimator:
     _target_: gtsfm.two_view_estimator.TwoViewEstimator
     eval_threshold_px: 3 # in px
-    min_num_inliers_acceptance: 30
+    min_num_inliers_acceptance: 100
 
     matcher:
       _target_: gtsfm.frontend.matcher.superglue_matcher.SuperGlueMatcher
@@ -24,7 +24,7 @@ SceneOptimizer:
       _target_: gtsfm.frontend.verifier.ransac.Ransac
       use_intrinsics_in_verification: True
       estimation_threshold_px: 4 # for H/E/F estimators
-      min_allowed_inlier_ratio_est_model: 0.1
+      min_allowed_inlier_ratio_est_model: 0.5
 
   multiview_optimizer:
     _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer

--- a/gtsfm/configs/sift_front_end.yaml
+++ b/gtsfm/configs/sift_front_end.yaml
@@ -14,7 +14,7 @@ SceneOptimizer:
   two_view_estimator:
     _target_: gtsfm.two_view_estimator.TwoViewEstimator
     eval_threshold_px: 3 # in px
-    min_num_inliers_acceptance: 15
+    min_num_inliers_acceptance: 30
     
     matcher:
       _target_: gtsfm.frontend.matcher.twoway_matcher.TwoWayMatcher

--- a/gtsfm/configs/sift_front_end.yaml
+++ b/gtsfm/configs/sift_front_end.yaml
@@ -14,7 +14,7 @@ SceneOptimizer:
   two_view_estimator:
     _target_: gtsfm.two_view_estimator.TwoViewEstimator
     eval_threshold_px: 3 # in px
-    min_num_inliers_acceptance: 30
+    min_num_inliers_acceptance: 200
     
     matcher:
       _target_: gtsfm.frontend.matcher.twoway_matcher.TwoWayMatcher
@@ -23,7 +23,7 @@ SceneOptimizer:
       _target_: gtsfm.frontend.verifier.ransac.Ransac
       use_intrinsics_in_verification: True
       estimation_threshold_px: 4 # for H/E/F estimators
-      min_allowed_inlier_ratio_est_model: 0.1
+      min_allowed_inlier_ratio_est_model: 0.6
 
   multiview_optimizer:
     _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer


### PR DESCRIPTION
Reduce noise in front-end by putting strict requirements on the type of image pairs we will accept.
Increasing #inliers threshold to 100, and min allowed inlier ratio to 0.5

These are important thresholds we should do a huge grid search over to tune in a future PR.