### PR TITLE
Create controller to gradually relax problem strictness

### DIFF
--- a/gtsfm/averaging/rotation/cycle_consistency.py
+++ b/gtsfm/averaging/rotation/cycle_consistency.py
@@ -98,7 +98,7 @@ def compute_cycle_error(
     i2Ri1_dict: Dict[Tuple[int, int], Rot3],
     cycle_nodes: Tuple[int, int, int],
     two_view_reports_dict: Dict[Tuple[int, int], TwoViewEstimationReport],
-    verbose: bool = True,
+    verbose: bool = False,
 ) -> Tuple[float, Optional[float], Optional[float]]:
     """Compute the cycle error by the magnitude of the axis-angle rotation after composing 3 rotations.
 

--- a/gtsfm/runner/run_scene_optimizer_colmaploader.py
+++ b/gtsfm/runner/run_scene_optimizer_colmaploader.py
@@ -5,6 +5,7 @@ import hydra
 from dask.distributed import Client, LocalCluster, performance_report
 from hydra.utils import instantiate
 
+import gtsfm.utils.io as io_utils
 import gtsfm.utils.logger as logger_utils
 from gtsfm.common.gtsfm_data import GtsfmData
 from gtsfm.loader.colmap_loader import ColmapLoader
@@ -13,37 +14,81 @@ from gtsfm.scene_optimizer import SceneOptimizer
 logger = logger_utils.get_logger()
 
 
+# fmt: off
+# Successive relaxation threshold pairs -- from strictest to loosest
+# `inlier ratio` is the minimum allowed inlier ratio w.r.t. the estimated model
+NUM_INLIERS_THRESHOLDS      =  [200, 175, 150, 125, 100, 75,  50,   25, 15]
+MIN_INLIER_RATIOS_THRESHOLDS = [0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.1, 0.1, 0.1]
+# fmt: on
+
+
 def run_scene_optimizer(args: argparse.Namespace) -> None:
-    """ """
+    """We solve the problem at varying level of difficulties, starting at the strictest
+    setting, and gradually relaxing the problem until a sufficient number of inliers can be found.
+    As for measurements that are fed to the backend, we require three times the number of input
+    images, for sufficient redundancy in the graph.
+    """
+    # create dask client only once, and will be re-used for all relaxations
+    cluster = LocalCluster(n_workers=args.num_workers, threads_per_worker=args.threads_per_worker)
+
     start = time.time()
     with hydra.initialize_config_module(config_module="gtsfm.configs"):
         # config is relative to the gtsfm module
         cfg = hydra.compose(config_name=args.config_name)
 
         scene_optimizer: SceneOptimizer = instantiate(cfg.SceneOptimizer)
-
         loader = ColmapLoader(
             colmap_files_dirpath=args.colmap_files_dirpath,
             images_dir=args.images_dir,
             max_frame_lookahead=args.max_frame_lookahead,
         )
 
-        sfm_result_graph = scene_optimizer.create_computation_graph(
-            num_images=len(loader),
-            image_pair_indices=loader.get_valid_pairs(),
-            image_graph=loader.create_computation_graph_for_images(),
-            camera_intrinsics_graph=loader.create_computation_graph_for_intrinsics(),
-            image_shape_graph=loader.create_computation_graph_for_image_shapes(),
-            gt_pose_graph=loader.create_computation_graph_for_poses(),
-        )
+        # try to relax the problem repeatedly
+        for (num_inliers_required, min_allowed_inlier_ratio_est_model) in zip(
+            NUM_INLIERS_THRESHOLDS, MIN_INLIER_RATIOS_THRESHOLDS
+        ):
+            scene_optimizer.two_view_estimator.min_num_inliers_acceptance = num_inliers_required
+            scene_optimizer.two_view_estimator._verifier.min_allowed_inlier_ratio_est_model = (
+                min_allowed_inlier_ratio_est_model
+            )
 
-        # create dask client
-        cluster = LocalCluster(n_workers=args.num_workers, threads_per_worker=args.threads_per_worker)
+            logger.info("New threshold:  %d inliers", scene_optimizer.two_view_estimator.min_num_inliers_acceptance)
+            logger.info(
+                "New threshold: %.f inlier ratio",
+                scene_optimizer.two_view_estimator._verifier.min_allowed_inlier_ratio_est_model,
+            )
 
-        with Client(cluster), performance_report(filename="dask-report.html"):
-            sfm_result = sfm_result_graph.compute()
+            sfm_result_graph = scene_optimizer.create_computation_graph(
+                num_images=len(loader),
+                image_pair_indices=loader.get_valid_pairs(),
+                image_graph=loader.create_computation_graph_for_images(),
+                camera_intrinsics_graph=loader.create_computation_graph_for_intrinsics(),
+                image_shape_graph=loader.create_computation_graph_for_image_shapes(),
+                gt_pose_graph=loader.create_computation_graph_for_poses(),
+            )
 
-        assert isinstance(sfm_result, GtsfmData)
+            try:
+                with Client(cluster), performance_report(filename="dask-report.html"):
+                    sfm_result = sfm_result_graph.compute()
+                assert isinstance(sfm_result, GtsfmData)
+
+                # check for success
+                frontend_result = io_utils.read_json_file("result_metrics/cycle_consistent_frontend_summary.json")
+                num_backend_input_pairs = frontend_result["cycle_consistent_frontend_summary"]["num_valid_image_pairs"]
+                num_required_backend_input_pairs = 3 * len(loader)
+                if num_backend_input_pairs < num_required_backend_input_pairs:
+                    logger.info("Too few measurements at this threshold, will try relaxing the problem...")
+                    logger.info(
+                        f"Found only %d num_backend_input_pairs, needed %d",
+                        num_backend_input_pairs,
+                        num_required_backend_input_pairs,
+                    )
+                else:
+                    break
+
+            except Exception as e:
+                logger.exception("Failed")
+                print("Computation failed, will try relaxing the problem ...")
 
     end = time.time()
     duration_sec = end - start


### PR DESCRIPTION
Tries first with 200 required inliers and 0.6 require inlier ratio, and decreases this until we get to our current default.

Empirically requiring at least 3 * number of images in the dataset for # of backend measurements, to accept result.