### PR TITLE
Improve performance and determinism by increasing RANSAC iterations

### DIFF
--- a/gtsfm/frontend/verifier/ransac.py
+++ b/gtsfm/frontend/verifier/ransac.py
@@ -24,8 +24,8 @@ from gtsfm.common.keypoints import Keypoints
 from gtsfm.frontend.verifier.verifier_base import VerifierBase, NUM_MATCHES_REQ_E_MATRIX, NUM_MATCHES_REQ_F_MATRIX
 
 
-RANSAC_SUCCESS_PROB = 0.9999
-RANSAC_MAX_ITERS = 10000
+RANSAC_SUCCESS_PROB = 0.999999
+RANSAC_MAX_ITERS = 1000000
 
 logger = logger_utils.get_logger()
 


### PR DESCRIPTION
Experiments (averaged over 10 runs each) at different settings indicate that we are not running nearly enough RANSAC iterations.

# Skydio-32, Deep Front End
Results reported below:
<img width="1390" alt="Screen Shot 2021-10-13 at 2 08 35 PM" src="https://user-images.githubusercontent.com/16724970/137189054-b1b6dcc2-2f16-40fe-9ae4-31b16629adcf.png">


