### PR TITLE
Resize images in base loader

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -66,7 +66,8 @@ jobs:
         run: |
           python gtsfm/runner/run_scene_optimizer.py \
             --dataset_root tests/data/set1_lund_door \
-            --config_name ${{ matrix.config }}.yaml
+            --config_name ${{ matrix.config }}.yaml \
+            --max_resolution 1296
       - name: Archive door dataset metrics
         uses: actions/upload-artifact@v2
         with:

--- a/gtsfm/loader/argoverse_dataset_loader.py
+++ b/gtsfm/loader/argoverse_dataset_loader.py
@@ -38,8 +38,10 @@ class ArgoverseDatasetLoader(LoaderBase):
             log_id: unique ID of vehicle log
             stride: sampling rate, e.g. every 2 images, every 4 images, etc.
             max_num_imgs: number of images to load (starting from beginning of log sequence)
-            max_resolution: integer representing maximum length of image's short side
-               e.g. for 1080p (1920 x 1080), max_resolution would be 1080
+            max_resolution: integer representing maximum length of image's short side, i.e.
+               the smaller of the height/width of the image. e.g. for 1080p (1920 x 1080),
+               max_resolution would be 1080. If the image resolution max(height, width) is
+               greater than the max_resolution, it will be downsampled to match the max_resolution.
         """
         super().__init__(max_resolution)
         self._log_id = log_id

--- a/gtsfm/loader/argoverse_dataset_loader.py
+++ b/gtsfm/loader/argoverse_dataset_loader.py
@@ -73,10 +73,6 @@ class ArgoverseDatasetLoader(LoaderBase):
         self._world_pose = Pose3(Rot3(), np.zeros((3, 1)))
         self._world_pose = self.get_camera_pose(0)
 
-        # call the BaseLoader's constructor, which will compute a re-scaling factor for all images
-        # and for all intrinsics, using the desired image resolution for inference.
-        super().__init__()
-
     def load_camera_calibration(self, log_id: str, camera_name: str) -> None:
         """Load extrinsics and intrinsics from disk."""
         calib_data = self._dl.get_log_calibration_data(log_id)

--- a/gtsfm/loader/argoverse_dataset_loader.py
+++ b/gtsfm/loader/argoverse_dataset_loader.py
@@ -30,6 +30,7 @@ class ArgoverseDatasetLoader(LoaderBase):
         max_num_imgs: int = 20,
         max_lookahead_sec: float = 2,
         camera_name: str = "ring_front_center",
+        max_resolution: int = 760,
     ) -> None:
         """Select the image paths and their corresponding timestamps for images to feed to GTSFM.
         Args:
@@ -37,8 +38,11 @@ class ArgoverseDatasetLoader(LoaderBase):
             log_id: unique ID of vehicle log
             stride: sampling rate, e.g. every 2 images, every 4 images, etc.
             max_num_imgs: number of images to load (starting from beginning of log sequence)
+            max_resolution: integer representing maximum length of image's short side
+               e.g. for 1080p (1920 x 1080), max_resolution would be 1080
         """
         self._log_id = log_id
+        self._max_resolution = max_resolution
         self._dl = SimpleArgoverseTrackingDataLoader(data_dir=dataset_dir, labels_dir=dataset_dir)
         self.load_camera_calibration(log_id, camera_name)
 

--- a/gtsfm/loader/argoverse_dataset_loader.py
+++ b/gtsfm/loader/argoverse_dataset_loader.py
@@ -41,8 +41,8 @@ class ArgoverseDatasetLoader(LoaderBase):
             max_resolution: integer representing maximum length of image's short side
                e.g. for 1080p (1920 x 1080), max_resolution would be 1080
         """
+        super().__init__(max_resolution)
         self._log_id = log_id
-        self._max_resolution = max_resolution
         self._dl = SimpleArgoverseTrackingDataLoader(data_dir=dataset_dir, labels_dir=dataset_dir)
         self.load_camera_calibration(log_id, camera_name)
 

--- a/gtsfm/loader/argoverse_dataset_loader.py
+++ b/gtsfm/loader/argoverse_dataset_loader.py
@@ -73,6 +73,10 @@ class ArgoverseDatasetLoader(LoaderBase):
         self._world_pose = Pose3(Rot3(), np.zeros((3, 1)))
         self._world_pose = self.get_camera_pose(0)
 
+        # call the BaseLoader's constructor, which will compute a re-scaling factor for all images
+        # and for all intrinsics, using the desired image resolution for inference.
+        super().__init__()
+
     def load_camera_calibration(self, log_id: str, camera_name: str) -> None:
         """Load extrinsics and intrinsics from disk."""
         calib_data = self._dl.get_log_calibration_data(log_id)

--- a/gtsfm/loader/argoverse_dataset_loader.py
+++ b/gtsfm/loader/argoverse_dataset_loader.py
@@ -95,8 +95,8 @@ class ArgoverseDatasetLoader(LoaderBase):
         """
         return len(self._image_paths)
 
-    def get_image(self, index: int) -> Image:
-        """Get the image at the given index.
+    def get_image_native_resolution(self, index: int) -> Image:
+        """Get the image at the given index, at native resolution.
 
         Args:
             index: the index to fetch.
@@ -113,8 +113,8 @@ class ArgoverseDatasetLoader(LoaderBase):
 
         return io_utils.load_image(self._image_paths[index])
 
-    def get_camera_intrinsics(self, index: int) -> Optional[Cal3Bundler]:
-        """Get the camera intrinsics at the given index.
+    def get_camera_intrinsics_native_resolution(self, index: int) -> Cal3Bundler:
+        """Get the camera intrinsics at the given index, for images at the native resolution of dataset.
 
         Args:
             the index to fetch.

--- a/gtsfm/loader/argoverse_dataset_loader.py
+++ b/gtsfm/loader/argoverse_dataset_loader.py
@@ -99,8 +99,8 @@ class ArgoverseDatasetLoader(LoaderBase):
         """
         return len(self._image_paths)
 
-    def get_image_native_resolution(self, index: int) -> Image:
-        """Get the image at the given index, at native resolution.
+    def get_image_full_res(self, index: int) -> Image:
+        """Get the image at the given index, at full resolution.
 
         Args:
             index: the index to fetch.
@@ -117,8 +117,8 @@ class ArgoverseDatasetLoader(LoaderBase):
 
         return io_utils.load_image(self._image_paths[index])
 
-    def get_camera_intrinsics_native_resolution(self, index: int) -> Cal3Bundler:
-        """Get the camera intrinsics at the given index, for images at the native resolution of dataset.
+    def get_camera_intrinsics_full_res(self, index: int) -> Cal3Bundler:
+        """Get the camera intrinsics at the given index, valid for a full-resolution image.
 
         Args:
             the index to fetch.

--- a/gtsfm/loader/astronet_loader.py
+++ b/gtsfm/loader/astronet_loader.py
@@ -36,6 +36,7 @@ class AstronetLoader(LoaderBase):
         use_gt_extrinsics: bool = True,
         use_gt_sfmtracks: bool = False,
         max_frame_lookahead: int = 2,
