### PR TITLE
Show Door dataset MVS teaser in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ GTSFM is an end-to-end SFM pipeline based on [GTSAM](https://github.com/borglab/
 
 <p align="left">
   <img src="https://user-images.githubusercontent.com/16724970/121294002-a4d7a400-c8ba-11eb-895e-a50305c049b6.gif" height="315" title="Olsson Lund Dataset: Door, 12 images">
-  <img src="https://user-images.githubusercontent.com/16724970/121293398-8cb35500-c8b9-11eb-8898-6162cb2372e1.gif" height="315">
+  <img src="https://user-images.githubusercontent.com/16724970/142500100-ed3bd07b-f839-488e-a01d-823a9fbeaba4.gif" height="315">
 </p>
 
 ## License


### PR DESCRIPTION
- Swaps out the old sparse teaser gif in the Readme with high quality MVS teaser gif.
![door12_downsampled2cm](https://user-images.githubusercontent.com/16724970/142500385-0b3bcf5c-3509-4e34-b01b-2dae55e7dd66.gif)


