### PR TITLE
fix the reported number of inputs to Rotation Cycle Consistency module in the HTML report

### DIFF
--- a/gtsfm/averaging/rotation/cycle_consistency.py
+++ b/gtsfm/averaging/rotation/cycle_consistency.py
@@ -385,7 +385,7 @@ def _compute_metrics(
     )
 
     rcc_metrics = [
-        GtsfmMetric("num_total_rcc_input_measurements", n_valid_edges),
+        GtsfmMetric("num_input_measurements", n_valid_edges),
         GtsfmMetric("num_inlier_rcc_measurements", len(inlier_i1_i2_pairs)),
         GtsfmMetric("num_outlier_rcc_measurements", len(outlier_i1_i2_pairs)),
         GtsfmMetric("rot_cycle_consistency_R_precision", R_precision),


### PR DESCRIPTION
Currently, the reported # of inputs to cycle consistency is incorrect.

For example, for 63K input pairs, and 26K valid pairs, only 26K are truly fed into the cycle consistency check.

However, the metrics suggest that 63K input pairs are going into the cycle consistency check, which is wrong (the correct number is 26K).
![Screen Shot 2021-10-18 at 7 21 16 PM](https://user-images.githubusercontent.com/16724970/137819291-eba82e25-4e73-48aa-b2a6-a203d29296ba.png)
![Screen Shot 2021-10-18 at 7 21 25 PM](https://user-images.githubusercontent.com/16724970/137819310-5201dd45-02e1-4dae-b8e0-b8a5114e4fdc.png)