+        max_resolution: int = 760,
     ) -> None:
         """Initialize loader from a specified segment directory (data_dir) on disk.
 
@@ -55,6 +56,8 @@ class AstronetLoader(LoaderBase):
             max_frame_lookahead (optional): maximum number of consecutive frames to consider for
                 matching/co-visibility. Any value of max_frame_lookahead less than the size of
                 the dataset assumes data is sequentially captured.
+            max_resolution: integer representing maximum length of image's short side
+               e.g. for 1080p (1920 x 1080), max_resolution would be 1080
 
         Raises:
             FileNotFoundError if `data_dir` doesn't exist or image path does not exist.
@@ -63,6 +66,7 @@ class AstronetLoader(LoaderBase):
         self._use_gt_extrinsics = use_gt_extrinsics
         self._use_gt_sfmtracks = use_gt_sfmtracks
         self._max_frame_lookahead = max_frame_lookahead
+        self._max_resolution = max_resolution
 
         # Use COLMAP model reader to load data and convert to GTSfM format.
         if not Path(data_dir).exists():

--- a/gtsfm/loader/astronet_loader.py
+++ b/gtsfm/loader/astronet_loader.py
@@ -63,10 +63,10 @@ class AstronetLoader(LoaderBase):
             FileNotFoundError if `data_dir` doesn't exist or image path does not exist.
             RuntimeError if ground truth camera calibrations not provided.
         """
+        super().__init__(max_resolution)
         self._use_gt_extrinsics = use_gt_extrinsics
         self._use_gt_sfmtracks = use_gt_sfmtracks
         self._max_frame_lookahead = max_frame_lookahead
-        self._max_resolution = max_resolution
 
         # Use COLMAP model reader to load data and convert to GTSfM format.
         if not Path(data_dir).exists():

--- a/gtsfm/loader/astronet_loader.py
+++ b/gtsfm/loader/astronet_loader.py
@@ -56,8 +56,10 @@ class AstronetLoader(LoaderBase):
             max_frame_lookahead (optional): maximum number of consecutive frames to consider for
                 matching/co-visibility. Any value of max_frame_lookahead less than the size of
                 the dataset assumes data is sequentially captured.
-            max_resolution: integer representing maximum length of image's short side
-               e.g. for 1080p (1920 x 1080), max_resolution would be 1080
+            max_resolution: integer representing maximum length of image's short side, i.e.
+               the smaller of the height/width of the image. e.g. for 1080p (1920 x 1080),
+               max_resolution would be 1080. If the image resolution max(height, width) is
+               greater than the max_resolution, it will be downsampled to match the max_resolution.
 
         Raises:
             FileNotFoundError if `data_dir` doesn't exist or image path does not exist.

--- a/gtsfm/loader/astronet_loader.py
+++ b/gtsfm/loader/astronet_loader.py
@@ -36,7 +36,7 @@ class AstronetLoader(LoaderBase):
         use_gt_extrinsics: bool = True,
         use_gt_sfmtracks: bool = False,
         max_frame_lookahead: int = 2,
-        max_resolution: int = 760,
+        max_resolution: int = 1024,
     ) -> None:
         """Initialize loader from a specified segment directory (data_dir) on disk.
 

--- a/gtsfm/loader/astronet_loader.py
+++ b/gtsfm/loader/astronet_loader.py
@@ -99,10 +99,6 @@ class AstronetLoader(LoaderBase):
         self._num_imgs = len(self._image_paths)
         logger.info("AstroNet loader found and loaded %d images and %d tracks.", self._num_imgs, self.num_sfmtracks)
 
-        # call the BaseLoader's constructor, which will compute a re-scaling factor for all images
-        # and for all intrinsics, using the desired image resolution for inference.
-        super().__init__()
-
     @staticmethod
     def colmap2gtsfm(
         cameras: Dict[int, ColmapCamera],

--- a/gtsfm/loader/astronet_loader.py
+++ b/gtsfm/loader/astronet_loader.py
@@ -157,8 +157,8 @@ class AstronetLoader(LoaderBase):
         """
         return self._num_imgs
 
-    def get_image_native_resolution(self, index: int) -> Image:
-        """Get the image at the given index, at native resolution.
+    def get_image_full_res(self, index: int) -> Image:
+        """Get the image at the given index, at full resolution.
 
         Args:
             index: the index to fetch.
@@ -175,8 +175,8 @@ class AstronetLoader(LoaderBase):
         img = io_utils.load_image(self._image_paths[index])
         return img
 
-    def get_camera_intrinsics_native_resolution(self, index: int) -> Cal3Bundler:
-        """Get the camera intrinsics at the given index, for images at the native resolution of dataset.
+    def get_camera_intrinsics_full_res(self, index: int) -> Cal3Bundler:
+        """Get the camera intrinsics at the given index, valid for a full-resolution image.
 
         Args:
             the index to fetch.

--- a/gtsfm/loader/astronet_loader.py
+++ b/gtsfm/loader/astronet_loader.py
@@ -153,8 +153,8 @@ class AstronetLoader(LoaderBase):
         """
         return self._num_imgs
 
-    def get_image(self, index: int) -> Image:
-        """Get the image at the given index.
+    def get_image_native_resolution(self, index: int) -> Image:
+        """Get the image at the given index, at native resolution.
 
         Args:
             index: the index to fetch.
@@ -171,8 +171,8 @@ class AstronetLoader(LoaderBase):
         img = io_utils.load_image(self._image_paths[index])
         return img
 
-    def get_camera_intrinsics(self, index: int) -> Cal3Bundler:
-        """Get the camera intrinsics at the given index.
+    def get_camera_intrinsics_native_resolution(self, index: int) -> Cal3Bundler:
+        """Get the camera intrinsics at the given index, for images at the native resolution of dataset.
 
         Args:
             the index to fetch.

--- a/gtsfm/loader/astronet_loader.py
+++ b/gtsfm/loader/astronet_loader.py
@@ -99,6 +99,10 @@ class AstronetLoader(LoaderBase):
         self._num_imgs = len(self._image_paths)
         logger.info("AstroNet loader found and loaded %d images and %d tracks.", self._num_imgs, self.num_sfmtracks)
 
+        # call the BaseLoader's constructor, which will compute a re-scaling factor for all images
+        # and for all intrinsics, using the desired image resolution for inference.
+        super().__init__()
+
     @staticmethod
     def colmap2gtsfm(
         cameras: Dict[int, ColmapCamera],

--- a/gtsfm/loader/colmap_loader.py
+++ b/gtsfm/loader/colmap_loader.py
@@ -63,10 +63,10 @@ class ColmapLoader(LoaderBase):
             max_resolution: integer representing maximum length of image's short side
                e.g. for 1080p (1920 x 1080), max_resolution would be 1080
         """
+        super().__init__(max_resolution)
         self._use_gt_intrinsics = use_gt_intrinsics
         self._use_gt_extrinsics = use_gt_extrinsics
         self._max_frame_lookahead = max_frame_lookahead
-        self._max_resolution = max_resolution
 
         self._wTi_list, img_fnames = io_utils.read_images_txt(fpath=os.path.join(colmap_files_dirpath, "images.txt"))
         self._calibrations = io_utils.read_cameras_txt(fpath=os.path.join(colmap_files_dirpath, "cameras.txt"))

--- a/gtsfm/loader/colmap_loader.py
+++ b/gtsfm/loader/colmap_loader.py
@@ -120,7 +120,7 @@ class ColmapLoader(LoaderBase):
         return img
 
     def get_camera_intrinsics_native_resolution(self, index: int) -> Cal3Bundler:
