### PR TITLE
Using robust Huber loss in Translation Averaging

### DIFF
--- a/gtsfm/averaging/translation/averaging_1dsfm.py
+++ b/gtsfm/averaging/translation/averaging_1dsfm.py
@@ -67,12 +67,10 @@ class TranslationAveraging1DSFM(TranslationAveragingBase):
                 or ill-constrained system).
             A GtsfmMetricsGroup of 1DSfM metrics.
         """
-        isotropic_noise_model = gtsam.noiseModel.Isotropic.Sigma(NOISE_MODEL_DIMENSION, NOISE_MODEL_SIGMA)
+        noise_model = gtsam.noiseModel.Isotropic.Sigma(NOISE_MODEL_DIMENSION, NOISE_MODEL_SIGMA)
         if robust_measurement_noise:
             huber_loss = gtsam.noiseModel.mEstimator.Huber.Create(HUBER_LOSS_K)
             noise_model = gtsam.noiseModel.Robust.Create(huber_loss, noise_model)
-        else:
-            noise_model = isotropic_noise_model
 
         # Note: all measurements are relative translation directions in the
         # world frame.

--- a/gtsfm/averaging/translation/averaging_1dsfm.py
+++ b/gtsfm/averaging/translation/averaging_1dsfm.py
@@ -28,7 +28,7 @@ OUTLIER_WEIGHT_THRESHOLD = 0.1
 
 NOISE_MODEL_DIMENSION = 3  # chordal distances on Unit3
 NOISE_MODEL_SIGMA = 0.01
-HUBER_LOSS_K = 1.345       # default value from GTSAM
+HUBER_LOSS_K = 1.345  # default value from GTSAM
 
 MAX_INLIER_MEASUREMENT_ERROR_DEG = 5.0
 
@@ -36,8 +36,13 @@ MAX_INLIER_MEASUREMENT_ERROR_DEG = 5.0
 class TranslationAveraging1DSFM(TranslationAveragingBase):
     """1D-SFM translation averaging with outlier rejection."""
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, robust_measurement_noise: bool = True) -> None:
+        """Initializes the 1DSFM averaging instance.
+
+        Args:
+            robust_measurement_noise: Whether to use a robust noise model for the measurements, defaults to true.
+        """
+        super().__init__(robust_measurement_noise)
 
         self._max_1dsfm_projection_directions = MAX_PROJECTION_DIRECTIONS
         self._outlier_weight_threshold = OUTLIER_WEIGHT_THRESHOLD
@@ -48,7 +53,6 @@ class TranslationAveraging1DSFM(TranslationAveragingBase):
         i2Ui1_dict: Dict[Tuple[int, int], Optional[Unit3]],
         wRi_list: List[Optional[Rot3]],
         scale_factor: float = 1.0,
-        robust_measurement_noise: bool = True,
         gt_wTi_list: Optional[List[Optional[Pose3]]] = None,
     ) -> Tuple[List[Optional[Point3]], Optional[GtsfmMetricsGroup]]:
         """Run the translation averaging.
@@ -58,7 +62,6 @@ class TranslationAveraging1DSFM(TranslationAveragingBase):
             i2Ui1_dict: relative unit-translation as dictionary (i1, i2): i2Ui1
             wRi_list: global rotations for each camera pose in the world coordinates.
             scale_factor: non-negative global scaling factor.
-            robust_measurement_noise: Whether to use Huber noise model for the measurements, defaults to true.
             gt_wTi_list: ground truth poses for computing metrics.
 
         Returns:
@@ -68,7 +71,7 @@ class TranslationAveraging1DSFM(TranslationAveragingBase):
             A GtsfmMetricsGroup of 1DSfM metrics.
         """
         noise_model = gtsam.noiseModel.Isotropic.Sigma(NOISE_MODEL_DIMENSION, NOISE_MODEL_SIGMA)
-        if robust_measurement_noise:
+        if self._robust_measurement_noise:
             huber_loss = gtsam.noiseModel.mEstimator.Huber.Create(HUBER_LOSS_K)
             noise_model = gtsam.noiseModel.Robust.Create(huber_loss, noise_model)
 

--- a/gtsfm/averaging/translation/averaging_1dsfm.py
+++ b/gtsfm/averaging/translation/averaging_1dsfm.py
@@ -28,6 +28,7 @@ OUTLIER_WEIGHT_THRESHOLD = 0.1
 
 NOISE_MODEL_DIMENSION = 3  # chordal distances on Unit3
 NOISE_MODEL_SIGMA = 0.01
+HUBER_LOSS_K = 1.345 # default value from GTSAM
 
 MAX_INLIER_MEASUREMENT_ERROR_DEG = 5.0
 
@@ -65,8 +66,8 @@ class TranslationAveraging1DSFM(TranslationAveragingBase):
             A GtsfmMetricsGroup of 1DSfM metrics.
         """
         noise_model = gtsam.noiseModel.Isotropic.Sigma(NOISE_MODEL_DIMENSION, NOISE_MODEL_SIGMA)
