### PR TITLE
remove unnecessary TwoViewReport attributes

### DIFF
--- a/gtsfm/common/two_view_estimation_report.py
+++ b/gtsfm/common/two_view_estimation_report.py
@@ -31,8 +31,6 @@ class TwoViewEstimationReport:
             Sampson error (using GT epipolar geometry).
         R_error_deg: relative pose error w.r.t. GT. Only defined if GT poses provided.
         U_error_deg: relative translation error w.r.t. GT. Only defined if GT poses provided.
-        i2Ri1: relative rotation.
-        i2Ui1: relative translation direction.
         reproj_error_gt_model: reprojection errors between correspondences w.r.t. GT.
         inlier_avg_reproj_error_gt_model: average reprojection error of inliers.
         outlier_avg_reproj_error_gt_model: average reprojection error of outliers.
@@ -46,8 +44,6 @@ class TwoViewEstimationReport:
     v_corr_idxs_inlier_mask_gt: Optional[np.ndarray] = None
     R_error_deg: Optional[float] = None
     U_error_deg: Optional[float] = None
-    i2Ri1: Optional[Rot3] = None
-    i2Ui1: Optional[Unit3] = None
     reproj_error_gt_model: Optional[np.ndarray] = None
     inlier_avg_reproj_error_gt_model: Optional[float] = None
     outlier_avg_reproj_error_gt_model: Optional[float] = None


### PR DESCRIPTION
i2Ri1 and i2Ui1 shouldn't be in this report (I don't remember how they got in here, probably was from some old debugging i did while prototyping)...