-        """Get the camera intrinsics at the given index.
+        """Get the camera intrinsics at the given index, for images at the native resolution of dataset.
 
         Args:
             the index to fetch.

--- a/gtsfm/loader/colmap_loader.py
+++ b/gtsfm/loader/colmap_loader.py
@@ -60,8 +60,10 @@ class ColmapLoader(LoaderBase):
             max_frame_lookahead: maximum number of consecutive frames to consider for
                 matching/co-visibility. Any value of max_frame_lookahead less than the size of
                 the dataset assumes data is sequentially captured
-            max_resolution: integer representing maximum length of image's short side
-               e.g. for 1080p (1920 x 1080), max_resolution would be 1080
+            max_resolution: integer representing maximum length of image's short side, i.e.
+               the smaller of the height/width of the image. e.g. for 1080p (1920 x 1080),
+               max_resolution would be 1080. If the image resolution max(height, width) is
+               greater than the max_resolution, it will be downsampled to match the max_resolution.
         """
         super().__init__(max_resolution)
         self._use_gt_intrinsics = use_gt_intrinsics

--- a/gtsfm/loader/colmap_loader.py
+++ b/gtsfm/loader/colmap_loader.py
@@ -91,10 +91,6 @@ class ColmapLoader(LoaderBase):
         self._num_imgs = len(self._image_paths)
         logger.info("Colmap image loader found and loaded %d images", self._num_imgs)
 
-        # call the BaseLoader's constructor, which will compute a re-scaling factor for all images
-        # and for all intrinsics, using the desired image resolution for inference.
-        super().__init__()
-
     def __len__(self) -> int:
         """The number of images in the dataset.
 

--- a/gtsfm/loader/colmap_loader.py
+++ b/gtsfm/loader/colmap_loader.py
@@ -117,7 +117,7 @@ class ColmapLoader(LoaderBase):
         img = io_utils.load_image(self._image_paths[index])
         return img
 
-    def get_camera_intrinsics_full_res(self, index: int) -> Cal3Bundler:
+    def get_camera_intrinsics_full_res(self, index: int) -> Optional[Cal3Bundler]:
         """Get the camera intrinsics at the given index, valid for a full-resolution image.
 
         Args:

--- a/gtsfm/loader/colmap_loader.py
+++ b/gtsfm/loader/colmap_loader.py
@@ -91,6 +91,8 @@ class ColmapLoader(LoaderBase):
         self._num_imgs = len(self._image_paths)
         logger.info("Colmap image loader found and loaded %d images", self._num_imgs)
 
+        # call the BaseLoader's constructor, which will compute a re-scaling factor for all images
+        # and for all intrinsics, using the desired image resolution for inference.
         super().__init__()
 
     def __len__(self) -> int:

--- a/gtsfm/loader/colmap_loader.py
+++ b/gtsfm/loader/colmap_loader.py
@@ -103,8 +103,8 @@ class ColmapLoader(LoaderBase):
         """
         return self._num_imgs
 
-    def get_image_native_resolution(self, index: int) -> Image:
-        """Get the image at the given index, at native resolution.
+    def get_image_full_res(self, index: int) -> Image:
+        """Get the image at the given index, at full resolution.
 
         Args:
             index: the index to fetch.
@@ -121,8 +121,8 @@ class ColmapLoader(LoaderBase):
         img = io_utils.load_image(self._image_paths[index])
         return img
 
-    def get_camera_intrinsics_native_resolution(self, index: int) -> Cal3Bundler:
-        """Get the camera intrinsics at the given index, for images at the native resolution of dataset.
+    def get_camera_intrinsics_full_res(self, index: int) -> Cal3Bundler:
+        """Get the camera intrinsics at the given index, valid for a full-resolution image.
 
         Args:
             the index to fetch.
@@ -136,7 +136,6 @@ class ColmapLoader(LoaderBase):
         if not self._use_gt_intrinsics:
             # get intrinsics from exif
             intrinsics = io_utils.load_image(self._image_paths[index]).get_intrinsics_from_exif()
-
         else:
             intrinsics = self._calibrations[index]
 

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -26,7 +26,7 @@ class LoaderBase(metaclass=abc.ABCMeta):
         Each loader implementation should set a `_max_resolution` attribute, that is
         used to determine how the camera intrinsics and images should be jointly rescaled.
         """
-        if not hasattr(self, '_max_resolution'):
+        if not hasattr(self, "_max_resolution"):
             raise RuntimeError("Each loader implementation must set the maximum image resolution for inference.")
 
         # read one image, to check if we need to downsample the images
@@ -39,7 +39,6 @@ class LoaderBase(metaclass=abc.ABCMeta):
             self._target_h,
             self._target_w,
         ) = img_utils.get_downsampling_factor_per_axis(sample_h, sample_w, self._max_resolution)
-
 
     # ignored-abstractmethod
     @abc.abstractmethod
@@ -103,7 +102,6 @@ class LoaderBase(metaclass=abc.ABCMeta):
             validation result.
         """
 
-
     def get_image(self, index: int) -> Image:
         """Get the image at the given index, for possibly resized image.
 
@@ -119,7 +117,6 @@ class LoaderBase(metaclass=abc.ABCMeta):
         img_native = self.get_image_native_resolution(index)
         resized_img = img_utils.resize_image(img_native, new_height=self._target_h, new_width=self._target_w)
         return resized_img
-
 
     def get_camera_intrinsics(self, index: int) -> Cal3Bundler:
         """Get the camera intrinsics at the given index, for possibly resized image.
@@ -139,8 +136,6 @@ class LoaderBase(metaclass=abc.ABCMeta):
             v0=intrinsics_native.py() * self._scale_v,
         )
         return rescaled_intrinsics
-
-
 
     def get_image_shape(self, idx: int) -> Tuple[int, int]:
         """Return a (H,W) tuple for each image"""

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -145,6 +145,8 @@ class LoaderBase(metaclass=abc.ABCMeta):
             intrinsics for the given camera.
         """
         intrinsics_full_res = self.get_camera_intrinsics_full_res(index)
+        if intrinsics_full_res is None:
+            raise ValueError(f"No intrinsics found for index {index}.")
 
         img_full_res = self.get_image_full_res(index)
         # no downsampling may be required, in which case scale_u and scale_v will be 1.0

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -30,6 +30,8 @@ class LoaderBase(metaclass=abc.ABCMeta):
             max_resolution: integer representing maximum length of image's short side
                e.g. for 1080p (1920 x 1080), max_resolution would be 1080
         """
+        if not isinstance(max_resolution, int):
+            raise ValueError("Maximum image resolution must be an integer argument.")
         self._max_resolution = max_resolution
 
     # ignored-abstractmethod

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -24,6 +24,14 @@ class LoaderBase(metaclass=abc.ABCMeta):
     The loader provides APIs to get an image, either directly or as a dask delayed task
     """
 
+    def __init__(self, max_resolution: int) -> None:
+        """
+        Args:
+            max_resolution: integer representing maximum length of image's short side
+               e.g. for 1080p (1920 x 1080), max_resolution would be 1080
+        """
+        self._max_resolution = max_resolution
+
     # ignored-abstractmethod
     @abc.abstractmethod
     def __len__(self) -> int:
@@ -102,9 +110,6 @@ class LoaderBase(metaclass=abc.ABCMeta):
                 allowed loader image resolution if the full-resolution images for a dataset
                 are too large.
         """
