### PR TITLE
Update cycle consistency verbosity to be false by default

### DIFF
--- a/gtsfm/averaging/rotation/cycle_consistency.py
+++ b/gtsfm/averaging/rotation/cycle_consistency.py
@@ -102,7 +102,7 @@ def compute_cycle_error(
     i2Ri1_dict: Dict[Tuple[int, int], Rot3],
     cycle_nodes: Tuple[int, int, int],
     two_view_reports_dict: Dict[Tuple[int, int], TwoViewEstimationReport],
-    verbose: bool = True,
+    verbose: bool = False,
 ) -> Tuple[float, Optional[float], Optional[float]]:
     """Compute the cycle error by the magnitude of the axis-angle rotation after composing 3 rotations.
 


### PR DESCRIPTION
--verbose flags are generally set to `false` by default. It needs to be true only when debugging, and then it has to be manually specified, potentially via command line args. 

The problem with setting this to true is that generates a lot of text making it hard to find other log statements. It gets worse when the dataset is huge, the logs for the palace of fine arts 281 image dataset generated by the CI is ~65 MB of text. 