### PR TITLE
3-view reprojection-error based ViewGraphEstimator

### DIFF
--- a/gtsfm/configs/deep_front_end.yaml
+++ b/gtsfm/configs/deep_front_end.yaml
@@ -38,8 +38,7 @@ SceneOptimizer:
   multiview_optimizer:
     _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer
     view_graph_estimator:
-      _target_: gtsfm.view_graph_estimator.cycle_consistent_rotation_estimator.CycleConsistentRotationViewGraphEstimator
-      edge_error_aggregation_criterion: MEDIAN_EDGE_ERROR
+      _target_: gtsfm.view_graph_estimator.reprojection_error_view_graph_estimator.ReprojectionErrorViewGraphEstimator
       
     rot_avg_module:
       _target_: gtsfm.averaging.rotation.shonan.ShonanRotationAveraging

--- a/gtsfm/data_association/data_assoc.py
+++ b/gtsfm/data_association/data_assoc.py
@@ -64,7 +64,7 @@ class DataAssociation(NamedTuple):
         corr_idxs_dict: Dict[Tuple[int, int], np.ndarray],
         keypoints_list: List[Keypoints],
         images: Optional[List[Image]] = None,
-        cameras_gt: Optional[List[Cal3Bundler]] = None,
+        cameras_gt: Optional[List[PinholeCameraCal3Bundler]] = None,
     ) -> Tuple[GtsfmData, GtsfmMetricsGroup]:
         """Perform the data association.
 

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -104,7 +104,7 @@ class MultiViewOptimizer:
         if gt_cameras_graph is None:
             return ba_input_graph, ba_result_graph, None
 
-        # TODO: move to rotation averaging
+        # TODO (akshaykrishnan): move rot avg metrics to rotation averaging module
         rot_avg_metrics = dask.delayed(metrics_utils.compute_global_rotation_metrics)(
             wRi_graph, wti_graph, gt_poses_graph
         )

--- a/gtsfm/utils/metrics.py
+++ b/gtsfm/utils/metrics.py
@@ -273,7 +273,7 @@ def compute_translation_angle_metric(
     for (i1, i2) in i2Ui1_dict:
         i2Ui1 = i2Ui1_dict[(i1, i2)]
         angles.append(comp_utils.compute_translation_to_direction_angle(i2Ui1, wTi_list[i2], wTi_list[i1]))
-    return GtsfmMetric("translation_angle_error_deg", np.array(angles, dtype=np.float))
+    return GtsfmMetric("translation_angle_error_deg", np.array(angles, dtype=np.float64))
 
 
 def compute_global_rotation_metrics(

--- a/gtsfm/utils/tracks.py
+++ b/gtsfm/utils/tracks.py
@@ -4,7 +4,7 @@ Authors: Ayush Baid
 """
 from typing import Dict, List
 