-        if not hasattr(self, "_max_resolution"):
-            raise RuntimeError("Each loader implementation must set the maximum image resolution for inference.")
-
         # no downsampling may be required, in which case target_h and target_w will be identical
         # to the full res height & width.
         img_full_res = self.get_image_full_res(index)
@@ -137,9 +142,6 @@ class LoaderBase(metaclass=abc.ABCMeta):
         Returns:
             intrinsics for the given camera.
         """
-        if not hasattr(self, "_max_resolution"):
-            raise RuntimeError("Each loader implementation must set the maximum image resolution for inference.")
-
         intrinsics_full_res = self.get_camera_intrinsics_full_res(index)
 
         img_full_res = self.get_image_full_res(index)

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -21,25 +21,6 @@ class LoaderBase(metaclass=abc.ABCMeta):
     The loader provides APIs to get an image, either directly or as a dask delayed task
     """
 
-    def __init__(self) -> None:
-        """
-        Each loader implementation should set a `_max_resolution` attribute, that is
-        used to determine how the camera intrinsics and images should be jointly rescaled.
-        """
-        if not hasattr(self, "_max_resolution"):
-            raise RuntimeError("Each loader implementation must set the maximum image resolution for inference.")
-
-        # read one image, to check if we need to downsample the images
-        img = io_utils.load_image(self._image_paths[0])
-        sample_h, sample_w = img.height, img.width
-        # no downsampling may be required, in which case scale_u and scale_v will be 1.0
-        (
-            self._scale_u,
-            self._scale_v,
-            self._target_h,
-            self._target_w,
-        ) = img_utils.get_downsampling_factor_per_axis(sample_h, sample_w, self._max_resolution)
-
     # ignored-abstractmethod
     @abc.abstractmethod
     def __len__(self) -> int:
@@ -52,9 +33,8 @@ class LoaderBase(metaclass=abc.ABCMeta):
 
     # ignored-abstractmethod
     @abc.abstractmethod
-    def get_image_native_resolution(self, index: int) -> Image:
-        """
-        Get the image at the given index, at native resolution.
+    def get_image_full_res(self, index: int) -> Image:
+        """Get the image at the given index, at full resolution.
 
         Args:
             index: the index to fetch.
@@ -68,8 +48,8 @@ class LoaderBase(metaclass=abc.ABCMeta):
 
     # ignored-abstractmethod
     @abc.abstractmethod
-    def get_camera_intrinsics_native_resolution(self, index: int) -> Optional[Cal3Bundler]:
-        """Get the camera intrinsics at the given index.
+    def get_camera_intrinsics_full_res(self, index: int) -> Optional[Cal3Bundler]:
+        """Get the camera intrinsics at the given index, valid for a full-resolution image.
 
         Args:
             the index to fetch.
@@ -103,7 +83,10 @@ class LoaderBase(metaclass=abc.ABCMeta):
         """
 
     def get_image(self, index: int) -> Image:
-        """Get the image at the given index, for possibly resized image.
+        """Get the image at the given index, satisfying a maximum image resolution constraint.
+
+        Determine how the camera intrinsics and images should be jointly rescaled based on desired img. resolution.
+        Each loader implementation should set a `_max_resolution` attribute.
 
         Args:
             index: the index to fetch.
@@ -112,14 +95,30 @@ class LoaderBase(metaclass=abc.ABCMeta):
             IndexError: if an out-of-bounds image index is requested.
 
         Returns:
-            Image: the image at the query index.
+            Image: the image at the query index. It will be resized to satisfy the maximum
+                allowed loader image resolution if the full-resolution images for a dataset
+                are too large.
         """
-        img_native = self.get_image_native_resolution(index)
-        resized_img = img_utils.resize_image(img_native, new_height=self._target_h, new_width=self._target_w)
+        if not hasattr(self, "_max_resolution"):
+            raise RuntimeError("Each loader implementation must set the maximum image resolution for inference.")
+
+        # no downsampling may be required, in which case target_h and target_w will be identical
+        # to the full res height & width.
+        img_full_res = self.get_image_full_res(index)
+        (
+            _,
+            scale_v,
+            target_h,
+            target_w,
+        ) = img_utils.get_downsampling_factor_per_axis(img_full_res.height, img_full_res.width, self._max_resolution)
+        resized_img = img_utils.resize_image(img_full_res, new_height=target_h, new_width=target_w)
         return resized_img
 
     def get_camera_intrinsics(self, index: int) -> Cal3Bundler:
-        """Get the camera intrinsics at the given index, for possibly resized image.
+        """Get the camera intrinsics at the given index, for a possibly resized image.
+
+        Determine how the camera intrinsics and images should be jointly rescaled based on desired img. resolution.
+        Each loader implementation should set a `_max_resolution` attribute.
 
         Args:
             the index to fetch.
@@ -127,13 +126,20 @@ class LoaderBase(metaclass=abc.ABCMeta):
         Returns:
             intrinsics for the given camera.
         """
-        intrinsics_native = self.get_camera_intrinsics_native_resolution(index)
+        if not hasattr(self, "_max_resolution"):
+            raise RuntimeError("Each loader implementation must set the maximum image resolution for inference.")
+
+        intrinsics_full_res = self.get_camera_intrinsics_full_res(index)
+
+        img_full_res = self.get_image_full_res(index)
+        # no downsampling may be required, in which case scale_u and scale_v will be 1.0
+        scale_u, scale_v, _, _ = img_utils.get_downsampling_factor_per_axis(img_full_res.height, img_full_res.width, self._max_resolution)
         rescaled_intrinsics = Cal3Bundler(
-            fx=intrinsics_native.fx() * self._scale_u,
+            fx=intrinsics_full_res.fx() * scale_u,
             k1=0.0,
             k2=0.0,
-            u0=intrinsics_native.px() * self._scale_u,
-            v0=intrinsics_native.py() * self._scale_v,
+            u0=intrinsics_full_res.px() * scale_u,
+            v0=intrinsics_full_res.py() * scale_v,
         )
         return rescaled_intrinsics
 

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -11,8 +11,11 @@ from dask.delayed import Delayed
 from gtsam import Cal3Bundler, Pose3
 
 import gtsfm.utils.images as img_utils
-import gtsfm.utils.io as io_utils
+import gtsfm.utils.logger as logger_utils
 from gtsfm.common.image import Image
+
+
+logger = logger_utils.get_logger()
 
 
 class LoaderBase(metaclass=abc.ABCMeta):
@@ -107,10 +110,18 @@ class LoaderBase(metaclass=abc.ABCMeta):
         img_full_res = self.get_image_full_res(index)
         (
             _,
-            scale_v,
+            _,
             target_h,
             target_w,
         ) = img_utils.get_downsampling_factor_per_axis(img_full_res.height, img_full_res.width, self._max_resolution)
+        logger.info(
+            "Image %d resized from (H,W)=(%d,%d) -> (%d,%d)",
+            index,
+            img_full_res.height,
+            img_full_res.width,
+            target_h,
+            target_w,
+        )
         resized_img = img_utils.resize_image(img_full_res, new_height=target_h, new_width=target_w)
         return resized_img
 
@@ -133,7 +144,9 @@ class LoaderBase(metaclass=abc.ABCMeta):
 
         img_full_res = self.get_image_full_res(index)
         # no downsampling may be required, in which case scale_u and scale_v will be 1.0
-        scale_u, scale_v, _, _ = img_utils.get_downsampling_factor_per_axis(img_full_res.height, img_full_res.width, self._max_resolution)
+        scale_u, scale_v, _, _ = img_utils.get_downsampling_factor_per_axis(
+            img_full_res.height, img_full_res.width, self._max_resolution
+        )
         rescaled_intrinsics = Cal3Bundler(
             fx=intrinsics_full_res.fx() * scale_u,
             k1=0.0,

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -10,6 +10,8 @@ import dask
 from dask.delayed import Delayed
 from gtsam import Cal3Bundler, Pose3
 
+import gtsfm.utils.images as img_utils
+import gtsfm.utils.io as io_utils
 from gtsfm.common.image import Image
 
 
@@ -18,6 +20,26 @@ class LoaderBase(metaclass=abc.ABCMeta):
 
     The loader provides APIs to get an image, either directly or as a dask delayed task
     """
