### PR TITLE
try median of cycle errors per edge as cycle consistency summary statistic, instead of min

### DIFF
--- a/gtsfm/averaging/rotation/cycle_consistency.py
+++ b/gtsfm/averaging/rotation/cycle_consistency.py
@@ -291,7 +291,7 @@ def filter_to_cycle_consistent_edges(
         plt.axis("equal")
         plt.savefig(os.path.join("plots", f"gt_err_vs_{edge_acceptance_criterion}_agg_error.jpg"), dpi=400)
         plt.close("all")
-    
+
         plt.scatter(cycle_errors, max_rot_errors)
         plt.xlabel("Cycle error")
         plt.ylabel("Avg. Rot3 error over cycle triplet")

--- a/gtsfm/averaging/rotation/cycle_consistency.py
+++ b/gtsfm/averaging/rotation/cycle_consistency.py
@@ -38,8 +38,7 @@ class EdgeErrorAggregationCriterion(str, Enum):
         with low error is accepted. High recall, but can have low precision, as false positives can enter
         (error was randomly cancelled out by another error, meaning accepted).
     MEDIAN: Choose the median cycle error. robust summary statistic. At least half of the time, this edge
-        appears in a good cycle (i.e. of low error).
-    MEAN: Choose the mean cycle error. Note: this is a non-robust summary statistic.
+        appears in a good cycle (i.e. of low error). Note: preferred over mean, which is not robust to outliers.
 
     Note: all summary statistics will be compared with an allowed upper bound/threshold. If they exceed the
     upper bound, they will be rejected.
@@ -47,7 +46,6 @@ class EdgeErrorAggregationCriterion(str, Enum):
 
     MIN_EDGE_ERROR = "MIN_EDGE_ERROR"
     MEDIAN_EDGE_ERROR = "MEDIAN_EDGE_ERROR"
-    MEAN_EDGE_ERROR = "MEAN_EDGE_ERROR"
 
 
 def extract_triplets(i2Ri1_dict: Dict[Tuple[int, int], Rot3]) -> List[Tuple[int, int, int]]:
@@ -292,7 +290,8 @@ def filter_to_cycle_consistent_edges(
     plt.scatter(errors_summary, errors_wrt_gt, 10, color="r", marker=".")
     plt.xlabel(f"{edge_acceptance_criterion} cycle error")
     plt.ylabel("Rotation error w.r.t GT")
-    plt.savefig(f"gt_err_vs_{edge_acceptance_criterion}_agg_error.jpg", dpi=400)
+    plt.savefig(os.path.join("plots", f"gt_err_vs_{edge_acceptance_criterion}_agg_error.jpg"), dpi=400)
+    plt.close("all")
 
     if visualize:
         plt.scatter(cycle_errors, max_rot_errors)

--- a/gtsfm/averaging/rotation/cycle_consistency.py
+++ b/gtsfm/averaging/rotation/cycle_consistency.py
@@ -278,9 +278,6 @@ def filter_to_cycle_consistent_edges(
         elif edge_acceptance_criterion == EdgeErrorAggregationCriterion.MEDIAN_EDGE_ERROR:
             error_summary = np.median(edge_cycle_errors)
 
-        elif edge_acceptance_criterion == EdgeErrorAggregationCriterion.MEAN_EDGE_ERROR:
-            error_summary = np.mean(edge_cycle_errors)
-
         if error_summary < CYCLE_ERROR_THRESHOLD:
             cycle_consistent_keys.add((i1, i2))
 

--- a/gtsfm/averaging/rotation/cycle_consistency.py
+++ b/gtsfm/averaging/rotation/cycle_consistency.py
@@ -26,8 +26,7 @@ from gtsfm.two_view_estimator import TwoViewEstimationReport
 logger = logger_utils.get_logger()
 
 
-CYCLE_ERROR_THRESHOLD = 5.0
-MEDIAN_CYCLE_ERROR_THRESHOLD = 10.0
+CYCLE_ERROR_THRESHOLD = 7.0
 
 MAX_INLIER_MEASUREMENT_ERROR_DEG = 5.0
 
@@ -37,12 +36,9 @@ class EdgeErrorAggregationCriterion(str, Enum):
 
     MIN: Choose the mininum cycle error of all cyles this edge appears in. An edge that appears in ANY cycle
         with low error is accepted. High recall, but can have low precision, as false positives can enter
-        (error was randomly cancelled out by another error, meaning accepted). Recall near 100%, for gains
-        in precision.
+        (error was randomly cancelled out by another error, meaning accepted).
     MEDIAN: Choose the median cycle error. robust summary statistic. At least half of the time, this edge
         appears in a good cycle (i.e. of low error). Note: preferred over mean, which is not robust to outliers.
-        Improves precision at the cost of recall.
-    MIN AND MEDIAN: Both conditions above must be satisfied.
 
     Note: all summary statistics will be compared with an allowed upper bound/threshold. If they exceed the
     upper bound, they will be rejected.
@@ -50,7 +46,6 @@ class EdgeErrorAggregationCriterion(str, Enum):
 
     MIN_EDGE_ERROR = "MIN_EDGE_ERROR"
     MEDIAN_EDGE_ERROR = "MEDIAN_EDGE_ERROR"
-    MIN_AND_MEDIAN_EDGE_ERROR = "MIN_AND_MEDIAN_EDGE_ERROR"
 
 
 def extract_triplets(i2Ri1_dict: Dict[Tuple[int, int], Rot3]) -> List[Tuple[int, int, int]]:
@@ -245,58 +240,70 @@ def filter_to_cycle_consistent_edges(
         v_corr_idxs_dict_consistent: subset of v_corr_idxs_dict above.
         metrics_group: Rotation cycle consistency metrics as a metrics group.
     """
+    cycle_errors = []
+    max_rot_errors = []
+    max_trans_errors = []
+
     n_valid_edges = len([i2Ri1 for (i1, i2), i2Ri1 in i2Ri1_dict.items() if i2Ri1 is not None])
+
+    # (i1,i2) pairs
+    cycle_consistent_keys = set()
 
     per_edge_errors = defaultdict(list)
 
     triplets = extract_triplets(i2Ri1_dict)
 
     for (i0, i1, i2) in triplets:
-        cycle_error, _, _ = compute_cycle_error(i2Ri1_dict, (i0, i1, i2), two_view_reports_dict)
+        cycle_error, max_rot_error, max_trans_error = compute_cycle_error(
+            i2Ri1_dict, (i0, i1, i2), two_view_reports_dict
+        )
         # since i0 < i1 < i2 by construction, we preserve the property `a < b` for each edge (a,b)
         per_edge_errors[(i0, i1)].append(cycle_error)
         per_edge_errors[(i1, i2)].append(cycle_error)
         per_edge_errors[(i0, i2)].append(cycle_error)
 
-    # (i1,i2) pairs
-    cycle_consistent_keys = set()
+        cycle_errors.append(cycle_error)
+        max_rot_errors.append(max_rot_error)
+        max_trans_errors.append(max_trans_error)
 
-    inlier_errors_wrt_gt = []
-    outlier_errors_wrt_gt = []
+    errors_summary = []
+    errors_wrt_gt = []
 
+    plt.close("all")
     # aggregate info over per edge_errors
     for (i1, i2), edge_cycle_errors in per_edge_errors.items():
         if edge_acceptance_criterion == EdgeErrorAggregationCriterion.MIN_EDGE_ERROR:
-            is_inlier = np.amin(edge_cycle_errors) < CYCLE_ERROR_THRESHOLD
+            error_summary = np.amin(edge_cycle_errors)
 
         elif edge_acceptance_criterion == EdgeErrorAggregationCriterion.MEDIAN_EDGE_ERROR:
-            is_inlier = np.median(edge_cycle_errors) < MEDIAN_CYCLE_ERROR_THRESHOLD
+            error_summary = np.median(edge_cycle_errors)
 
-        elif edge_acceptance_criterion == EdgeErrorAggregationCriterion.MIN_AND_MEDIAN_EDGE_ERROR:
-            is_inlier = (np.amin(edge_cycle_errors) < CYCLE_ERROR_THRESHOLD) and (
-                np.median(edge_cycle_errors) < MEDIAN_CYCLE_ERROR_THRESHOLD
-            )
-
-        error_wrt_gt = two_view_reports_dict[(i1, i2)].R_error_deg
-        if is_inlier:
+        if error_summary < CYCLE_ERROR_THRESHOLD:
             cycle_consistent_keys.add((i1, i2))
-            inlier_errors_wrt_gt.append(error_wrt_gt)
-        else:
-            outlier_errors_wrt_gt.append(error_wrt_gt)
+
+        errors_summary.append(error_summary)
+        errors_wrt_gt.append(two_view_reports_dict[(i1, i2)].R_error_deg)
 
     if visualize:
+        plt.scatter(errors_summary, errors_wrt_gt, 10, color="r", marker=".")
+        plt.xlabel(f"{edge_acceptance_criterion} cycle error")
+        plt.ylabel("Rotation error w.r.t GT")
+        plt.axis("equal")
+        plt.savefig(os.path.join("plots", f"gt_err_vs_{edge_acceptance_criterion}_agg_error.jpg"), dpi=400)
         plt.close("all")
-        plt.hist(inlier_errors_wrt_gt, bins=np.linspace(0,180,61))
-        plt.ylabel("Count")
-        plt.xlabel("Rotation error w.r.t. GT (deg.)")
-        plt.savefig(os.path.join("plots", f"inlier_errors_wrt_gt_{edge_acceptance_criterion}.jpg"), dpi=400)
+    
+        plt.scatter(cycle_errors, max_rot_errors)
+        plt.xlabel("Cycle error")
+        plt.ylabel("Avg. Rot3 error over cycle triplet")
+        plt.axis("equal")
+        plt.savefig(os.path.join("plots", "cycle_error_vs_GT_rot_error.jpg"), dpi=200)
         plt.close("all")
 
-        plt.hist(outlier_errors_wrt_gt, bins=np.linspace(0,180,61))
-        plt.ylabel("Count")
-        plt.xlabel("Rotation error w.r.t. GT (deg.)")
-        plt.savefig(os.path.join("plots", f"outlier_errors_wrt_gt_{edge_acceptance_criterion}.jpg"), dpi=400)
-        plt.close("all")
+        plt.scatter(cycle_errors, max_trans_errors)
+        plt.xlabel("Cycle error")
+        plt.ylabel("Avg. Unit3 error over cycle triplet")
+        plt.axis("equal")
+        plt.savefig(os.path.join("plots", "cycle_error_vs_GT_trans_error.jpg"), dpi=200)
 
     logger.info("cycle_consistent_keys: " + str(cycle_consistent_keys))
 

--- a/gtsfm/averaging/rotation/cycle_consistency.py
+++ b/gtsfm/averaging/rotation/cycle_consistency.py
@@ -286,13 +286,13 @@ def filter_to_cycle_consistent_edges(
 
     if visualize:
         plt.close("all")
-        plt.hist(inlier_errors_wrt_gt, bins=60)
+        plt.hist(inlier_errors_wrt_gt, bins=np.linspace(0,180,61))
         plt.ylabel("Count")
         plt.xlabel("Rotation error w.r.t. GT (deg.)")
         plt.savefig(os.path.join("plots", f"inlier_errors_wrt_gt_{edge_acceptance_criterion}.jpg"), dpi=400)
         plt.close("all")
 
-        plt.hist(outlier_errors_wrt_gt, bins=60)
+        plt.hist(outlier_errors_wrt_gt, bins=np.linspace(0,180,61))
         plt.ylabel("Count")
         plt.xlabel("Rotation error w.r.t. GT (deg.)")
         plt.savefig(os.path.join("plots", f"outlier_errors_wrt_gt_{edge_acceptance_criterion}.jpg"), dpi=400)

--- a/gtsfm/averaging/rotation/cycle_consistency.py
+++ b/gtsfm/averaging/rotation/cycle_consistency.py
@@ -305,7 +305,7 @@ def filter_to_cycle_consistent_edges(
         plt.xlabel(f"{edge_acceptance_criterion} cycle error")
         plt.ylabel("Rotation error w.r.t GT")
         plt.axis("equal")
-        plt.legend()
+        plt.legend(loc="lower right")
         plt.savefig(os.path.join("plots", f"gt_err_vs_{edge_acceptance_criterion}_agg_error.jpg"), dpi=400)
         plt.close("all")
 

--- a/gtsfm/averaging/rotation/cycle_consistency.py
+++ b/gtsfm/averaging/rotation/cycle_consistency.py
@@ -252,18 +252,15 @@ def filter_to_cycle_consistent_edges(
     triplets = extract_triplets(i2Ri1_dict)
 
     for (i0, i1, i2) in triplets:
-        cycle_error, _, _ = compute_cycle_error(
-            i2Ri1_dict, (i0, i1, i2), two_view_reports_dict
-        )
+        cycle_error, _, _ = compute_cycle_error(i2Ri1_dict, (i0, i1, i2), two_view_reports_dict)
         # since i0 < i1 < i2 by construction, we preserve the property `a < b` for each edge (a,b)
         per_edge_errors[(i0, i1)].append(cycle_error)
         per_edge_errors[(i1, i2)].append(cycle_error)
         per_edge_errors[(i0, i2)].append(cycle_error)
 
-
     # (i1,i2) pairs
     cycle_consistent_keys = set()
-    
+
     inlier_errors_wrt_gt = []
     outlier_errors_wrt_gt = []
 
@@ -289,13 +286,13 @@ def filter_to_cycle_consistent_edges(
 
     if visualize:
         plt.close("all")
-        plt.hist(inlier_errors_wrt_gt)
+        plt.hist(inlier_errors_wrt_gt, bins=60)
         plt.ylabel("Count")
         plt.xlabel("Rotation error w.r.t. GT (deg.)")
         plt.savefig(os.path.join("plots", f"inlier_errors_wrt_gt_{edge_acceptance_criterion}.jpg"), dpi=400)
         plt.close("all")
 
-        plt.hist(outlier_errors_wrt_gt)
+        plt.hist(outlier_errors_wrt_gt, bins=60)
         plt.ylabel("Count")
         plt.xlabel("Rotation error w.r.t. GT (deg.)")
         plt.savefig(os.path.join("plots", f"outlier_errors_wrt_gt_{edge_acceptance_criterion}.jpg"), dpi=400)

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -191,7 +191,7 @@ class SceneOptimizer:
             i2Ui1_graph_dict,
             v_corr_idxs_graph_dict,
             two_view_reports_dict,
-            EdgeErrorAggregationCriterion.MEDIAN_EDGE_ERROR,
+            EdgeErrorAggregationCriterion.MIN_AND_MEDIAN_EDGE_ERROR,
         )
         metrics_graph_list.append(rcc_metrics_graph)
 

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -191,7 +191,7 @@ class SceneOptimizer:
             i2Ui1_graph_dict,
             v_corr_idxs_graph_dict,
             two_view_reports_dict,
-            EdgeErrorAggregationCriterion.MIN_AND_MEDIAN_EDGE_ERROR,
+            EdgeErrorAggregationCriterion.MEDIAN_EDGE_ERROR,
         )
         metrics_graph_list.append(rcc_metrics_graph)
 

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -24,6 +24,7 @@ import gtsfm.utils.io as io_utils
 import gtsfm.utils.logger as logger_utils
 import gtsfm.utils.metrics as metrics_utils
 import gtsfm.utils.viz as viz_utils
+from gtsfm.averaging.rotation.cycle_consistency import EdgeErrorAggregationCriterion
 from gtsfm.common.image import Image
 from gtsfm.feature_extractor import FeatureExtractor
 from gtsfm.multi_view_optimizer import MultiViewOptimizer
@@ -185,7 +186,13 @@ class SceneOptimizer:
         # ensure cycle consistency in triplets
         i2Ri1_graph_dict, i2Ui1_graph_dict, v_corr_idxs_graph_dict, rcc_metrics_graph = dask.delayed(
             cycle_consistency.filter_to_cycle_consistent_edges, nout=4
-        )(i2Ri1_graph_dict, i2Ui1_graph_dict, v_corr_idxs_graph_dict, two_view_reports_dict)
+        )(
+            i2Ri1_graph_dict,
+            i2Ui1_graph_dict,
+            v_corr_idxs_graph_dict,
+            two_view_reports_dict,
+            EdgeErrorAggregationCriterion.MEDIAN_EDGE_ERROR,
+        )
         metrics_graph_list.append(rcc_metrics_graph)
 
         def _filter_dict_keys(dict: Dict[Any, Any], ref_dict: Dict[Any, Any]) -> Dict[Any, Any]:


### PR DESCRIPTION
Use median of cycle errors per edge as cycle consistency summary statistic, instead of min.

Look at the cycle errors that each edge appears in. False Positives are anything above the line y=x in the plots below. False negatives are anything below the line y=x. True positives are on the line y = x:

Min
![gt_err_vs_min_agg_error](https://user-images.githubusercontent.com/16724970/135741470-eeeb447a-152a-4fe6-8996-aaf112b4616e.jpg)


Median
![gt_err_vs_median_agg_error](https://user-images.githubusercontent.com/16724970/135741473-0a795435-9983-4dca-825c-9a7ed16a6c5f.jpg)

Mean
![gt_err_vs_mean_agg_error](https://user-images.githubusercontent.com/16724970/135741475-3c07c29a-5165-4f26-a7d6-9c1b1b038586.jpg)


