### PR TITLE
Improve error message when no images are found in Olsson loader

### DIFF
--- a/gtsfm/loader/olsson_loader.py
+++ b/gtsfm/loader/olsson_loader.py
@@ -58,7 +58,7 @@ class OlssonLoader(LoaderBase):
         self._image_paths.sort()
         self._num_imgs = len(self._image_paths)
         
-        if len(self._num_imgs) == 0:
+        if self._num_imgs == 0:
             raise RuntimeError(f"Loader could not find any images with the specified file extension in {folder}")
 
         cam_matrices_fpath = os.path.join(folder, "data.mat")

--- a/gtsfm/loader/olsson_loader.py
+++ b/gtsfm/loader/olsson_loader.py
@@ -57,6 +57,9 @@ class OlssonLoader(LoaderBase):
         # sort the file names
         self._image_paths.sort()
         self._num_imgs = len(self._image_paths)
+        
+        if len(self._num_imgs) == 0:
+            raise RuntimeError(f"Loader could not find any images with the specified file extension in {folder}")
 
         cam_matrices_fpath = os.path.join(folder, "data.mat")
         if not Path(cam_matrices_fpath).exists():


### PR DESCRIPTION
Currently, if the wrong image extension is passed, we see an error like
```
Traceback (most recent call last):
  File "gtsfm/runner/run_scene_optimizer.py", line 72, in <module>
    run_scene_optimizer(args)
  File "gtsfm/runner/run_scene_optimizer.py", line 26, in run_scene_optimizer
    loader = OlssonLoader(
  File "/home/runner/work/gtsfm/gtsfm/gtsfm/loader/olsson_loader.py", line 77, in __init__
    self._K = M_list[0][:3,:3]
IndexError: list index out of range
```
This is not interpretable, and this PR instead explains that simply no images were found, leading to this error.