### PR TITLE
add trimesh to mac conda env

### DIFF
--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -45,5 +45,4 @@ dependencies:
   - pip:
     - pydegensac
     - colour
-
-
+    - trimesh[easy]


### PR DESCRIPTION
Present in linux env file, but missing in mac env file.