### PR TITLE
[WIP] Expanding gtsfm data

### DIFF
--- a/gtsfm/common/gtsfm_data.py
+++ b/gtsfm/common/gtsfm_data.py
@@ -31,8 +31,8 @@ class GtsfmData:
     def __init__(
         self,
         number_images: int,
-        cameras: Dict[int, PinholeCameraCal3Bundler] = {},
-        tracks: List[SfmTrack] = [],
+        cameras: Optional[Dict[int, PinholeCameraCal3Bundler]] = None,
+        tracks: Optional[List[SfmTrack]] = None,
         scene_mesh: Optional[Trimesh] = None,
     ) -> None:
         """Initializes the class.
@@ -41,9 +41,17 @@ class GtsfmData:
             number_images: number of images/cameras in the scene.
         """
         self._number_images = number_images
-        self._cameras = cameras
-        self._tracks = tracks
-        self._scene_mesh = scene_mesh
+        self._cameras = cameras if cameras else {}
+        self._tracks = tracks if tracks else []
+        # self._cameras = cameras  # this caused an error for some reason??
+        # self._tracks = tracks
+        self.scene_mesh = scene_mesh
+
+    def get_two_view_data(self, i1: int, i2: int) -> "GtsfmData":
+        """Collects GtsfmData for a sinbgle image pair."""
+        # TODO (travisdriver): also collect tracks if available.
+        cameras_pair = {0: self.get_camera(i1), 1: self.get_camera(i2)}
+        return GtsfmData(2, cameras_pair, None, self.scene_mesh)
 
     def __eq__(self, other: object) -> bool:
         """Checks equality with the other object."""

--- a/gtsfm/common/gtsfm_data.py
+++ b/gtsfm/common/gtsfm_data.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 from gtsam import PinholeCameraCal3Bundler, Pose3, SfmTrack, Similarity3
+from trimesh import Trimesh
 
 import gtsfm.utils.geometry_comparisons as geometry_comparisons
 import gtsfm.utils.graph as graph_utils
