### PR TITLE
fix typo in plot legend for cycle consistency module

### DIFF
--- a/gtsfm/averaging/rotation/cycle_consistency.py
+++ b/gtsfm/averaging/rotation/cycle_consistency.py
@@ -292,7 +292,7 @@ def filter_to_cycle_consistent_edges(
             10,
             color="g",
             marker=".",
-            label=f"outliers @ {CYCLE_ERROR_THRESHOLD} deg.",
+            label=f"inliers @ {CYCLE_ERROR_THRESHOLD} deg.",
         )
         plt.scatter(
             outlier_errors_aggregate,
@@ -300,7 +300,7 @@ def filter_to_cycle_consistent_edges(
             10,
             color="r",
             marker=".",
-            label=f"inliers @ {CYCLE_ERROR_THRESHOLD} deg.",
+            label=f"outliers @ {CYCLE_ERROR_THRESHOLD} deg.",
         )
         plt.xlabel(f"{edge_acceptance_criterion} cycle error")
         plt.ylabel("Rotation error w.r.t GT")


### PR DESCRIPTION
Titles of metrics were swapped in the plot before:
![Screen Shot 2021-10-18 at 7 00 17 PM](https://user-images.githubusercontent.com/16724970/137817821-3d1aee9d-3f46-40ff-88e2-fd7c4b1bfb54.png)
