### PR TITLE
cleanup docstrings and count of input edges for ViewGraphEstimator

### DIFF
--- a/gtsfm/bundle/bundle_adjustment.py
+++ b/gtsfm/bundle/bundle_adjustment.py
@@ -178,12 +178,14 @@ class BundleAdjustmentOptimizer:
     def run(
         self,
         initial_data: GtsfmData,
+        verbose = True,
     ) -> Tuple[GtsfmData, GtsfmMetricsGroup]:
         """Run the bundle adjustment by forming factor graph and optimizing using Levenberg–Marquardt optimization.
 
         Args:
             initial_data: initialized cameras, tracks w/ their 3d landmark from triangulation.
             cameras_gt: list of GT cameras, ordered by camera index.
+            verbose: Boolean flag to print out additional info for debugging.
 
         Results:
             Optimized camera poses, 3D point w/ tracks, and error metrics, aligned to GT (if provided).
@@ -206,13 +208,15 @@ class BundleAdjustmentOptimizer:
         final_error = graph.error(result_values)
 
         # Error drops from ~2764.22 to ~0.046
-        logger.info(f"initial error: {graph.error(initial_values):.2f}")
-        logger.info(f"final error: {final_error:.2f}")
+        if verbose:
+            logger.info(f"initial error: {graph.error(initial_values):.2f}")
+            logger.info(f"final error: {final_error:.2f}")
 
         # construct the results
         optimized_data = values_to_gtsfm_data(result_values, initial_data, self._shared_calib)
 
-        logger.info("[Result] Number of tracks before filtering: %d", optimized_data.number_tracks())
+        if verbose:
+            logger.info("[Result] Number of tracks before filtering: %d", optimized_data.number_tracks())
 
         # filter the largest errors
         if self._output_reproj_error_thresh:

--- a/gtsfm/bundle/bundle_adjustment.py
+++ b/gtsfm/bundle/bundle_adjustment.py
@@ -178,7 +178,7 @@ class BundleAdjustmentOptimizer:
     def run(
         self,
         initial_data: GtsfmData,
-        verbose = True,
+        verbose: bool = True,
     ) -> Tuple[GtsfmData, GtsfmMetricsGroup]:
         """Run the bundle adjustment by forming factor graph and optimizing using Levenberg–Marquardt optimization.
 

