### PR TITLE
Add Homography multi model fitting check

### DIFF
--- a/gtsfm/frontend/verifier/homography.py
+++ b/gtsfm/frontend/verifier/homography.py
@@ -1,0 +1,70 @@
+from typing import Tuple
+
+import cv2
+import numpy as np
+
+from gtsfm.common.keypoints import Keypoints
+
+# from gtsfm.frontend.verifier.verifier_base import TwoViewEstimationReport
+
+import gtsfm.utils.logger as logger_utils
+
+logger = logger_utils.get_logger()
+
+"""
+Verification that determines whether the scene is planar or the camera motion is a pure rotation.
+
+COLMAP also checks degeneracy of structure here:
+    https://github.com/colmap/colmap/blob/dev/src/estimators/two_view_geometry.cc#L277
+"""
+
+MIN_PTS_HOMOGRAPHY = 4
+DEFAULT_RANSAC_PROB = 0.999
+
+
+class HomographyEstimator:
+    def __init__(self, estimation_threshold_px: float) -> None:
+        """
+        """
+        self._px_threshold = estimation_threshold_px
+
+    def estimate(
+        self, keypoints_i1: Keypoints, keypoints_i2: Keypoints, match_indices: np.ndarray
+    ) -> Tuple[float, int]:
+        """Estimate to what extent the correspondences agree with an estimated homography.
+
+        We provide statistics of the RANSAC result, like COLMAP does here for LORANSAC:
+        https://github.com/colmap/colmap/blob/dev/src/optim/loransac.h
+
+        Args:
+        keypoints_i1: detected features in image #i1.
+        keypoints_i2: detected features in image #i2.
+        match_indices: matches as indices of features from both images, of shape (N3, 2), where N3 <= min(N1, N2).
+
+        Returns:
+            inlier_ratio: i.e. ratio of correspondences which approximately agree with planar geometry
+            num_inliers: number of correspondence consistent with estimated homography H
+        """
+        if match_indices.shape[0] < MIN_PTS_HOMOGRAPHY:
+            num_inliers = 0
+            inlier_ratio = 0.0
+            return num_inliers, inlier_ratio
+
+        uv_i1 = keypoints_i1.coordinates
+        uv_i2 = keypoints_i2.coordinates
+
+        # TODO: cast as np.float32?
+        H, inlier_mask = cv2.findHomography(
+            srcPoints=uv_i1[match_indices[:, 0]],
+            dstPoints=uv_i2[match_indices[:, 1]],
+            method=cv2.RANSAC,
+            ransacReprojThreshold=self._px_threshold,
+            # maxIters=10000,
+            confidence=DEFAULT_RANSAC_PROB,
+        )
+
+        inlier_idxs = np.where(inlier_mask.ravel() == 1)[0]
+        inlier_ratio = inlier_mask.mean()
+
+        num_inliers = inlier_mask.sum()
+        return num_inliers, inlier_ratio

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -342,6 +342,8 @@ def save_full_frontend_metrics(
                 else None,
                 "inlier_ratio_est_model": round(report.inlier_ratio_est_model, PRINT_NUM_SIG_FIGS),
                 "num_inliers_est_model": report.num_inliers_est_model,
+                "num_H_inliers": int(report.num_H_inliers),
+                "H_inlier_ratio": round(report.H_inlier_ratio, PRINT_NUM_SIG_FIGS),
             }
         )
 

--- a/tests/frontend/verifier/test_homography.py
+++ b/tests/frontend/verifier/test_homography.py
@@ -1,0 +1,108 @@
+"""
+Unit tests on homography estimation.
+
+Author: John Lambert
+"""
+
+import numpy as np
+
+from gtsfm.common.keypoints import Keypoints
+from gtsfm.frontend.verifier.homography import HomographyEstimator
+
+
+def test_estimate_homography_inliers_minimalset() -> None:
+    """Fit homography on minimal set of 4 correspondences, w/ no outliers."""
+
+    # fmt: off
+    uv_i1 = np.array(
+    	[
+    		[0,0],
+    		[1,0],
+    		[1,1],
+    		[0,1]
+    	]
+    )
+
+    uv_i2 = np.array(
+    	[
+    		[0,0],
+    		[2,0],
+    		[2,2],
+    		[0,2]
+    	]
+    )
+
+    # fmt: on
+    keypoints_i1 = Keypoints(coordinates=uv_i1)
+    keypoints_i2 = Keypoints(coordinates=uv_i2)
+    # fmt: off
+    match_indices = np.array(
+    	[
+    		[0,0],
+    		[1,1],
+    		[2,2],
+    		[3,3]
+    	]
+    )
+
+    # fmt: on
+    estimator = HomographyEstimator()
+    num_inliers, inlier_ratio = estimator.estimate(keypoints_i1, keypoints_i2, match_indices)
+    assert inlier_ratio == 1.0
+    assert num_inliers == 4
+
+
+# def test_estimate_homography_inliers_corrupted() -> None:
+#     """Fit homography on set of 6 correspondences, w/ 2 outliers."""
+
+#     # fmt: off
+#     uv_i1 = np.array(
+#     	[
+#     		[0,0],
+#     		[1,0],
+#     		[1,1],
+#     		[0,1],
+#     		[0,1000], # outlier
+#     		[0,2000] # outlier
+#     	]
+#     )
+
+#     # # 2x multiplier on uv_i1
+#     # uv_i2 = np.array(
+#     # 	[
+#     # 		[0,0],
+#     # 		[2,0],
+#     # 		[2,2],
+#     # 		[0,2],
+#     # 		[500,0], # outlier
+#     # 		[1000,0] # outlier
+#     # 	]
+#     # )
+
+#  #    # fmt: on
+# 	# keypoints_i1 = Keypoints(coordinates=uv_i1)
+# 	# keypoints_i2 = Keypoints(coordinates=uv_i2)
+# 	# # fmt: off
+# 	# match_indices = np.array(
+# 	# 	[
+# 	# 		[0,0],
+# 	# 		[1,1],
+# 	# 		[2,2],
+# 	# 		[3,3],
+# 	# 		[4,4],
+# 	# 		[5,5]
+# 	# 	]
+# 	# )
+
+# 	# fmt: on
+# 	estimator = HomographyEstimator()
+# 	num_inliers, inlier_ratio = estimator.estimate(
+# 		keypoints_i1,
+# 		keypoints_i2,
+# 		match_indices
+# 	)
+
+# 	assert inlier_ratio == 4/6
+# 	assert num_inliers == 4
+
+#     # # TODO: add case from virtual plane, and real camera geometry


### PR DESCRIPTION
Per [COLMAP](https://demuc.de/papers/schoenberger2016sfm.pdf) section 4.1:

```
We propose a multi-model geometric verification strategy to augment the scene graph with the appropriate geometric relation. First, we estimate a fundamental matrix. If
at least NF inliers are found, we consider the image pair
as geometrically verified. Next, we classify the transformation by determining the number of homography inliers
NH for the same image pair. To approximate model selection methods like GRIC, we assume a moving camera
in a general scene if NH/NF < HF . For calibrated images, we also estimate an essential matrix and its number
of inliers NE. If NE/NF > EF , we assume correct calibration. In case of correct calibration and NH/NF < HF ,
we decompose the essential matrix, triangulate points from
inlier correspondences, and determine the median triangulation angle αm. Using αm, we distinguish between the
case of pure rotation (panoramic) and planar scenes (planar). 
```