+
+    def __init__(self) -> None:
+        """
+        Each loader implementation should set a `_max_resolution` attribute, that is
+        used to determine how the camera intrinsics and images should be jointly rescaled.
+        """
+        if not hasattr(self, '_max_resolution'):
+            raise RuntimeError("Each loader implementation must set the maximum image resolution for inference.")
+
+        # read one image, to check if we need to downsample the images
+        img = io_utils.load_image(self._image_paths[0])
+        sample_h, sample_w = img.height, img.width
+        # no downsampling may be required, in which case scale_u and scale_v will be 1.0
+        (
+            self._scale_u,
+            self._scale_v,
+            self._target_h,
+            self._target_w,
+        ) = img_utils.get_downsampling_factor_per_axis(sample_h, sample_w, self._max_resolution)
+
 
     # ignored-abstractmethod
     @abc.abstractmethod
@@ -31,9 +53,9 @@ class LoaderBase(metaclass=abc.ABCMeta):
 
     # ignored-abstractmethod
     @abc.abstractmethod
-    def get_image(self, index: int) -> Image:
+    def get_image_native_resolution(self, index: int) -> Image:
         """
-        Get the image at the given index.
+        Get the image at the given index, at native resolution.
 
         Args:
             index: the index to fetch.
@@ -47,7 +69,7 @@ class LoaderBase(metaclass=abc.ABCMeta):
 
     # ignored-abstractmethod
     @abc.abstractmethod
-    def get_camera_intrinsics(self, index: int) -> Optional[Cal3Bundler]:
+    def get_camera_intrinsics_native_resolution(self, index: int) -> Optional[Cal3Bundler]:
         """Get the camera intrinsics at the given index.
 
         Args:
@@ -80,6 +102,45 @@ class LoaderBase(metaclass=abc.ABCMeta):
         Returns:
             validation result.
         """
+
+
+    def get_image(self, index: int) -> Image:
+        """Get the image at the given index, for possibly resized image.
+
+        Args:
+            index: the index to fetch.
+
+        Raises:
+            IndexError: if an out-of-bounds image index is requested.
+
+        Returns:
+            Image: the image at the query index.
+        """
+        img_native = self.get_image_native_resolution(index)
+        resized_img = img_utils.resize_image(img_native, new_height=self._target_h, new_width=self._target_w)
+        return resized_img
+
+
+    def get_camera_intrinsics(self, index: int) -> Cal3Bundler:
+        """Get the camera intrinsics at the given index, for possibly resized image.
+
+        Args:
+            the index to fetch.
+
+        Returns:
+            intrinsics for the given camera.
+        """
+        intrinsics_native = self.get_camera_intrinsics_native_resolution(index)
+        rescaled_intrinsics = Cal3Bundler(
+            fx=intrinsics_native.fx() * self._scale_u,
+            k1=0.0,
+            k2=0.0,
+            u0=intrinsics_native.px() * self._scale_u,
+            v0=intrinsics_native.py() * self._scale_v,
+        )
+        return rescaled_intrinsics
+
+
 
     def get_image_shape(self, idx: int) -> Tuple[int, int]:
         """Return a (H,W) tuple for each image"""

--- a/gtsfm/loader/olsson_loader.py
+++ b/gtsfm/loader/olsson_loader.py
@@ -98,8 +98,8 @@ class OlssonLoader(LoaderBase):
         """
         return self._num_imgs
 
-    def get_image(self, index: int) -> Image:
-        """Get the image at the given index.
+    def get_image_native_resolution(self, index: int) -> Image:
+        """Get the image at the given index, at native resolution.
 
         Args:
             index: the index to fetch.
@@ -117,8 +117,8 @@ class OlssonLoader(LoaderBase):
         return io_utils.load_image(self._image_paths[index])
 
 
-    def get_camera_intrinsics(self, index: int) -> Cal3Bundler:
-        """Get the camera intrinsics at the given index.
+    def get_camera_intrinsics_native_resolution(self, index: int) -> Cal3Bundler:
+        """Get the camera intrinsics at the given index, for images at the native resolution of dataset.
 
         Args:
             the index to fetch.

--- a/gtsfm/loader/olsson_loader.py
+++ b/gtsfm/loader/olsson_loader.py
@@ -101,8 +101,8 @@ class OlssonLoader(LoaderBase):
         """
         return self._num_imgs
 
-    def get_image_native_resolution(self, index: int) -> Image:
-        """Get the image at the given index, at native resolution.
+    def get_image_full_res(self, index: int) -> Image:
+        """Get the image at the given index, at full resolution.
 
         Args:
             index: the index to fetch.
@@ -119,9 +119,8 @@ class OlssonLoader(LoaderBase):
 
         return io_utils.load_image(self._image_paths[index])
 
-
-    def get_camera_intrinsics_native_resolution(self, index: int) -> Cal3Bundler:
-        """Get the camera intrinsics at the given index, for images at the native resolution of dataset.
+    def get_camera_intrinsics_full_res(self, index: int) -> Cal3Bundler:
+        """Get the camera intrinsics at the given index, valid for a full-resolution image.
 
         Args:
             the index to fetch.

--- a/gtsfm/loader/olsson_loader.py
+++ b/gtsfm/loader/olsson_loader.py
@@ -115,7 +115,7 @@ class OlssonLoader(LoaderBase):
 
         return io_utils.load_image(self._image_paths[index])
 
-    def get_camera_intrinsics_full_res(self, index: int) -> Cal3Bundler:
+    def get_camera_intrinsics_full_res(self, index: int) -> Optional[Cal3Bundler]:
         """Get the camera intrinsics at the given index, valid for a full-resolution image.
 
         Args:

--- a/gtsfm/loader/olsson_loader.py
+++ b/gtsfm/loader/olsson_loader.py
@@ -89,6 +89,9 @@ class OlssonLoader(LoaderBase):
         iTw_list = [ Kinv @ M_list[i] for i in range(self._num_imgs)]
         self._wTi_list = [Pose3(Rot3(iTw[:3,:3]), iTw[:,3]).inverse() for iTw in iTw_list ]
 
+        # call the BaseLoader's constructor, which will compute a re-scaling factor for all images
+        # and for all intrinsics, using the desired image resolution for inference.
+        super().__init__()
 
     def __len__(self) -> int:
         """The number of images in the dataset.

--- a/gtsfm/loader/olsson_loader.py
+++ b/gtsfm/loader/olsson_loader.py
@@ -48,10 +48,10 @@ class OlssonLoader(LoaderBase):
             max_resolution: integer representing maximum length of image's short side
                e.g. for 1080p (1920 x 1080), max_resolution would be 1080
         """