-from gtsam import Cal3Bundler, SfmTrack
+from gtsam import PinholeCameraCal3Bundler, SfmTrack
 
 from gtsfm.common.sfm_track import SfmMeasurement, SfmTrack2d
 from gtsfm.data_association.point3d_initializer import (
@@ -15,7 +15,7 @@ from gtsfm.data_association.point3d_initializer import (
 
 
 def classify_tracks2d_with_gt_cameras(
-    tracks: List[SfmTrack2d], cameras_gt: List[Cal3Bundler], reproj_error_thresh_px: float = 3
+    tracks: List[SfmTrack2d], cameras_gt: List[PinholeCameraCal3Bundler], reproj_error_thresh_px: float = 3
 ) -> List[TriangulationExitCode]:
     """Classifies the 2D tracks w.r.t ground truth cameras by performing triangulation and collecting exit codes.
 
@@ -29,7 +29,7 @@ def classify_tracks2d_with_gt_cameras(
         The triangulation exit code for each input track, as list of the same length as of tracks.
     """
     # do a simple triangulation with the GT cameras
-    cameras_dict: Dict[int, Cal3Bundler] = {i: cam for i, cam in enumerate(cameras_gt)}
+    cameras_dict: Dict[int, PinholeCameraCal3Bundler] = {i: cam for i, cam in enumerate(cameras_gt)}
     point3d_initializer = Point3dInitializer(
         track_camera_dict=cameras_dict, mode=TriangulationParam.NO_RANSAC, reproj_error_thresh=reproj_error_thresh_px
     )
@@ -43,7 +43,7 @@ def classify_tracks2d_with_gt_cameras(
 
 
 def classify_tracks3d_with_gt_cameras(
-    tracks: List[SfmTrack], cameras_gt: List[Cal3Bundler], reproj_error_thresh_px: float = 3
+    tracks: List[SfmTrack], cameras_gt: List[PinholeCameraCal3Bundler], reproj_error_thresh_px: float = 3
 ) -> List[TriangulationExitCode]:
     """Classifies the 3D tracks w.r.t ground truth cameras by performing triangulation and collecting exit codes.
 

--- a/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
+++ b/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
@@ -196,28 +196,6 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
         plt.savefig(os.path.join("plots", "cycle_error_vs_GT_rot_error.jpg"), dpi=400)
         plt.close("all")
 
-    def __get_valid_input_edges(self, i2Ri1_dict: Dict[Tuple[int, int], Rot3]) -> List[Tuple[int, int]]:
-        """Gets the input edges (i1, i2) with the relative rotation i2Ri1 where:
-        1. i1 < i2
-        2. i2Ri1 is not None
-
-        Args:
-            i2Ri1_dict: input dictionary of relative rotations.
-
-        Returns:
-            List of valid edges.
-        """
-        valid_edges = []
-        for (i1, i2), i2Ri1 in i2Ri1_dict.items():
-            if i2Ri1 is None:
-                continue  # edge was previously discarded for insufficient support
-            if i1 >= i2:
-                logger.error("Incorrectly ordered edge indices found in cycle consistency for (%d, %d)", i1, i2)
-                continue
-            valid_edges.append((i1, i2))
-
-        return valid_edges
-
     def __aggregate_errors_for_edge(self, edge_errors: List[float]) -> float:
         """Aggregates a list of errors from different triplets into a single scalar value.
 

--- a/gtsfm/view_graph_estimator/reprojection_error_view_graph_estimator.py
+++ b/gtsfm/view_graph_estimator/reprojection_error_view_graph_estimator.py
@@ -1,0 +1,202 @@
+"""
+In the spirit of "Growing Consensus" (Son16eccv)
+
+Authors: John Lambert
+"""
+
+import logging
+import os
+from collections import defaultdict
+from enum import Enum
+from typing import Dict, List, Optional, Set, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+from gtsam import Cal3Bundler, PinholeCameraCal3Bundler, Pose3, Rot3, Unit3
+
+import gtsfm.multi_view_optimizer as multi_view_optimizer
+import gtsfm.utils.geometry_comparisons as comp_utils
+import gtsfm.utils.graph as graph_utils
+import gtsfm.utils.logger as logger_utils
+import gtsfm.utils.metrics as metrics_utils
+from gtsfm.averaging.rotation.shonan import ShonanRotationAveraging
+from gtsfm.averaging.translation.averaging_1dsfm import TranslationAveraging1DSFM
+from gtsfm.bundle.bundle_adjustment import BundleAdjustmentOptimizer
+from gtsfm.common.keypoints import Keypoints
+from gtsfm.data_association.data_assoc import DataAssociation, TriangulationParam
+from gtsfm.evaluation.metrics import GtsfmMetricsGroup
+from gtsfm.two_view_estimator import TwoViewEstimationReport
+from gtsfm.view_graph_estimator.view_graph_estimator_base import ViewGraphEstimatorBase
+
+logger = logger_utils.get_logger()
+
+
+class ThreeViewRegistrationMethod(str, Enum):
+    """Two supported modes for 3-view registration:
+    1. PNP (a la incremental SfM) or
+    2. Global rotation averaging + translation averaging.
+    """
+
+    PNP: str = "PNP"
+    AVERAGING: str = "AVERAGING"
+
+
+class ReprojectionErrorViewGraphEstimator(ViewGraphEstimatorBase):
+    """Triangulates and bundle adjusts points in 3-views and uses their reprojection error to reason about outliers.
+
+    Alternatively, could use triangulation + PNP.
+    """
+
+    def __init__(
+        self, registration_method: ThreeViewRegistrationMethod = ThreeViewRegistrationMethod.AVERAGING
+    ) -> None:
+        """ """
+        self._registration_method = registration_method
+        self._rot_avg_module = ShonanRotationAveraging()
+        self._trans_avg_module = TranslationAveraging1DSFM(robust_measurement_noise=True)
+
+        # TODO: could limit to length 3 tracks.
+        self._data_association_module = DataAssociation(
+            reproj_error_thresh=100,
+            min_track_len=2,
+            mode=TriangulationParam.NO_RANSAC,
+            num_ransac_hypotheses=20,
+            save_track_patches_viz=False,
+        )
+
+        self._bundle_adjustment_module = BundleAdjustmentOptimizer(
+            output_reproj_error_thresh=3,  # for post-optimization filtering
+            robust_measurement_noise=True,
+            shared_calib=False,
+        )
+
+    def run(
+        self,
+        i2Ri1_dict: Dict[Tuple[int, int], Rot3],
+        i2Ui1_dict: Dict[Tuple[int, int], Unit3],
+        calibrations: List[Cal3Bundler],
+        corr_idxs_i1i2: Dict[Tuple[int, int], np.ndarray],
+        keypoints: List[Keypoints],
+        two_view_reports: Dict[Tuple[int, int], TwoViewEstimationReport],
+    ) -> Set[Tuple[int, int]]:
+        """Estimates the view graph using the rotation consistency constraint in a cycle of 3 edges.
+
+        Args:
+            i2Ri1_dict: Dict from (i1, i2) to relative rotation of i1 with respect to i2.
+            i2Ui1_dict: Dict from (i1, i2) to relative translation direction of i1 with respect to i2.
+            calibrations: list of calibrations for each image.
+            corr_idxs_i1i2: Dict from (i1, i2) to indices of verified correspondences from i1 to i2.
+            keypoints: keypoints for each images.
+            two_view_reports: Dict from (i1, i2) to the TwoViewEstimationReport of the edge.
+
+        Returns:
+            Edges of the view-graph, which are the subset of the image pairs in the input args.
+        """
+
+        valid_edges = set()
+
+        logger.info("Input number of edges: %d" % len(i2Ri1_dict))
+        input_edges: List[Tuple[int, int]] = self._get_valid_input_edges(i2Ri1_dict)
+        triplets: List[Tuple[int, int, int]] = graph_utils.extract_cyclic_triplets_from_edges(input_edges)
+
+        logger.info("Number of triplets: %d" % len(triplets))
+        for i0, i1, i2 in triplets:  # sort order guaranteed
+            logger.info("On triplet (%d,%d,%d)", i0, i1, i2)
+            i2Ri1_dict_subscene, i2Ui1_dict_subscene, corr_idxs_i1_i2_subscene, _ = self._filter_with_edges(
+                i2Ri1_dict=i2Ri1_dict,
+                i2Ui1_dict=i2Ui1_dict,
+                corr_idxs_i1i2=corr_idxs_i1i2,
+                two_view_reports=two_view_reports,
+                edges_to_select=[(i0, i1), (i1, i2), (i0, i2)],
+            )
+            if self._registration_method == ThreeViewRegistrationMethod.AVERAGING:
+                logger.setLevel(logging.WARNING)
+                wTi_list, reproj_errors, _, _, _ = self.optimize_three_views_averaging(
+                    i2Ri1_dict_subscene, i2Ui1_dict_subscene, calibrations, corr_idxs_i1_i2_subscene, keypoints
+                )
+                logger.setLevel(logging.INFO)
+
+            elif self._registration_method == ThreeViewRegistrationMethod.PNP:
+                self.optimize_three_views_incremental()
+
+            # require at least 500 points with reproj error under 5 px?
+            MAX_ALLOWED_REPROJ_ERROR = 5
+            support = (reproj_errors < MAX_ALLOWED_REPROJ_ERROR).sum()
+            MIN_REQUIRED_SUPPORT = 500
+            logger.info("Triplet had %d inliers according to reproj. error.", support)
+            if support > MIN_REQUIRED_SUPPORT:
+                valid_edges.add((i0, i1))
+                valid_edges.add((i1, i2))
+                valid_edges.add((i0, i2))
+
+        return valid_edges
+
+    def optimize_three_views_averaging(
+        self,
+        i2Ri1_dict: Dict[Tuple[int, int], Rot3],
+        i2Ui1_dict: Dict[Tuple[int, int], Unit3],
+        calibrations: List[Cal3Bundler],
+        corr_idxs_i1_i2: Dict[Tuple[int, int], np.ndarray],
+        keypoints_list: List[Keypoints],
+        cameras_gt: Optional[List[PinholeCameraCal3Bundler]] = None,
+    ) -> Tuple[List[Optional[Pose3]], np.ndarray, Optional[GtsfmMetricsGroup], GtsfmMetricsGroup, GtsfmMetricsGroup]:
+        """Use 3-view averaging to estimate global camera poses, and then compute per-point reprojection errors.
+
+        Args:
+            i2Ri1_dict: Dict from (i1, i2) to relative rotation of i1 with respect to i2.
+            i2Ui1_dict: Dict from (i1, i2) to relative translation direction of i1 with respect to i2.
+            calibrations: list of calibrations for each image.
+            corr_idxs_i1i2: Dict from (i1, i2) to indices of verified correspondences from i1 to i2.
+            keypoints_list: keypoints for each images.
+            cameras_gt: cameras with GT intrinsics and GT extrinsics.
+
+        Returns:
+            wTi_list: estimated camera poses.
+            reproj_errors: reprojection errors.
+            ra_metrics: 3-view rotation averaging metrics.
+            ta_metrics: 3-view translation averaging metrics.
+            ba_metrics: 3-view bundle adjustment metrics.
+        """
+        if cameras_gt is not None:
+            gt_wTi_list = [cam.pose() for cam in cameras_gt]
+        else:
+            gt_wTi_list = None
+
+        # num_images is arbitrary, as long as it is larger than the largest key
+        num_images = max([max(i1, i2) for (i1, i2) in i2Ri1_dict.keys()]) + 1
+        wRi_list = self._rot_avg_module.run(num_images, i2Ri1_dict)
+
+        wti_list, ta_metrics = self._trans_avg_module.run(num_images, i2Ui1_dict, wRi_list, gt_wTi_list=gt_wTi_list)
+
+        if gt_wTi_list:
+            ra_metrics = metrics_utils.compute_global_rotation_metrics(wRi_list, wti_list, gt_wTi_list)
+        else:
+            ra_metrics = None
+
+        init_cameras_dict = multi_view_optimizer.init_cameras(wRi_list, wti_list, calibrations)
+        ba_input_data, _ = self._data_association_module.run(
+            num_images=num_images,
+            cameras=init_cameras_dict,
+            corr_idxs_dict=corr_idxs_i1_i2,
+            keypoints_list=keypoints_list,
+            images=None,
+            cameras_gt=cameras_gt,
+        )
+
+        unfiltered_data, filtered_data = self._bundle_adjustment_module.run(ba_input_data)
+        reproj_errors = unfiltered_data.get_scene_reprojection_errors()
+        wTi_list = unfiltered_data.get_camera_poses()
+
+        # import pdb; pdb.set_trace()
+        ba_metrics = self._bundle_adjustment_module.evaluate(unfiltered_data, filtered_data, cameras_gt)
+        return wTi_list, reproj_errors, ra_metrics, ta_metrics, ba_metrics
+
+    def optimize_three_views_incremental(self) -> None:
+        """
+        Estimate global camera poses for 3-views using PNP / absolute pose estimation.
+        """
+        import pycolmap
+
+        reconstructions = pycolmap.incremental_mapping(
+            database_path, image_dir, models_path, num_threads=min(multiprocessing.cpu_count(), 16)
+        )

--- a/gtsfm/view_graph_estimator/view_graph_estimator_base.py
+++ b/gtsfm/view_graph_estimator/view_graph_estimator_base.py
@@ -58,6 +58,28 @@ class ViewGraphEstimatorBase(metaclass=abc.ABCMeta):
             Edges of the view-graph, which are the subset of the image pairs in the input args.
         """
 
+    def _get_valid_input_edges(self, i2Ri1_dict: Dict[Tuple[int, int], Rot3]) -> List[Tuple[int, int]]:
+        """Gets the input edges (i1, i2) with the relative rotation i2Ri1 where:
+        1. i1 < i2
+        2. i2Ri1 is not None
+
+        Args:
+            i2Ri1_dict: input dictionary of relative rotations.
+
+        Returns:
+            List of valid edges.
+        """
+        valid_edges = []
+        for (i1, i2), i2Ri1 in i2Ri1_dict.items():
+            if i2Ri1 is None:
+                continue  # edge was previously discarded for insufficient support
+            if i1 >= i2:
+                logger.error("Incorrectly ordered edge indices found in cycle consistency for (%d, %d)", i1, i2)
+                continue
+            valid_edges.append((i1, i2))
+
+        return valid_edges
+
     def _filter_with_edges(
         self,
         i2Ri1_dict: Dict[Tuple[int, int], Rot3],

--- a/tests/view_graph_estimator/test_reprojection_error_view_graph_estimator.py
+++ b/tests/view_graph_estimator/test_reprojection_error_view_graph_estimator.py
@@ -1,0 +1,160 @@
+"""Unit tests on 3-view BA + reprojection error view graph estimator.
+
+Authors: John Lambert
+"""
+import unittest
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+from gtsam import Cal3Bundler
+
+import gtsfm.runner.frontend_runner as frontend_runner
+from gtsfm.common.keypoints import Keypoints
+from gtsfm.feature_extractor import FeatureExtractor
+from gtsfm.frontend.detector_descriptor.superpoint import SuperPointDetectorDescriptor
+from gtsfm.frontend.inlier_support_processor import InlierSupportProcessor
+from gtsfm.frontend.matcher.superglue_matcher import SuperGlueMatcher
+from gtsfm.frontend.verifier.ransac import Ransac
+from gtsfm.loader.loader_base import LoaderBase
+from gtsfm.loader.olsson_loader import OlssonLoader
+from gtsfm.two_view_estimator import TwoViewEstimator
+
+from gtsfm.frontend.cacher.matcher_cacher import MatcherCacher
+from gtsfm.frontend.cacher.detector_descriptor_cacher import DetectorDescriptorCacher
+
+from gtsfm.view_graph_estimator.reprojection_error_view_graph_estimator import ReprojectionErrorViewGraphEstimator
+
+TEST_DATA_ROOT = Path(__file__).resolve().parent.parent / "data"
+
+
+class TestReprojectionErrorViewGraphEstimator(unittest.TestCase):
+    def setUp(self) -> None:
+        """ """
+        det_desc = SuperPointDetectorDescriptor()
+
+        self.feature_extractor = FeatureExtractor(
+            detector_descriptor=DetectorDescriptorCacher(detector_descriptor_obj=det_desc)
+        )
+        # feature_extractor = FeatureExtractor(det_desc)
+        self.two_view_estimator = TwoViewEstimator(
+            # matcher=SuperGlueMatcher(use_outdoor_model=True),
+            matcher=MatcherCacher(matcher_obj=SuperGlueMatcher(use_outdoor_model=True)),
+            verifier=Ransac(use_intrinsics_in_verification=True, estimation_threshold_px=4),
+            inlier_support_processor=InlierSupportProcessor(
+                min_num_inliers_est_model=15, min_inlier_ratio_est_model=0.1
+            ),
+            bundle_adjust_2view=False,
+            eval_threshold_px=4,
+            bundle_adjust_2view_maxiters=0,
+        )
+
+    def test_optimize_three_views_averaging_door(self) -> None:
+        """ """
+        dataset_root = TEST_DATA_ROOT / "set1_lund_door"
+        image_extension = "JPG"
+
+        loader = OlssonLoader(dataset_root, image_extension=image_extension)
+        camera_intrinsics = [loader.get_camera_intrinsics(i) for i in range(11)]
+
+        keypoints_list, i2Ri1_dict, i2Ui1_dict, corr_idxs_dict = frontend_runner.run_frontend(
+            loader, self.feature_extractor, self.two_view_estimator
+        )
+
+        vge = ReprojectionErrorViewGraphEstimator()
+        wTi_list_gt = [loader.get_camera_pose(i) for i in range(11)]
+
+        # only using first 11 of 12 images, since we need to have N gt cameras for N estimated cameras
+        # and we use num_images=(max_index+1) to determine this.
+        cameras_gt = [loader.get_camera(i) for i in range(11)]
+
+        # choose an arbitrary known triplet of cameras
+        i0, i1, i2 = 0, 5, 10
+
+        two_view_reports = {k: None for k in i2Ri1_dict.keys()}
+        i2Ri1_dict_subscene, i2Ui1_dict_subscene, corr_idxs_i1_i2_subscene, _ = vge._filter_with_edges(
+            i2Ri1_dict=i2Ri1_dict,
+            i2Ui1_dict=i2Ui1_dict,
+            corr_idxs_i1i2=corr_idxs_dict,
+            two_view_reports=two_view_reports,
+            edges_to_select=[(i0, i1), (i1, i2), (i0, i2)],
+        )
+
+        wTi_list, reproj_errors, ra_metrics, ta_metrics, ba_metrics = vge.optimize_three_views_averaging(
+            i2Ri1_dict=i2Ri1_dict_subscene,
+            i2Ui1_dict=i2Ui1_dict_subscene,
+            calibrations=camera_intrinsics,
+            corr_idxs_i1_i2=corr_idxs_i1_i2_subscene,
+            keypoints_list=keypoints_list,
+            cameras_gt=cameras_gt,
+        )
+
+        # import matplotlib.pyplot as plt
+        # plt.hist(reproj_errors, bins=100)
+        # plt.show()
+
+        assert ra_metrics._metrics[1].name == "rotation_error_angle_deg"
+        assert np.less(ra_metrics._metrics[1].data, 0.5).all()
+
+        assert ba_metrics._metrics[4].name == "rotation_error_angle_deg"
+        assert np.less(ba_metrics._metrics[4].data, 0.1).all()
+
+        assert ta_metrics._metrics[9].name == "translation_error_distance"
+        assert np.less(ta_metrics._metrics[9].data, 0.1).all()
+
+        assert ba_metrics._metrics[5].name == "translation_error_distance"
+        assert np.less(ba_metrics._metrics[5].data, 0.01).all()
+
+        # import gtsfm.utils.geometry_comparisons as geometry_comparisons
+        # wTi_list_aligned = geometry_comparisons.align_poses_sim3_ignore_missing(aTi_list=wTi_list_gt, bTi_list=wTi_list)
+
+def test_view_graph_estimator_run_door() -> None:
+    """ """
+
+    det_desc = SuperPointDetectorDescriptor()
+
+    feature_extractor = FeatureExtractor(
+        detector_descriptor=DetectorDescriptorCacher(detector_descriptor_obj=det_desc)
+    )
+    # feature_extractor = FeatureExtractor(det_desc)
+    two_view_estimator = TwoViewEstimator(
+        # matcher=SuperGlueMatcher(use_outdoor_model=True),
+        matcher=MatcherCacher(matcher_obj=SuperGlueMatcher(use_outdoor_model=True)),
+        verifier=Ransac(use_intrinsics_in_verification=True, estimation_threshold_px=4),
+        inlier_support_processor=InlierSupportProcessor(
+            min_num_inliers_est_model=15, min_inlier_ratio_est_model=0.1
+        ),
+        bundle_adjust_2view=False,
+        eval_threshold_px=4,
+        bundle_adjust_2view_maxiters=0,
+    )
+
+    dataset_root = TEST_DATA_ROOT / "set1_lund_door"
+    image_extension = "JPG"
+    loader = OlssonLoader(dataset_root, image_extension=image_extension)
+    num_images = 12
+    
+    camera_intrinsics = [loader.get_camera_intrinsics(i) for i in range(num_images)]
+
+    keypoints_list, i2Ri1_dict, i2Ui1_dict, corr_idxs_dict = frontend_runner.run_frontend(
+        loader, feature_extractor, two_view_estimator
+    )
+
+    two_view_reports = {k: None for k in i2Ri1_dict.keys()}
+
+    vge = ReprojectionErrorViewGraphEstimator()
+    result = vge.run(
+        i2Ri1_dict=i2Ri1_dict,
+        i2Ui1_dict=i2Ui1_dict,
+        calibrations=camera_intrinsics,
+        corr_idxs_i1i2=corr_idxs_dict,
+        two_view_reports=two_view_reports,
+        keypoints=keypoints_list,
+    )
+    # import pdb; pdb.set_trace()
+
+
+if __name__ == "__main__":
+    #unittest.main()
+
+    test_view_graph_estimator_run_door()


### PR DESCRIPTION
Register 3 views using averaging or PNP, then perform BA, and check the support for the triplet via reprojection error.