### PR TITLE
Adding GMS matcher

### DIFF
--- a/gtsfm/configs/deep_front_end.yaml
+++ b/gtsfm/configs/deep_front_end.yaml
@@ -19,10 +19,12 @@ SceneOptimizer:
     bundle_adjust_2view_maxiters: 100
 
     matcher:
-      _target_: gtsfm.frontend.cacher.matcher_cacher.MatcherCacher
-      matcher_obj:
-        _target_: gtsfm.frontend.matcher.superglue_matcher.SuperGlueMatcher
-        use_outdoor_model: True
+      _target_: gtsfm.frontend.matcher.gms_matcher_decorator.GmsMatcher
+      underlying_matcher_obj:
+        _target_: gtsfm.frontend.cacher.matcher_cacher.MatcherCacher
+        matcher_obj:
+          _target_: gtsfm.frontend.matcher.superglue_matcher.SuperGlueMatcher
+          use_outdoor_model: True
 
     verifier:
       _target_: gtsfm.frontend.verifier.ransac.Ransac

--- a/gtsfm/configs/sift_front_end.yaml
+++ b/gtsfm/configs/sift_front_end.yaml
@@ -19,9 +19,11 @@ SceneOptimizer:
     bundle_adjust_2view_maxiters: 100
 
     matcher:
-      _target_: gtsfm.frontend.cacher.matcher_cacher.MatcherCacher
-      matcher_obj:
-        _target_: gtsfm.frontend.matcher.twoway_matcher.TwoWayMatcher
+      _target_: gtsfm.frontend.matcher.gms_matcher_decorator.GmsMatcher
+      underlying_matcher_obj:
+        _target_: gtsfm.frontend.cacher.matcher_cacher.MatcherCacher
+        matcher_obj:
+          _target_: gtsfm.frontend.matcher.twoway_matcher.TwoWayMatcher
 
     verifier:
       _target_: gtsfm.frontend.verifier.ransac.Ransac

--- a/gtsfm/configs/sift_front_end.yaml
+++ b/gtsfm/configs/sift_front_end.yaml
@@ -10,7 +10,7 @@ SceneOptimizer:
     detector_descriptor:
       _target_: gtsfm.frontend.cacher.detector_descriptor_cacher.DetectorDescriptorCacher
       detector_descriptor_obj:
-        _target_: gtsfm.frontend.detector_descriptor.sift.SIFTDetectorDescriptor
+        _target_: gtsfm.frontend.detector_descriptor.orb.ORB
 
   two_view_estimator:
     _target_: gtsfm.two_view_estimator.TwoViewEstimator

--- a/gtsfm/frontend/detector_descriptor/orb.py
+++ b/gtsfm/frontend/detector_descriptor/orb.py
@@ -1,0 +1,53 @@
+"""ORB detector-descriptor implementation.
+
+The algorithm was proposed in 'Orb: an efficient alternative to sift or surf' and is implemented by wrapping over 
+OpenCV's API.
+
+References:
+- https://ieeexplore.ieee.org/document/6126544
+- https://docs.opencv.org/3.4/db/d95/classcv_1_1ORB.html
+
+Authors: Ayush Baid
+"""
+from typing import Tuple
+
+import cv2 as cv
+import numpy as np
+
+import gtsfm.utils.features as feature_utils
+import gtsfm.utils.images as image_utils
+from gtsfm.common.image import Image
+from gtsfm.common.keypoints import Keypoints
+from gtsfm.frontend.detector_descriptor.detector_descriptor_base import DetectorDescriptorBase
+
+
+class ORB(DetectorDescriptorBase):
+    """DoG detector using OpenCV's implementation, with settings optimized for GMS."""
+
+    def __init__(self, max_keypoints: int = 10000, fast_threshold: int = 0) -> None:
+        super().__init__(max_keypoints=max_keypoints)
+        self._fast_threshold = fast_threshold
+
+    def detect_and_describe(self, image: Image) -> Tuple[Keypoints, np.ndarray]:
+        """Perform feature detection as well as their description.
+
+        Refer to detect() in DetectorBase and describe() in DescriptorBase for details about the output format.
+
+        Args:
+            image: the input image.
+
+        Returns:
+            Detected keypoints, with length N <= max_keypoints.
+            Corr. descriptors, of shape (N, D) where D is the dimension of each descriptor.
+        """
+        gray_image = image_utils.rgb_to_gray_cv(image)
+
+        opencv_obj = cv.ORB_create(nfeatures=self.max_keypoints, fastThreshold=self._fast_threshold)
+        cv_keypoints, descriptors = opencv_obj.detectAndCompute(gray_image.value_array, image.mask)
+
+        keypoints = feature_utils.cast_to_gtsfm_keypoints(cv_keypoints)
+
+        keypoints, selection_idxs = keypoints.get_top_k(self.max_keypoints)
+        descriptors = descriptors[selection_idxs]
+
+        return keypoints, descriptors

