### PR TITLE
Reducing max frame lookahead to 15

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
             [deep_front_end,  skydio-8,              8,   jpg,  gdrive,     colmap-loader,  760, true],
             [sift_front_end,  skydio-32,             32,  jpg,  gdrive,     colmap-loader,  760, true],
             [deep_front_end,  skydio-32,             32,  jpg,  gdrive,     colmap-loader,  760, true],
-            [deep_front_end,  skydio-501,            30,  jpg,  wget,       colmap-loader,  760, true],
+            [deep_front_end,  skydio-501,            15,  jpg,  wget,       colmap-loader,  760, true],
             [sift_front_end,  palace-fine-arts-281,  25,  jpg,  wget,       olsson-loader,  320, true],
             [deep_front_end,  notre-dame-20,         20,  jpg,  gdrive,     colmap-loader,  760, false],
             [sift_front_end,  2011205_rc3,           65,  png,  wget,       astronet,       1024, true],


### PR DESCRIPTION
Reducing the max frame lookahead to 15 to ensure that the front-end cache is not booted by the CI. Github CI provides 5GB of cache space, and the current `max_frame_lookahead` of 30 requires ~1498 MB of cache. As a result, the cache is deleted ocassionally.

Reducing the max frame lookahead will reduce the number of pairs and hence the number of match indices.

| Data | Number of entries in current | Number of entries in new |
| ------ | --------- | ------ |
| Keypoints | 501 | 501 |
| Descriptors | 501 | 501 |
| Matches | 14565 | 7395 |

This should have a significant impact on the cache size from the dataset.
