### PR TITLE
create artifacts for plots and output data in CI benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -72,23 +72,11 @@ jobs:
             $SHARE_INTRINSICS
 
 
-      - name: Archive dataset metrics
-        uses: actions/upload-artifact@v2
-        with:
-          name: metrics-${{ matrix.config_dataset_info }}.zip
-          path: |
-            result_metrics
-
-      - name: Archive dataset plots
-        uses: actions/upload-artifact@v2
-        with:
-          name: plots-${{ matrix.config_dataset_info }}.zip
-          path: |
-            plots
-
-      - name: Archive dataset output data (camera poses + points)
+      - name: Archive dataset metrics, plots, and output data (camera poses + points)
         uses: actions/upload-artifact@v2
         with:
           name: results-${{ matrix.config_dataset_info }}.zip
           path: |
+            result_metrics
+            plots
             results

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -78,3 +78,17 @@ jobs:
           name: metrics-${{ matrix.config_dataset_info }}.zip
           path: |
             result_metrics
+
+      - name: Archive dataset plots
+        uses: actions/upload-artifact@v2
+        with:
+          name: plots-${{ matrix.config_dataset_info }}.zip
+          path: |
+            plots
+
+      - name: Archive dataset output data (camera poses + points)
+        uses: actions/upload-artifact@v2
+        with:
+          name: results-${{ matrix.config_dataset_info }}.zip
+          path: |
+            results


### PR DESCRIPTION
Currently only the result metrics are uploaded after a CI benchmark run. It would be nice to be able to inspect the actual output poses and point cloud, by downloading the artifacts.