+        super().__init__(max_resolution)
         self._use_gt_intrinsics = use_gt_intrinsics
         self._use_gt_extrinsics = use_gt_extrinsics
         self._max_frame_lookahead = max_frame_lookahead
-        self._max_resolution = max_resolution
 
         # fetch all the file names in /images folder
         search_path = os.path.join(folder, "images", f"*.{image_extension}")

--- a/gtsfm/loader/olsson_loader.py
+++ b/gtsfm/loader/olsson_loader.py
@@ -45,8 +45,10 @@ class OlssonLoader(LoaderBase):
             image_extension: file extension for the image files. Defaults to 'jpg'.
             use_gt_intrinsics: whether to use ground truth intrinsics
             use_gt_extrinsics: whether to use ground truth extrinsics
-            max_resolution: integer representing maximum length of image's short side
-               e.g. for 1080p (1920 x 1080), max_resolution would be 1080
+            max_resolution: integer representing maximum length of image's short side, i.e.
+               the smaller of the height/width of the image. e.g. for 1080p (1920 x 1080),
+               max_resolution would be 1080. If the image resolution max(height, width) is
+               greater than the max_resolution, it will be downsampled to match the max_resolution.
         """
         super().__init__(max_resolution)
         self._use_gt_intrinsics = use_gt_intrinsics

--- a/gtsfm/loader/olsson_loader.py
+++ b/gtsfm/loader/olsson_loader.py
@@ -89,10 +89,6 @@ class OlssonLoader(LoaderBase):
         iTw_list = [ Kinv @ M_list[i] for i in range(self._num_imgs)]
         self._wTi_list = [Pose3(Rot3(iTw[:3,:3]), iTw[:,3]).inverse() for iTw in iTw_list ]
 
-        # call the BaseLoader's constructor, which will compute a re-scaling factor for all images
-        # and for all intrinsics, using the desired image resolution for inference.
-        super().__init__()
-
     def __len__(self) -> int:
         """The number of images in the dataset.
 

--- a/gtsfm/loader/olsson_loader.py
+++ b/gtsfm/loader/olsson_loader.py
@@ -35,7 +35,8 @@ class OlssonLoader(LoaderBase):
         image_extension: str = "jpg",
         use_gt_intrinsics: bool = True,
         use_gt_extrinsics: bool = True,
-        max_frame_lookahead: int = 20
+        max_frame_lookahead: int = 20,
+        max_resolution: int = 760,
     ) -> None:
         """Initializes to load from a specified folder on disk.
 
@@ -44,10 +45,13 @@ class OlssonLoader(LoaderBase):
             image_extension: file extension for the image files. Defaults to 'jpg'.
             use_gt_intrinsics: whether to use ground truth intrinsics
             use_gt_extrinsics: whether to use ground truth extrinsics
+            max_resolution: integer representing maximum length of image's short side
+               e.g. for 1080p (1920 x 1080), max_resolution would be 1080
         """
         self._use_gt_intrinsics = use_gt_intrinsics
         self._use_gt_extrinsics = use_gt_extrinsics
         self._max_frame_lookahead = max_frame_lookahead
+        self._max_resolution = max_resolution
 
         # fetch all the file names in /images folder
         search_path = os.path.join(folder, "images", f"*.{image_extension}")

--- a/gtsfm/loader/yfcc_imb_loader.py
+++ b/gtsfm/loader/yfcc_imb_loader.py
@@ -21,16 +21,19 @@ class YfccImbLoader(LoaderBase):
     Code ref: https://github.com/vcg-uvic/image-matching-benchmark/blob/master/compute_stereo.py
     """
 
-    def __init__(self, folder: str, coviz_thresh: float = 0.1):
+    def __init__(self, folder: str, coviz_thresh: float = 0.1, max_resolution: int = 760) -> None:
         """Initializes the loader.
 
         Args:
             folder: the base folder of the dataset.
             coviz_thresh (optional): threshold for covisibility between two images to be considered a valid pair.
                                      Defaults to 0.1.
+            max_resolution: integer representing maximum length of image's short side
+               e.g. for 1080p (1920 x 1080), max_resolution would be 1080
         """
 
         self._folder = folder
+        self._max_resolution = max_resolution
 
         # load all the image pairs according to the covisibility threshold used
         # in IMB's reporting

--- a/gtsfm/loader/yfcc_imb_loader.py
+++ b/gtsfm/loader/yfcc_imb_loader.py
@@ -28,8 +28,10 @@ class YfccImbLoader(LoaderBase):
             folder: the base folder of the dataset.
             coviz_thresh (optional): threshold for covisibility between two images to be considered a valid pair.
                                      Defaults to 0.1.
-            max_resolution: integer representing maximum length of image's short side
-               e.g. for 1080p (1920 x 1080), max_resolution would be 1080
+            max_resolution: integer representing maximum length of image's short side, i.e.
+               the smaller of the height/width of the image. e.g. for 1080p (1920 x 1080),
+               max_resolution would be 1080. If the image resolution max(height, width) is
+               greater than the max_resolution, it will be downsampled to match the max_resolution.
         """
         super().__init__(max_resolution)
         self._folder = folder

--- a/gtsfm/loader/yfcc_imb_loader.py
+++ b/gtsfm/loader/yfcc_imb_loader.py
@@ -63,6 +63,10 @@ class YfccImbLoader(LoaderBase):
 
         self._cameras = self.__read_calibrations()  # self.__read_colmap_model()
 
+        # call the BaseLoader's constructor, which will compute a re-scaling factor for all images
+        # and for all intrinsics, using the desired image resolution for inference.
+        super().__init__()
+
     def __len__(self) -> int:
         """
         The number of images in the dataset.

--- a/gtsfm/loader/yfcc_imb_loader.py
+++ b/gtsfm/loader/yfcc_imb_loader.py
@@ -63,10 +63,6 @@ class YfccImbLoader(LoaderBase):
 
         self._cameras = self.__read_calibrations()  # self.__read_colmap_model()
 
-        # call the BaseLoader's constructor, which will compute a re-scaling factor for all images
-        # and for all intrinsics, using the desired image resolution for inference.
-        super().__init__()
-
     def __len__(self) -> int:
         """
         The number of images in the dataset.

--- a/gtsfm/loader/yfcc_imb_loader.py
+++ b/gtsfm/loader/yfcc_imb_loader.py
@@ -76,8 +76,8 @@ class YfccImbLoader(LoaderBase):
         """
         return len(self._image_names)
 
-    def get_image_native_resolution(self, index: int) -> Image:
-        """Get the image at the given index, at native resolution.
+    def get_image_full_res(self, index: int) -> Image:
+        """Get the image at the given index, at full resolution.
 
         Args:
             index: the index to fetch.
@@ -97,8 +97,8 @@ class YfccImbLoader(LoaderBase):
 
         return io_utils.load_image(file_name)
 
-    def get_camera_intrinsics_native_resolution(self, index: int) -> Cal3Bundler:
-        """Get the camera intrinsics at the given index, for images at the native resolution of dataset.
+    def get_camera_intrinsics_full_res(self, index: int) -> Cal3Bundler:
+        """Get the camera intrinsics at the given index, valid for a full-resolution image.
 
         Args:
             the index to fetch.

--- a/gtsfm/loader/yfcc_imb_loader.py
+++ b/gtsfm/loader/yfcc_imb_loader.py
@@ -72,9 +72,8 @@ class YfccImbLoader(LoaderBase):
         """
         return len(self._image_names)
 
