### PR TITLE
Gracefully catch file read errors on BZ2 cache files, delete such corrupted files

### DIFF
--- a/gtsfm/utils/io.py
+++ b/gtsfm/utils/io.py
@@ -424,10 +424,17 @@ def save_track_visualizations(
 
 def read_from_bz2_file(file_path: Path) -> Optional[Any]:
     """Reads data using pickle from a compressed file, if it exists."""
-    if file_path.exists():
-        return pickle.load(BZ2File(file_path, "rb"))
+    if not file_path.exists():
+        return None
 
-    return None
+    try:
+        data = pickle.load(BZ2File(file_path, "rb"))
+    except Exception:
+        logger.exception("Cache file was corrupted, removing it...")
+        os.remove(file_path)
+        data = None
+
+    return data
 
 
 def write_to_bz2_file(data: Any, file_path: Path) -> None:


### PR DESCRIPTION

On SkyNet, we see errors like the following when using cached files:
```
[2021-10-28 19:09:07,099 WARNING verification.py line 57 17922] Recovered R, t cannot create the input Essential Matrix
[2021-10-28 19:09:07,133 WARNING verification.py line 57 17922] Recovered R, t cannot create the input Essential Matrix
[2021-10-28 19:09:07,301 WARNING verification.py line 57 17922] Recovered R, t cannot create the input Essential Matrix
Loaded SuperGlue model ("outdoor" weights)
Traceback (most recent call last):
  File "gtsfm/runner/run_scene_optimizer_colmaploader.py", line 45, in <module>
    runner.run()
  File "/coc/scratch/jlambert30/gtsfm/gtsfm/runner/gtsfm_runner_base.py", line 106, in run
    sfm_result = sfm_result_graph.compute()
  File "/nethome/jlambert30/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/dask/base.py", line 285, in compute
    (result,) = compute(self, traverse=False, **kwargs)
  File "/nethome/jlambert30/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/dask/base.py", line 567, in compute
    results = schedule(dsk, keys, **kwargs)
  File "/nethome/jlambert30/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 2673, in get
    results = self.gather(packed, asynchronous=asynchronous, direct=direct)
  File "/nethome/jlambert30/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 1982, in gather
    return self.sync(
  File "/nethome/jlambert30/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 853, in sync
    return sync(
  File "/nethome/jlambert30/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/utils.py", line 354, in sync
    raise exc.with_traceback(tb)
  File "/nethome/jlambert30/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/utils.py", line 337, in f
    result[0] = yield future
  File "/nethome/jlambert30/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/tornado/gen.py", line 762, in run
    value = future.result()
  File "/nethome/jlambert30/miniconda3/envs/gtsfm-v1/lib/python3.8/site-packages/distributed/client.py", line 1847, in _gather
    raise exception.with_traceback(traceback)
  File "/coc/scratch/jlambert30/gtsfm/gtsfm/frontend/cacher/matcher_cacher.py", line 155, in match
    cached_data = self.__load_result_from_cache(
  File "/coc/scratch/jlambert30/gtsfm/gtsfm/frontend/cacher/matcher_cacher.py", line 96, in __load_result_from_cache
    return io_utils.read_from_bz2_file(cache_path)
  File "/coc/scratch/jlambert30/gtsfm/gtsfm/utils/io.py", line 428, in read_from_bz2_file
    return pickle.load(BZ2File(file_path, "rb"))
  File "/nethome/jlambert30/miniconda3/envs/gtsfm-v1/lib/python3.8/bz2.py", line 172, in peek
    return self._buffer.peek(n)
  File "/nethome/jlambert30/miniconda3/envs/gtsfm-v1/lib/python3.8/_compression.py", line 68, in readinto
    data = self.read(len(byte_view))
  File "/nethome/jlambert30/miniconda3/envs/gtsfm-v1/lib/python3.8/_compression.py", line 99, in read
    raise EOFError("Compressed file ended before the "
EOFError: Compressed file ended before the end-of-stream marker was reached
distributed.nanny - WARNING - Worker process still alive after 3 seconds, killing
distributed.nanny - WARNING - Worker process still alive after 3 seconds, killing
distributed.nanny - WARNING - Worker process still alive after 3 seconds, killing
Exception in thread AsyncProcess Dask Worker process (from Nanny) watch process join:
Traceback (most recent call last):
  File "/nethome/jlambert30/miniconda3/envs/gtsfm-v1/lib/python3.8/threading.py", line 932, in _bootstrap_inner
```

This PR gracefully catches such errors, and deletes such corrupted files, and then proceeds.