### PR TITLE
Fix bash bug in benchmark script

### DIFF
--- a/.github/scripts/execute_single_benchmark.sh
+++ b/.github/scripts/execute_single_benchmark.sh
@@ -35,9 +35,9 @@ echo "Config: ${CONFIG_NAME}, Dataset: ${DATASET_NAME}, Download Source: ${DATAS
 
 # Setup the command line arg if intrinsics are to be shared
 if [ "$SHARE_INTRINSICS" ]; then
-  export SHARE_INTRINSICS_ARG = "--share_intrinsics"
+  export SHARE_INTRINSICS_ARG="--share_intrinsics"
 else
-  export SHARE_INTRINSICS_ARG = ""
+  export SHARE_INTRINSICS_ARG=""
 fi
 
 # Prepare the download URLs.


### PR DESCRIPTION
Bash variable assignment cannot have spaces between operators.


Error message (see https://github.com/borglab/gtsfm/runs/3764284507?check_suite_focus=true):
```
Config: sift_front_end, Dataset: door-12, Download Source: test_data, Loader: olsson-loader
.github/scripts/execute_single_benchmark.sh: line 38: export: `=': not a valid identifier
.github/scripts/execute_single_benchmark.sh: line 38: export: `--share_intrinsics': not a valid identifier
```