-    def get_image(self, index: int) -> Image:
-        """
-        Get the image at the given index.
+    def get_image_native_resolution(self, index: int) -> Image:
+        """Get the image at the given index, at native resolution.
 
         Args:
             index: the index to fetch.
@@ -94,8 +93,8 @@ class YfccImbLoader(LoaderBase):
 
         return io_utils.load_image(file_name)
 
-    def get_camera_intrinsics(self, index: int) -> Optional[Cal3Bundler]:
-        """Get the camera intrinsics at the given index.
+    def get_camera_intrinsics_native_resolution(self, index: int) -> Cal3Bundler:
+        """Get the camera intrinsics at the given index, for images at the native resolution of dataset.
 
         Args:
             the index to fetch.

--- a/gtsfm/loader/yfcc_imb_loader.py
+++ b/gtsfm/loader/yfcc_imb_loader.py
@@ -31,9 +31,8 @@ class YfccImbLoader(LoaderBase):
             max_resolution: integer representing maximum length of image's short side
                e.g. for 1080p (1920 x 1080), max_resolution would be 1080
         """
-
+        super().__init__(max_resolution)
         self._folder = folder
-        self._max_resolution = max_resolution
 
         # load all the image pairs according to the covisibility threshold used
         # in IMB's reporting

--- a/gtsfm/runner/run_scene_optimizer.py
+++ b/gtsfm/runner/run_scene_optimizer.py
@@ -24,7 +24,10 @@ def run_scene_optimizer(args: argparse.Namespace) -> None:
         scene_optimizer: SceneOptimizer = instantiate(cfg.SceneOptimizer)
 
         loader = OlssonLoader(
-            args.dataset_root, image_extension=args.image_extension, max_frame_lookahead=args.max_frame_lookahead
+            args.dataset_root,
+            image_extension=args.image_extension,
+            max_frame_lookahead=args.max_frame_lookahead,
+            max_resolution=args.max_resolution,
         )
 
         sfm_result_graph = scene_optimizer.create_computation_graph(
@@ -56,16 +59,29 @@ if __name__ == "__main__":
         help="maximum number of consecutive frames to consider for matching/co-visibility",
     )
     parser.add_argument(
-        "--num_workers", type=int, default=1, help="Number of workers to start (processes, by default)",
+        "--num_workers",
+        type=int,
+        default=1,
+        help="Number of workers to start (processes, by default)",
     )
     parser.add_argument(
-        "--threads_per_worker", type=int, default=1, help="Number of threads per each worker",
+        "--threads_per_worker",
+        type=int,
+        default=1,
+        help="Number of threads per each worker",
     )
     parser.add_argument(
         "--config_name",
         type=str,
         default="sift_front_end.yaml",
         help="Choose sift_front_end.yaml or deep_front_end.yaml",
+    )
+    parser.add_argument(
+        "--max_resolution",
+        type=int,
+        default=760,
+        help="integer representing maximum length of image's short side"
+        " e.g. for 1080p (1920 x 1080), max_resolution would be 1080",
     )
     args = parser.parse_args()
 

--- a/gtsfm/runner/run_scene_optimizer_argoverse.py
+++ b/gtsfm/runner/run_scene_optimizer_argoverse.py
@@ -27,6 +27,7 @@ def run_scene_optimizer(args: argparse.Namespace) -> None:
             max_num_imgs=args.max_num_imgs,
             max_lookahead_sec=args.max_lookahead_sec,
             camera_name=args.camera_name,
+            max_resolution=args.max_resolution
         )
 
         sfm_result_graph = scene_optimizer.create_computation_graph(
@@ -105,6 +106,13 @@ if __name__ == "__main__":
         type=str,
         default="deep_front_end.yaml",
         help="Choose sift_front_end.yaml or deep_front_end.yaml",
+    )
+    parser.add_argument(
+        "--max_resolution",
+        type=int,
+        default=760,
+        help="integer representing maximum length of image's short side"
+        " e.g. for 1080p (1920 x 1080), max_resolution would be 1080",
     )
     args = parser.parse_args()
     logger.info(args)

--- a/gtsfm/runner/run_scene_optimizer_colmaploader.py
+++ b/gtsfm/runner/run_scene_optimizer_colmaploader.py
@@ -26,6 +26,7 @@ def run_scene_optimizer(args: argparse.Namespace) -> None:
             colmap_files_dirpath=args.colmap_files_dirpath,
             images_dir=args.images_dir,
             max_frame_lookahead=args.max_frame_lookahead,
+            max_resolution=args.max_resolution,
         )
 
         sfm_result_graph = scene_optimizer.create_computation_graph(
@@ -86,6 +87,12 @@ if __name__ == "__main__":
         default="deep_front_end.yaml",
         help="Choose sift_front_end.yaml or deep_front_end.yaml",
     )
-
+    parser.add_argument(
+        "--max_resolution",
+        type=int,
+        default=760,
+        help="integer representing maximum length of image's short side"
+        " e.g. for 1080p (1920 x 1080), max_resolution would be 1080",
+    )
     args = parser.parse_args()
     run_scene_optimizer(args)

--- a/tests/data_association/test_point3d_initializer.py
+++ b/tests/data_association/test_point3d_initializer.py
@@ -179,11 +179,12 @@ class TestPoint3dInitializer(unittest.TestCase):
         """Test the tracks of the door dataset using simple triangulation initialization. Using computed tracks with
         ground truth camera params.
 
-        Expecting failures on 2 tracks which have incorrect matches."""
+        Expecting failures on 2 tracks which have incorrect matches.
+        """
         with open(DOOR_TRACKS_PATH, "rb") as handle:
             tracks = pickle.load(handle)
 
-        loader = OlssonLoader(DOOR_DATASET_PATH, image_extension="JPG")
+        loader = OlssonLoader(DOOR_DATASET_PATH, image_extension="JPG", max_resolution=1296)
 
         camera_dict = {
             i: PinholeCameraCal3Bundler(loader.get_camera_pose(i), loader.get_camera_intrinsics(i))

--- a/tests/loader/test_argoverse_dataset_loader.py
+++ b/tests/loader/test_argoverse_dataset_loader.py
@@ -22,6 +22,7 @@ class TestArgoverseDatasetLoader(unittest.TestCase):
             max_num_imgs=2,
             max_lookahead_sec=50,
             camera_name="ring_front_center",
+            max_resolution=1200
         )
         assert len(self.loader)
 

--- a/tests/loader/test_colmap_loader.py
+++ b/tests/loader/test_colmap_loader.py
@@ -76,17 +76,19 @@ class TestColmapLoader(unittest.TestCase):
     def test_image_resolution(self) -> None:
         """Ensure that the image is downsampled properly to a max resolution of 500 px.
 
-        Note: native resolution is (1936, 1296) for (H,W)
+        Note: full resolution is (1936, 1296) for (H,W)
         """
-        assert self.loader._scale_u == 500.0 / 1296.0
-        assert np.isclose(self.loader._scale_v, 500.0 / 1296.0, atol=1e-4)
+        img0_full_res = self.loader.get_image_full_res(0)
+        assert img0.width == 1296
+        assert img0.height == 1936
 