--- a/gtsfm/frontend/matcher/gms_matcher_decorator.py
+++ b/gtsfm/frontend/matcher/gms_matcher_decorator.py
@@ -1,0 +1,62 @@
+"""Grid-based motion statistics (GMS) feature matching implemented as a decorator to work with other matching 
+techniques.
+
+The algorithm was proposed in "GMS: Grid-based Motion Statistics for Fast, Ultra-robust Feature Correspondence" and
+is implemented by calling OpenCV's API.
+
+References:
+- https://openaccess.thecvf.com/content_cvpr_2017/papers/Bian_GMS_Grid-based_Motion_CVPR_2017_paper.pdf
+- https://docs.opencv.org/3.4/db/dd9/group__xfeatures2d__match.html#gaaf19e0024c555f8d8982396376150288
+
+Authors: Ayush Baid, Travis Head
+"""
+from typing import List, Tuple
+
+import cv2 as cv
+import numpy as np
+from cv2 import DMatch
+
+import gtsfm.utils.logger as logger_utils
+from gtsfm.common.keypoints import Keypoints
+from gtsfm.frontend.matcher.matcher_base import MatcherBase
+
+logger = logger_utils.get_logger()
+
+
+class GmsMatcher(MatcherBase):
+    def __init__(self, underlying_matcher_obj: MatcherBase) -> None:
+        self._underlying_matcher: MatcherBase = underlying_matcher_obj
+        self._with_rotation: bool = True
+        self._with_scale: bool = True
+
+    def match(
+        self,
+        keypoints_i1: Keypoints,
+        keypoints_i2: Keypoints,
+        descriptors_i1: np.ndarray,
+        descriptors_i2: np.ndarray,
+        im_shape_i1: Tuple[int, int],
+        im_shape_i2: Tuple[int, int],
+    ) -> np.ndarray:
+        matches_from_underlying_matcher = self._underlying_matcher.match(
+            keypoints_i1, keypoints_i2, descriptors_i1, descriptors_i2, im_shape_i1, im_shape_i2
+        )
+
+        gms_matches = cv.xfeatures2d.matchGMS(
+            size1=im_shape_i1,
+            size2=im_shape_i2,
+            keypoints1=keypoints_i1.cast_to_opencv_keypoints(),
+            keypoints2=keypoints_i2.cast_to_opencv_keypoints(),
+            matches1to2=self.__cast_to_opencv_dmatches(matches_from_underlying_matcher),
+            withRotation=self._with_rotation,
+            withScale=self._with_scale,
+        )
+
+        return np.array([[m.queryIdx, m.trainIdx] for m in gms_matches]).astype(np.int32)
+
+    def __cast_to_opencv_dmatches(self, matches: np.ndarray) -> List[DMatch]:
+        dmatches: List[DMatch] = []
+        for idx_i1, idx_i2 in matches:
+            dmatches.append(DMatch(_queryIdx=idx_i1, _trainIdx=idx_i2, _distance=0.0))
+
+        return dmatches


### PR DESCRIPTION
This PR adds the GMS matcher as a decorator, so it can be used in conjunction with any other matcher.

Note: the cache is used on the underlying macther results and not the GMS matcher for now.