### PR TITLE
Adding conda env file for CPU only machines

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           miniconda-version: "latest"
           activate-environment: gtsfm-v1
-          environment-file: environment_linux.yml
+          environment-file: environment_linux_cpuonly.yml
           python-version: 3.8
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
       - name: Environment setup

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         miniconda-version: "latest"
         activate-environment: gtsfm-v1
-        environment-file: environment_linux.yml
+        environment-file: environment_linux_cpuonly.yml
         python-version: 3.8
     - name: Environment setup
       run: |

--- a/environment_linux_cpuonly.yml
+++ b/environment_linux_cpuonly.yml
@@ -1,0 +1,46 @@
+name: gtsfm-v1
+channels:
+  # for priority order, we prefer pytorch as the highest priority as it supplies
+  # latest stable packages for numerous deep learning based methods. conda-forge
+  # supplies higher versions of packages like opencv compared to the defaults
+  # channel.
+  - open3d-admin
+  - pytorch
+  - conda-forge
+dependencies:
+  # python essentials
+  - python=3.8
+  - pip
+  # formatting and dev environment
+  - black
+  - coverage
+  - mypy
+  - pylint
+  - pytest
+  - flake8
+  # dask and related
+  - dask # same as dask[complete] pip distribution
+  - python-graphviz
+  # core functionality and APIs
+  - matplotlib==3.4.2
+  - networkx
+  - numpy
+  - nodejs
+  - pandas
+  - pillow>=8.0.1
+  - scikit-learn
+  - hydra-core
+  # 3rd party algorithms for different modules
+  - cpuonly # replacement of cudatoolkit for cpu only machines
+  - opencv=4.5.0 # preferring conda-forge's distribution as it provides the latest distribution
+  - pytorch
+  # io
+  - h5py
+  - plotly=4.14.3
+  - tabulate
+  # visualization
+  - open3d
+  - pip:
+    - pydegensac
+    - colour
+    - pycolmap


### PR DESCRIPTION
This PR adds a conda env file for CPU only machines. 

CPU only machines do not need `cudatoolkit` package, and hence replacing it with `cpuonly` saves a lot of space and will make the environment creation faster.

This will be particularly helpful on the CI.