### PR TITLE
Separate rotation and translation averaging metrics

### DIFF
--- a/gtsfm/evaluation/plot_metrics.py
+++ b/gtsfm/evaluation/plot_metrics.py
@@ -27,7 +27,8 @@ def create_metrics_plots_html(json_path: str, output_dir: str) -> None:
     GTSFM_MODULE_METRICS_FNAMES = [
         "frontend_summary.json",
         "rotation_cycle_consistency_metrics.json",
-        "averaging_metrics.json",
+        "rotation_averaging_metrics.json",
+        "translation_averaging_metrics.json",
         "data_association_metrics.json",
         "bundle_adjustment_metrics.json"
     ]

--- a/gtsfm/evaluation/visualize_benchmark_comparison.py
+++ b/gtsfm/evaluation/visualize_benchmark_comparison.py
@@ -41,7 +41,8 @@ TABLE_NAMES = [
     "Verifier Summary Post Inlier Support Processor 2view Report",
     "View Graph Estimation Metrics",
     "Verifier Summary Viewgraph 2view Report",
-    "Averaging Metrics",
+    "Rotation Averaging Metrics",
+    "Translation Averaging Metrics",
     "Data Association Metrics",
     "Bundle Adjustment Metrics",
 ]

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -14,7 +14,6 @@ from gtsfm.averaging.rotation.rotation_averaging_base import RotationAveragingBa
 from gtsfm.averaging.translation.translation_averaging_base import TranslationAveragingBase
 from gtsfm.bundle.bundle_adjustment import BundleAdjustmentOptimizer
 from gtsfm.data_association.data_assoc import DataAssociation
-from gtsfm.evaluation.metrics import GtsfmMetricsGroup
 from gtsfm.two_view_estimator import TwoViewEstimationReport
 from gtsfm.view_graph_estimator.view_graph_estimator_base import ViewGraphEstimatorBase
 

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -108,11 +108,11 @@ class MultiViewOptimizer:
         rot_avg_metrics = dask.delayed(metrics_utils.compute_global_rotation_metrics)(
             wRi_graph, wti_graph, gt_poses_graph
         )
-        averaging_metrics = dask.delayed(get_averaging_metrics)(rot_avg_metrics, ta_metrics)
 
         multiview_optimizer_metrics_graph = [
             viewgraph_estimation_metrics,
-            averaging_metrics,
+            rot_avg_metrics,
+            ta_metrics,
             data_assoc_metrics_graph,
             ba_metrics_graph,
         ]
@@ -145,18 +145,3 @@ def init_cameras(
             cameras[idx] = PinholeCameraCal3Bundler(Pose3(wRi, wti), intrinsics_list[idx])
 
     return cameras
-
-
-def get_averaging_metrics(
-    rot_avg_metrics: GtsfmMetricsGroup, trans_avg_metrics: GtsfmMetricsGroup
-) -> GtsfmMetricsGroup:
-    """Helper to combine rotation and translation averaging metrics groups into a single averaging metrics group.
-
-    Args:
-        rot_avg_metrics: Rotation averaging metrics group.
-        trans_avg_metrics: Translation averaging metrics group.
-
-    Returns:
-        An averaging metrics group with both rotation and translation averaging metrics.
-    """
-    return GtsfmMetricsGroup("averaging_metrics", rot_avg_metrics.metrics + trans_avg_metrics.metrics)


### PR DESCRIPTION
Separating the rotation and translation averaging metrics into two sections in the report. 

We wont be able to move RA metrics into RA module because it currently needs the estimated translations to compute them. 