--- a/gtsfm/evaluation/visualize_benchmark_comparison.py
+++ b/gtsfm/evaluation/visualize_benchmark_comparison.py
@@ -36,11 +36,11 @@ BENCHMARK_YAML_FPATH = Path(__file__).parent.parent.parent / ".github" / "workfl
 
 
 TABLE_NAMES = [
-    "Rotation Cycle Consistency Metrics",
     "Verifier Summary Pre Ba 2view Report",
     "Verifier Summary Post Ba 2view Report",
     "Verifier Summary Post Inlier Support Processor 2view Report",
-    "Verifier Summary Post Cycle Consistent 2view Report",
+    "View Graph Estimation Metrics",
+    "Verifier Summary Viewgraph 2view Report",
     "Averaging Metrics",
     "Data Association Metrics",
     "Bundle Adjustment Metrics",

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -178,7 +178,7 @@ class TwoViewEstimator:
         ba_input.add_camera(1, camera_i2)
         for track in triangulated_tracks:
             ba_input.add_track(track)
-        ba_output, _ = self._ba_optimizer.run(ba_input)
+        ba_output, _ = self._ba_optimizer.run(ba_input, verbose=False)
         wTi1, wTi2 = ba_output.get_camera_poses()  # extract the camera poses
         if wTi1 is None or wTi2 is None:
             logger.warning("2-view BA failed")

--- a/gtsfm/utils/metrics.py
+++ b/gtsfm/utils/metrics.py
@@ -10,7 +10,6 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from trimesh import Trimesh
-from dask.delayed import Delayed
 from gtsam import PinholeCameraCal3Bundler, Cal3Bundler, EssentialMatrix, Point3, Pose3, Rot3, Unit3
 
 import gtsfm.utils.geometry_comparisons as comp_utils
@@ -414,7 +413,7 @@ def get_rotations_translations_from_poses(
     return rotations, translations
 
 
-def save_metrics_as_json(metrics_groups: Delayed, output_dir: str) -> None:
+def save_metrics_as_json(metrics_groups: List[GtsfmMetricsGroup], output_dir: str) -> None:
     """Saves the input metrics groups as JSON files using the name of the group.
 
     Args:

--- a/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
+++ b/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
@@ -122,7 +122,7 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
             rot_errors = [two_view_reports[e].R_error_deg for e in edges]
             gt_known = all([err is not None for err in rot_errors])
             # if ground truth unknown, cannot estimate error w.r.t. GT
-            max_rot_error = float(np.max(rot_errors)) if gt_known else None
+            max_rot_error = max(rot_errors) if gt_known else None
             max_gt_error_in_cycle.append(max_rot_error)
 
         # Filter the edges based on the aggregate error.

--- a/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
+++ b/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
@@ -98,7 +98,7 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
         # pylint: disable=unused-argument
 
         logger.info("Input number of edges: %d" % len(i2Ri1_dict))
-        input_edges: List[Tuple[int, int]] = self.__get_valid_input_edges(i2Ri1_dict)
+        input_edges: List[Tuple[int, int]] = i2Ri1_dict.keys()
         triplets: List[Tuple[int, int, int]] = graph_utils.extract_cyclic_triplets_from_edges(input_edges)
 
         logger.info("Number of triplets: %d" % len(triplets))

--- a/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
+++ b/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
@@ -226,7 +226,7 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
         MEDIAN_EDGE_ERROR: Returns the median value among the input values.
 
         Args:
-            errors (List[float]): A list of errors for the edge in different triplets.
+            edge_errors: A list of errors for the edge in different triplets.
 
         Returns:
             float: The aggregated error value.

--- a/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
+++ b/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
@@ -196,28 +196,6 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
         plt.savefig(os.path.join("plots", "cycle_error_vs_GT_rot_error.jpg"), dpi=400)
         plt.close("all")
 
-    def __get_valid_input_edges(self, i2Ri1_dict: Dict[Tuple[int, int], Rot3]) -> List[Tuple[int, int]]:
-        """Gets the input edges (i1, i2) with the relative rotation i2Ri1 where:
-        1. i1 < i2
-        2. i2Ri1 is not None
-
-        Args:
-            i2Ri1_dict: input dictionary of relative rotations.
-
-        Returns:
-            List of valid edges.
-        """
-        valid_edges = []
-        for (i1, i2), i2Ri1 in i2Ri1_dict.items():
-            if i2Ri1 is None:
-                continue  # edge was previously discarded for insufficient support
-            if i1 >= i2:
-                logger.error("Incorrectly ordered edge indices found in cycle consistency for (%d, %d)", i1, i2)
-                continue
-            valid_edges.append((i1, i2))
-
-        return valid_edges
-
     def __aggregate_errors_for_edge(self, edge_errors: List[float]) -> float:
         """Aggregates a list of errors from different triplets into a single scalar value.
 

--- a/gtsfm/view_graph_estimator/view_graph_estimator_base.py
+++ b/gtsfm/view_graph_estimator/view_graph_estimator_base.py
@@ -58,6 +58,28 @@ class ViewGraphEstimatorBase(metaclass=abc.ABCMeta):
             Edges of the view-graph, which are the subset of the image pairs in the input args.
         """
 
+    def __get_valid_input_edges(self, i2Ri1_dict: Dict[Tuple[int, int], Rot3]) -> List[Tuple[int, int]]:
+        """Gets the input edges (i1, i2) with the relative rotation i2Ri1 where:
+        1. i1 < i2
+        2. i2Ri1 is not None
+
+        Args:
+            i2Ri1_dict: input dictionary of relative rotations.
+
+        Returns:
+            List of valid edges.
+        """
+        valid_edges = []
+        for (i1, i2), i2Ri1 in i2Ri1_dict.items():
+            if i2Ri1 is None:
+                continue  # edge was previously discarded for insufficient support
+            if i1 >= i2:
+                logger.error("Incorrectly ordered edge indices found in cycle consistency for (%d, %d)", i1, i2)
+                continue
+            valid_edges.append((i1, i2))
+
+        return valid_edges
+
     def _filter_with_edges(
         self,
         i2Ri1_dict: Dict[Tuple[int, int], Rot3],
@@ -123,7 +145,6 @@ class ViewGraphEstimatorBase(metaclass=abc.ABCMeta):
         if len(two_view_reports) == 0:
             return GtsfmMetricsGroup(name="rotation_cycle_consistency_metrics", metrics=[])
 
-        input_edges = two_view_reports.keys()
         valid_edges = self.__get_valid_input_edges(i2Ri1_dict)
         inlier_i1_i2 = view_graph_edges
         outlier_i1_i2 = list(set(valid_edges) - set(inlier_i1_i2))

--- a/gtsfm/view_graph_estimator/view_graph_estimator_base.py
+++ b/gtsfm/view_graph_estimator/view_graph_estimator_base.py
@@ -181,9 +181,6 @@ class ViewGraphEstimatorBase(metaclass=abc.ABCMeta):
                 else:
                     outlier_U_angular_errors.append(report.U_error_deg)
 
-        logger.info("Calling PR computation for R errors")
-        print("inlier errors ", inlier_R_angular_errors)
-        print("outlier errors", outlier_R_angular_errors)
         R_precision, R_recall = metrics_utils.get_precision_recall_from_errors(
             inlier_R_angular_errors, outlier_R_angular_errors, MAX_INLIER_MEASUREMENT_ERROR_DEG
         )

--- a/gtsfm/view_graph_estimator/view_graph_estimator_base.py
+++ b/gtsfm/view_graph_estimator/view_graph_estimator_base.py
@@ -124,8 +124,9 @@ class ViewGraphEstimatorBase(metaclass=abc.ABCMeta):
             return GtsfmMetricsGroup(name="rotation_cycle_consistency_metrics", metrics=[])
 
         input_edges = two_view_reports.keys()
+        valid_edges = self.__get_valid_input_edges(i2Ri1_dict)
         inlier_i1_i2 = view_graph_edges
-        outlier_i1_i2 = [i1_i2 for i1_i2 in input_edges if i1_i2 not in inlier_i1_i2]
+        outlier_i1_i2 = list(set(valid_edges) - set(inlier_i1_i2))
 
         inlier_R_angular_errors = []
         outlier_R_angular_errors = []
@@ -157,7 +158,7 @@ class ViewGraphEstimatorBase(metaclass=abc.ABCMeta):
             inlier_U_angular_errors, outlier_U_angular_errors, MAX_INLIER_MEASUREMENT_ERROR_DEG
         )
         view_graph_metrics = [
-            GtsfmMetric("num_input_measurements", len(two_view_reports)),
+            GtsfmMetric("num_input_measurements", len(valid_edges),
             GtsfmMetric("num_inlier_measurements", len(inlier_i1_i2)),
             GtsfmMetric("num_outlier_measurements", len(outlier_i1_i2)),
             GtsfmMetric("R_precision", R_precision),

--- a/gtsfm/view_graph_estimator/view_graph_estimator_base.py
+++ b/gtsfm/view_graph_estimator/view_graph_estimator_base.py
@@ -158,7 +158,7 @@ class ViewGraphEstimatorBase(metaclass=abc.ABCMeta):
             inlier_U_angular_errors, outlier_U_angular_errors, MAX_INLIER_MEASUREMENT_ERROR_DEG
         )
         view_graph_metrics = [
-            GtsfmMetric("num_input_measurements", len(valid_edges),
+            GtsfmMetric("num_input_measurements", len(valid_edges)),
             GtsfmMetric("num_inlier_measurements", len(inlier_i1_i2)),
             GtsfmMetric("num_outlier_measurements", len(outlier_i1_i2)),
             GtsfmMetric("R_precision", R_precision),

--- a/gtsfm/view_graph_estimator/view_graph_estimator_base.py
+++ b/gtsfm/view_graph_estimator/view_graph_estimator_base.py
@@ -61,7 +61,7 @@ class ViewGraphEstimatorBase(metaclass=abc.ABCMeta):
             Edges of the view-graph, which are the subset of the image pairs in the input args.
         """
 
-    def __get_valid_input_edges(
+    def _get_valid_input_edges(
         self, 
         i2Ri1_dict: Dict[Tuple[int, int], Rot3],
         i2Ui1_dict: Dict[Tuple[int, int], Unit3]
@@ -236,7 +236,7 @@ class ViewGraphEstimatorBase(metaclass=abc.ABCMeta):
             - GtsfmMetricsGroup with the view graph estimation metrics
         """
         # Remove all invalid edges in the input dicts.
-        valid_edges = dask.delayed(self.__get_valid_input_edges)(
+        valid_edges = dask.delayed(self._get_valid_input_edges)(
             i2Ri1_dict=i2Ri1_dict,
             i2Ui1_dict=i2Ui1_dict,
         )


### PR DESCRIPTION
- Since many edges have been discarded by the time we get to the ViewGraphEstimator, inlier/outlier counts have to be computed from the valid set.