### PR TITLE
Fix COLMAP extrinsics reading bug in ReactJS

### DIFF
--- a/rtf_vis_tool/src/Components/AllFrustums.js
+++ b/rtf_vis_tool/src/Components/AllFrustums.js
@@ -98,7 +98,8 @@ function AllFrustums() {
             const rotation_matrix = q.toMatrix(true);
             const rotation = nj.array(rotation_matrix);
             const translation = nj.array([tx,ty,tz]);
-            const wTc = new SE3(rotation, translation);
+            const cTw = new SE3(rotation, translation);
+            const wTc = cTw.inverse();
             var verts_worldframe = frustumObj.get_mesh_vertices_worldframe(wTc);
 
             finalFrustumsJSX.push(<Frustum 

--- a/rtf_vis_tool/src/Components/frustum_classes/se3.js
+++ b/rtf_vis_tool/src/Components/frustum_classes/se3.js
@@ -32,6 +32,10 @@ class SE3 {
             this.transform_matrix.set(row, 3, this.translation.get(row));
         }
     }
+    
+    inverse {
+     // to be implemented :-)
+    }
 
     transform_from(point) {
         /*Apply the SE3 transformation to the point.


### PR DESCRIPTION
COLMAP stores extrinsics cTw not world poses wTc
- Read incorrectly in React
- Read correctly in Python: https://github.com/borglab/gtsfm/blob/master/gtsfm/utils/io.py#L268

We should add a `.inverse()` method to our SE(3) class in ReactJS to make this a trivial one-line fix:
```python
def inverse(self) -> "SE3":
    return SE3(rotation=self.rotation.T, translation=self.rotation.T.dot(-self.translation))
```