@@ -27,15 +28,22 @@ class GtsfmData:
     The situation of non-contiguous cameras can exists because of failures in front-end.
     """
 
-    def __init__(self, number_images: int) -> None:
+    def __init__(
+        self,
+        number_images: int,
+        cameras: Dict[int, PinholeCameraCal3Bundler] = {},
+        tracks: List[SfmTrack] = [],
+        scene_mesh: Optional[Trimesh] = None,
+    ) -> None:
         """Initializes the class.
 
         Args:
             number_images: number of images/cameras in the scene.
         """
-        self._cameras: Dict[int, PinholeCameraCal3Bundler] = {}
-        self._tracks: List[SfmTrack] = []
         self._number_images = number_images
+        self._cameras = cameras
+        self._tracks = tracks
+        self._scene_mesh = scene_mesh
 
     def __eq__(self, other: object) -> bool:
         """Checks equality with the other object."""

--- a/gtsfm/runner/run_scene_optimizer_astronet.py
+++ b/gtsfm/runner/run_scene_optimizer_astronet.py
@@ -58,7 +58,7 @@ class GtsfmRunnerAstronetLoader(GtsfmRunnerBase):
 
         with Client(cluster) as client, performance_report(filename="dask-report.html"):
             # Scatter surface mesh across all nodes to preserve computation time and memory.
-            gt_scene_trimesh_future = client.scatter(self.loader.gt_scene_trimesh, broadcast=True)
+            gt_gtsfm_data_future = client.scatter(self.loader.gt_gtsfm_data, broadcast=True)
 
             # Prepare computation graph.
             start_time = time.time()
@@ -68,8 +68,7 @@ class GtsfmRunnerAstronetLoader(GtsfmRunnerBase):
                 image_graph=self.loader.create_computation_graph_for_images(),
                 camera_intrinsics_graph=self.loader.create_computation_graph_for_intrinsics(),
                 image_shape_graph=self.loader.create_computation_graph_for_image_shapes(),
-                gt_cameras_graph=self.loader.create_computation_graph_for_cameras(),
-                gt_scene_mesh=gt_scene_trimesh_future,
+                gt_gtsfm_data=self.loader.gt_gtsfm_data,
             )
 
             # Run SfM pipeline.

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -103,10 +103,16 @@ class SceneOptimizer:
         image_graph: List[Delayed],
         camera_intrinsics_graph: List[Delayed],
         image_shape_graph: List[Delayed],
-        gt_cameras_graph: Optional[List[Delayed]] = None,
-        gt_scene_mesh: Optional[Trimesh] = None,
+        gt_gtsfm_data: Optional[GtsfmData] = None,
     ) -> Delayed:
         """The SceneOptimizer plate calls the FeatureExtractor and TwoViewEstimator plates several times."""
+        # Build cameras graph from GT GtsfmData.
+        # TODO (): remove later; this is just to conform to the required input of other functions.
+        gt_cameras_graph = (
+            [dask.delayed(gt_gtsfm_data.get_camera)(i) for i in gt_gtsfm_data._cameras.keys()]
+            if gt_gtsfm_data
+            else None
+        )
 
         # auxiliary graph elements for visualizations and saving intermediate
         # data for analysis, not returned to the user.
@@ -128,13 +134,6 @@ class SceneOptimizer:
         two_view_reports_dict: Dict[Tuple[int, int], TwoViewEstimationReport] = {}
         two_view_reports_pp_dict: Dict[Tuple[int, int], TwoViewEstimationReport] = {}
         for (i1, i2) in image_pair_indices:
-            # Collect ground truth relative and absolute poses if available.
-            # TODO(johnwlambert): decompose this method -- name it as "calling_the_plate()"
-            if gt_cameras_graph is not None:
-                gt_wTi1, gt_wTi2 = gt_cameras_graph[i1].pose(), gt_cameras_graph[i2].pose()
-            else:
-                gt_wTi1, gt_wTi2 = None, None
-
             # TODO(johnwlambert): decompose this so what happens in the loop is a separate method
             (
                 i2Ri1,
@@ -151,9 +150,7 @@ class SceneOptimizer:
                 camera_intrinsics_graph[i2],
                 image_shape_graph[i1],
                 image_shape_graph[i2],
-                gt_wTi1,
-                gt_wTi2,
-                gt_scene_mesh,
+                gt_gtsfm_data.get_two_view_data(i1, i2),
             )
 
             # Store results.

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -69,9 +69,7 @@ class TwoViewEstimator:
         camera_intrinsics_i2_graph: Delayed,
         im_shape_i1_graph: Delayed,
         im_shape_i2_graph: Delayed,
-        gt_wTi1_graph: Optional[Delayed] = None,
-        gt_wTi2_graph: Optional[Delayed] = None,
-        gt_scene_mesh_graph: Optional[Delayed] = None,
+        gt_gtsfm_data: Optional[Delayed] = None,
     ) -> Tuple[Delayed, Delayed, Delayed, Optional[Delayed], Optional[Delayed]]:
         """Create delayed tasks for matching and verification.
 
@@ -94,6 +92,13 @@ class TwoViewEstimator:
             Two view report w/ verifier metrics wrapped as Delayed.
             Two view report w/ post-processor metrics wrapped as Delayed.
         """
+        # Unpack GT data.
+        if gt_gtsfm_data is not None:
+            gt_wTi1_graph = gt_gtsfm_data.get_camera(0).pose()
+            gt_wTi2_graph = gt_gtsfm_data.get_camera(1).pose()
+        else:
+            gt_wTi1_graph, gt_wTi2_graph = None, None
+        gt_scene_mesh_graph = gt_gtsfm_data.scene_mesh
 
         # graph for matching to obtain putative correspondences
         corr_idxs_graph = self._matcher.create_computation_graph(


### PR DESCRIPTION
**Disclaimer: currently only working on AstroNet data**

The docstring for the `GtsfmData` class states that its purpose is "describing the complete 3D scene." Therefore, I thought it made sense to extend the class' functionality slightly to support describing the _ground truth_ scene as well. That way we can just track a single `GtsfmData` object as opposed to tracking the various components of the ground truth scene: `gt_cameras_graph`, `gt_poses_graph`, `gt_scene_mesh_graph`, etc.

This is definitely not in its final form, but I wanted to get some feedback before I sunk too much time into refactoring things.
