### PR TITLE
Prevents other configs from being canceled if one of them fails in the benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,6 +7,8 @@ jobs:
     name: Benchmark
     runs-on: ubuntu-latest
     strategy:
+      # Prevents other configs from being canceled if one of them fails.
+      fail-fast: false
       matrix:
         config_dataset_info:
           [


### PR DESCRIPTION
Some configs fail due to flaky wget or unzip, and we dont have to cancel other configs in the benchmark. 
GitHub documentation [here](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast)