### PR TITLE
Add a benchmark for Notre-Dame-20

### DIFF
--- a/.github/scripts/execute_single_benchmark.sh
+++ b/.github/scripts/execute_single_benchmark.sh
@@ -17,6 +17,8 @@ if [ "$DATASET_NAME" == "skydio-8" ]; then
   export GDRIVE_FILEID='1mmM1p_NpL7-pnf3iHWeWVKpsm1pcBoD5'
 elif [ "$DATASET_NAME" == "skydio-32" ]; then
   export GDRIVE_FILEID='1BQ6jp0DD3D9yhTnrDoEddzlMYT0RRH68'
+elif [ "$DATASET_NAME" == "notre-dame-20" ]; then
+  export GDRIVE_FILEID='1t_CptH7ZWdKQVW-yw56bpLS83TntNQiK'
 elif [ "$DATASET_NAME" == "palace-fine-arts-281" ]; then
   WGET_URL1=http://vision.maths.lth.se/calledataset/fine_arts_palace/fine_arts_palace.zip
   WGET_URL2=http://vision.maths.lth.se/calledataset/fine_arts_palace/data.mat
@@ -50,6 +52,11 @@ elif [ "$DATASET_NAME" == "skydio-32" ]; then
   unzip -qq skydio-32.zip -d skydio-32
   COLMAP_FILES_DIRPATH=skydio-32/colmap_crane_mast_32imgs
   IMAGES_DIR=skydio-32/images
+
+elif [ "$DATASET_NAME" == "notre-dame-20" ]; then
+  unzip -qq notre-dame-20.zip
+  COLMAP_FILES_DIRPATH=notre-dame-20/notre-dame-20-colmap
+  IMAGES_DIR=notre-dame-20/images
 
 elif [ "$DATASET_NAME" == "palace-fine-arts-281" ]; then \
   mkdir palace-fine-arts-281

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,8 @@ jobs:
             "deep_front_end,  skydio-8,              8,   jpg,  gdrive,     colmap-loader,  760",
             "sift_front_end,  skydio-32,             32,  jpg,  gdrive,     colmap-loader,  760",
             "deep_front_end,  skydio-32,             32,  jpg,  gdrive,     colmap-loader,  760",
-            "sift_front_end,  palace-fine-arts-281,  25,  jpg,  wget,       olsson-loader,  320"
+            "sift_front_end,  palace-fine-arts-281,  25,  jpg,  wget,       olsson-loader,  320",
+            "deep_front_end,  notre-dame-20,         20,  jpg,  gdrive,     colmap-loader,  760"
         ]
     defaults:
       run:


### PR DESCRIPTION
20 upright images from different cameras from Phototourism project, around Notre Dame Cathedral.

This dataset is good for debugging DA errors since all points should really be just on one plane (the cathedral's facade).