-        huber = gtsam.noiseModel.mEstimator.Huber.Create(1.345)
-        robust_noise_model = gtsam.noiseModel.Robust.Create(huber, noise_model) 
+        huber_loss = gtsam.noiseModel.mEstimator.Huber.Create(HUBER_LOSS_K)
+        robust_noise_model = gtsam.noiseModel.Robust.Create(huber_loss, noise_model) 
 
         # Note: all measurements are relative translation directions in the
         # world frame.

--- a/gtsfm/averaging/translation/averaging_1dsfm.py
+++ b/gtsfm/averaging/translation/averaging_1dsfm.py
@@ -65,6 +65,8 @@ class TranslationAveraging1DSFM(TranslationAveragingBase):
             A GtsfmMetricsGroup of 1DSfM metrics.
         """
         noise_model = gtsam.noiseModel.Isotropic.Sigma(NOISE_MODEL_DIMENSION, NOISE_MODEL_SIGMA)
+        huber = gtsam.noiseModel.mEstimator.Huber.Create(1.345)
+        robust_noise_model = gtsam.noiseModel.Robust.Create(huber, noise_model) 
 
         # Note: all measurements are relative translation directions in the
         # world frame.
@@ -74,7 +76,7 @@ class TranslationAveraging1DSFM(TranslationAveragingBase):
         for (i1, i2), i2Ui1 in i2Ui1_dict.items():
             if i2Ui1 is not None and wRi_list[i2] is not None:
                 w_i2Ui1_measurements.append(
-                    BinaryMeasurementUnit3(i2, i1, Unit3(wRi_list[i2].rotate(i2Ui1.point3())), noise_model)
+                    BinaryMeasurementUnit3(i2, i1, Unit3(wRi_list[i2].rotate(i2Ui1.point3())), robust_noise_model)
                 )
 
         # sample indices to be used as projection directions

--- a/gtsfm/averaging/translation/averaging_1dsfm.py
+++ b/gtsfm/averaging/translation/averaging_1dsfm.py
@@ -28,7 +28,7 @@ OUTLIER_WEIGHT_THRESHOLD = 0.1
 
 NOISE_MODEL_DIMENSION = 3  # chordal distances on Unit3
 NOISE_MODEL_SIGMA = 0.01
-HUBER_LOSS_K = 1.345 # default value from GTSAM
+HUBER_LOSS_K = 1.345       # default value from GTSAM
 
 MAX_INLIER_MEASUREMENT_ERROR_DEG = 5.0
 

--- a/gtsfm/averaging/translation/translation_averaging_base.py
+++ b/gtsfm/averaging/translation/translation_averaging_base.py
@@ -26,6 +26,7 @@ class TranslationAveragingBase(metaclass=abc.ABCMeta):
         i2Ui1_dict: Dict[Tuple[int, int], Optional[Unit3]],
         wRi_list: List[Optional[Rot3]],
         scale_factor: float = 1.0,
+        robust_measurement_noise: bool = True,
         gt_wTi_list: Optional[List[Optional[Pose3]]] = None,
     ) -> Tuple[List[Optional[Point3]], Optional[GtsfmMetricsGroup]]:
         """Run the translation averaging.
@@ -35,6 +36,8 @@ class TranslationAveragingBase(metaclass=abc.ABCMeta):
             i2Ui1_dict: relative unit-trans as dictionary (i1, i2): i2Ui1.
             wRi_list: global rotations for each camera pose in the world coordinates.
             scale_factor: non-negative global scaling factor.
+            robust_measurement_noise: Whether to use a robust noise model for the measurements, defaults to true.
+            gt_wTi_list: List of ground truth poses (wTi) for computing metrics.
 
         Returns:
             Global translation wti for each camera pose. The number of entries in the list is `num_images`. The list
@@ -48,6 +51,7 @@ class TranslationAveragingBase(metaclass=abc.ABCMeta):
         i2Ui1_graph: Delayed,
         wRi_graph: Delayed,
         scale_factor: float = 1.0,
