### PR TITLE
moving open3d to pip in the Mac environment file

### DIFF
--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -40,9 +40,8 @@ dependencies:
   - h5py
   - plotly=4.14.3
   - tabulate
-  # visualization
-  - open3d
   - pip:
+    - open3d # conda-forge version does not support M1 Macs. 
     - pydegensac
     - colour
     - trimesh[easy]


### PR DESCRIPTION
The conda forge version does not support ARM M1 Macs. https://github.com/isl-org/Open3D/issues/2675#issuecomment-996530610 