-        assert self.loader._target_h == 747
-        assert self.loader._target_w == 500
+        img0 = self.loader.get_image(0)
 
-        # ensure that the aspect ratios match up to 3 decimal places
-        downsampled_aspect_ratio = self.loader._target_w / self.loader._target_h
-        assert np.isclose(downsampled_aspect_ratio, 1296 / 1936, atol=1e-3)
+        # scale_u is 500.0 / 1296.0
+        # scale_v is 500.0 / 1296.0
+        # downsampled aspect ratio is 1296 / 1936
+        assert img0.width == 500
+        assert img0.height == 747
 
     def test_get_image(self) -> None:
         """Ensure a downsampled image can be successfully provided."""

--- a/tests/loader/test_colmap_loader.py
+++ b/tests/loader/test_colmap_loader.py
@@ -79,8 +79,8 @@ class TestColmapLoader(unittest.TestCase):
         Note: full resolution is (1936, 1296) for (H,W)
         """
         img0_full_res = self.loader.get_image_full_res(0)
-        assert img0.width == 1296
-        assert img0.height == 1936
+        assert img0_full_res.width == 1296
+        assert img0_full_res.height == 1936
 
         img0 = self.loader.get_image(0)
 

--- a/tests/loader/test_olsson_loader.py
+++ b/tests/loader/test_olsson_loader.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import dask
 import numpy as np
+import pytest
 from gtsam import Cal3Bundler, Rot3, Pose3
 
 import gtsfm.utils.io as io_utils
@@ -112,10 +113,10 @@ class TestFolderLoader(unittest.TestCase):
         self.assertTrue(expected.equals(computed, 1e-3))
 
     def test_get_camera_intrinsics_missing(self) -> None:
-        """Tests getter for intrinsics when explicit numpy arrays are absent and we fall back on exif."""
+        """Tests getter for intrinsics when explicit numpy arrays are absent, exif is missing, and we raise an error."""
         loader = OlssonLoader(NO_EXIF_FOLDER, image_extension="JPG")
-        computed = loader.get_camera_intrinsics(5)
-        self.assertIsNone(computed)
+        with pytest.raises(ValueError):
+            computed = loader.get_camera_intrinsics(5)
 
     def test_create_computation_graph_for_images(self) -> None:
         """Tests the graph for loading all the images."""

--- a/tests/loader/test_olsson_loader.py
+++ b/tests/loader/test_olsson_loader.py
@@ -23,24 +23,24 @@ NO_EXIF_FOLDER = DATA_ROOT_PATH / "set4_lund_door_nointrinsics_noextrinsics_noex
 class TestFolderLoader(unittest.TestCase):
     """Unit tests for folder loader, which loads image from a folder on disk."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up the loader for the test."""
         super().setUp()
 
         self.loader = OlssonLoader(str(DEFAULT_FOLDER), image_extension="JPG")
 
-    def test_len(self):
+    def test_len(self) -> None:
         """Test the number of entries in the loader."""
 
         self.assertEqual(12, len(self.loader))
 
-    def test_get_image_valid_index(self):
+    def test_get_image_valid_index(self) -> None:
         """Tests that get_image works for all valid indices."""
 
         for idx in range(len(self.loader)):
             self.assertIsNotNone(self.loader.get_image(idx))
 
-    def test_get_image_invalid_index(self):
+    def test_get_image_invalid_index(self) -> None:
         """Test that get_image raises an exception on an invalid index."""
 
         # negative index
@@ -53,18 +53,18 @@ class TestFolderLoader(unittest.TestCase):
         with self.assertRaises(IndexError):
             self.loader.get_image(15)
 
-    def test_image_contents(self):
+    def test_image_contents(self) -> None:
         """Test the actual image which is being fetched by the loader at an index.
 
         This test's primary purpose is to check if the ordering of filename is being respected by the loader
         """
         index_to_test = 5
         file_path = DEFAULT_FOLDER / "images" / "DSC_0006.JPG"
-        loader_image = self.loader.get_image(index_to_test)
+        loader_image = self.loader.get_image_full_res(index_to_test)
         expected_image = io_utils.load_image(file_path)
         np.testing.assert_allclose(expected_image.value_array, loader_image.value_array)
 
-    def test_get_camera_pose_exists(self):
+    def test_get_camera_pose_exists(self) -> None:
         """Tests that the correct pose is fetched (present on disk)."""
         fetched_pose = self.loader.get_camera_pose(1)
 
@@ -86,7 +86,7 @@ class TestFolderLoader(unittest.TestCase):
         fetched_pose = loader.get_camera_pose(5)
         self.assertIsNone(fetched_pose)
 
-    def test_get_camera_intrinsics_explicit(self):
+    def test_get_camera_intrinsics_explicit(self) -> None:
         """Tests getter for intrinsics when explicit data.mat file with intrinsics are present on disk."""
         expected_fx = 2398.119
         expected_fy = 2393.952
@@ -95,29 +95,29 @@ class TestFolderLoader(unittest.TestCase):
         expected_px = 628.265
         expected_py = 932.382
 
-        computed = self.loader.get_camera_intrinsics(5)
+        computed = self.loader.get_camera_intrinsics_full_res(5)
         expected = Cal3Bundler(
             fx=expected_fx, k1=0, k2=0, u0=expected_px, v0=expected_py
         )
 
         self.assertTrue(expected.equals(computed, 1e-3))
 
-    def test_get_camera_intrinsics_exif(self):
+    def test_get_camera_intrinsics_exif(self) -> None:
         """Tests getter for intrinsics when explicit numpy arrays are absent and we fall back on exif."""
         loader = OlssonLoader(
             EXIF_FOLDER, image_extension="JPG", use_gt_intrinsics=False
         )
-        computed = loader.get_camera_intrinsics(5)
+        computed = loader.get_camera_intrinsics_full_res(5)
         expected = Cal3Bundler(fx=2378.983, k1=0, k2=0, u0=648.0, v0=968.0)
         self.assertTrue(expected.equals(computed, 1e-3))
 
-    def test_get_camera_intrinsics_missing(self):
+    def test_get_camera_intrinsics_missing(self) -> None:
         """Tests getter for intrinsics when explicit numpy arrays are absent and we fall back on exif."""
         loader = OlssonLoader(NO_EXIF_FOLDER, image_extension="JPG")
         computed = loader.get_camera_intrinsics(5)
         self.assertIsNone(computed)
 
-    def test_create_computation_graph_for_images(self):
+    def test_create_computation_graph_for_images(self) -> None:
         """Tests the graph for loading all the images."""
         image_graph = self.loader.create_computation_graph_for_images()
 
@@ -133,7 +133,7 @@ class TestFolderLoader(unittest.TestCase):
             results[7].value_array, self.loader.get_image(7).value_array
         )
 
-    def test_create_computation_graph_for_intrinsics(self):
+    def test_create_computation_graph_for_intrinsics(self) -> None:
         """Tests the graph for all intrinsics."""
 
         intrinsics_graph = self.loader.create_computation_graph_for_intrinsics()


### PR DESCRIPTION
Currently we try to run inference for all runners, except the COLMAP loader runner, at full image resolution. Like 2k or 4k. This is crazy and not feasible for datasets with 100s of images like palace-fine-arts-281.


This allows us to run `python gtsfm/runner/run_scene_optimizer.py` at a maximum image resolution.