+        robust_measurement_noise: bool = True,
         gt_wTi_graph: Optional[Delayed] = None,
     ) -> Delayed:
         """Create the computation graph for performing translation averaging.
@@ -57,7 +61,8 @@ class TranslationAveragingBase(metaclass=abc.ABCMeta):
             i2Ui1_graph: dictionary of relative unit translations as a delayed task.
             wRi_graph: list of global rotations wrapped up in Delayed.
             scale_factor: non-negative global scaling factor.
-            gt_poses_graph: List of ground truth poses (wTi) wrapped as Delayed for computing metrics.
+            robust_measurement_noise: Whether to use a robust noise model for the measurements, defaults to true.
+            gt_wTi_graph: List of ground truth poses (wTi) wrapped as Delayed for computing metrics.
 
         Returns:
             Global unit translations wrapped as Delayed.

--- a/gtsfm/averaging/translation/translation_averaging_base.py
+++ b/gtsfm/averaging/translation/translation_averaging_base.py
@@ -18,6 +18,14 @@ class TranslationAveragingBase(metaclass=abc.ABCMeta):
     This class generates global unit translation estimates from pairwise relative unit translation and global rotations.
     """
 
+    def __init__(self, robust_measurement_noise: bool = True) -> None:
+        """Initializes the translation averaging.
+
+        Args:
+            robust_measurement_noise: Whether to use a robust noise model for the measurements, defaults to true.
+        """
+        self._robust_measurement_noise = robust_measurement_noise
+
     # ignored-abstractmethod
     @abc.abstractmethod
     def run(
@@ -26,7 +34,6 @@ class TranslationAveragingBase(metaclass=abc.ABCMeta):
         i2Ui1_dict: Dict[Tuple[int, int], Optional[Unit3]],
         wRi_list: List[Optional[Rot3]],
         scale_factor: float = 1.0,
-        robust_measurement_noise: bool = True,
         gt_wTi_list: Optional[List[Optional[Pose3]]] = None,
     ) -> Tuple[List[Optional[Point3]], Optional[GtsfmMetricsGroup]]:
         """Run the translation averaging.
@@ -36,7 +43,6 @@ class TranslationAveragingBase(metaclass=abc.ABCMeta):
             i2Ui1_dict: relative unit-trans as dictionary (i1, i2): i2Ui1.
             wRi_list: global rotations for each camera pose in the world coordinates.
             scale_factor: non-negative global scaling factor.
-            robust_measurement_noise: Whether to use a robust noise model for the measurements, defaults to true.
             gt_wTi_list: List of ground truth poses (wTi) for computing metrics.
 
         Returns:
@@ -51,7 +57,6 @@ class TranslationAveragingBase(metaclass=abc.ABCMeta):
         i2Ui1_graph: Delayed,
         wRi_graph: Delayed,
         scale_factor: float = 1.0,
-        robust_measurement_noise: bool = True,
         gt_wTi_graph: Optional[Delayed] = None,
     ) -> Delayed:
         """Create the computation graph for performing translation averaging.
@@ -61,7 +66,6 @@ class TranslationAveragingBase(metaclass=abc.ABCMeta):
             i2Ui1_graph: dictionary of relative unit translations as a delayed task.
             wRi_graph: list of global rotations wrapped up in Delayed.
             scale_factor: non-negative global scaling factor.
-            robust_measurement_noise: Whether to use a robust noise model for the measurements, defaults to true.
             gt_wTi_graph: List of ground truth poses (wTi) wrapped as Delayed for computing metrics.
 
         Returns:

--- a/gtsfm/configs/deep_front_end.yaml
+++ b/gtsfm/configs/deep_front_end.yaml
@@ -33,6 +33,7 @@ SceneOptimizer:
 
     trans_avg_module:
       _target_: gtsfm.averaging.translation.averaging_1dsfm.TranslationAveraging1DSFM
+      robust_measurement_noise: True
 
     data_association_module:
       _target_: gtsfm.data_association.data_assoc.DataAssociation

--- a/gtsfm/configs/sift_front_end.yaml
+++ b/gtsfm/configs/sift_front_end.yaml
@@ -32,6 +32,7 @@ SceneOptimizer:
 
     trans_avg_module:
       _target_: gtsfm.averaging.translation.averaging_1dsfm.TranslationAveraging1DSFM
+      robust_measurement_noise: True
 
     data_association_module:
       _target_: gtsfm.data_association.data_assoc.DataAssociation


### PR DESCRIPTION
The metrics on skydio-32 show a clear improvement: 

Before the change:

|Metric | Value|
|---|---|
|mean_translation_angle_error_deg | 16.2499|
|mean_translation_error_distance | 0.98776 |

After the change:

|Metric | Value|
|---|---|
|mean_translation_angle_error_deg | 10.3671|
|mean_translation_error_distance | 0.546729 |

There are also small improvements after bundle adjustment. The improvement is similar on skydio-8, not too significant on door. 
I see from the plots that the inlier errors significantly decrease, but large outliers are not quite affected, which is expected.  

[CI run for plots](https://github.com/borglab/gtsfm/actions/runs/1223467854)