### PR TITLE
Cache image shapes

### DIFF
--- a/gtsfm/loader/argoverse_dataset_loader.py
+++ b/gtsfm/loader/argoverse_dataset_loader.py
@@ -74,6 +74,7 @@ class ArgoverseDatasetLoader(LoaderBase):
         # set the first pose as origin
         self._world_pose = Pose3(Rot3(), np.zeros((3, 1)))
         self._world_pose = self.get_camera_pose(0)
+        self._build_image_shapes_cache()
 
     def load_camera_calibration(self, log_id: str, camera_name: str) -> None:
         """Load extrinsics and intrinsics from disk."""

--- a/gtsfm/loader/astronet_loader.py
+++ b/gtsfm/loader/astronet_loader.py
@@ -120,6 +120,7 @@ class AstronetLoader(LoaderBase):
 
         self._num_imgs = len(self._image_paths)
         logger.info("AstroNet loader found and loaded %d images and %d tracks.", self._num_imgs, self.num_sfmtracks)
+        self._build_image_shapes_cache()
 
     @staticmethod
     def colmap2gtsfm(

--- a/gtsfm/loader/colmap_loader.py
+++ b/gtsfm/loader/colmap_loader.py
@@ -100,6 +100,7 @@ class ColmapLoader(LoaderBase):
 
         self._num_imgs = len(self._image_paths)
         logger.info("Colmap image loader found and loaded %d images", self._num_imgs)
+        self._build_image_shapes_cache()
 
     def get_image_fname(self, idx: int) -> str:
         """Given an image index, provide the corresponding image filename."""

--- a/gtsfm/loader/olsson_loader.py
+++ b/gtsfm/loader/olsson_loader.py
@@ -101,6 +101,7 @@ class OlssonLoader(LoaderBase):
 
         # GT 3d structure (point cloud)
         self._point_cloud = data["U"].T[:, :3]
+        self._build_image_shapes_cache()
 
     def __len__(self) -> int:
         """The number of images in the dataset.

--- a/gtsfm/loader/yfcc_imb_loader.py
+++ b/gtsfm/loader/yfcc_imb_loader.py
@@ -68,6 +68,7 @@ class YfccImbLoader(LoaderBase):
                 self._image_pairs.add((i2, i1))
 
         self._cameras = self.__read_calibrations()  # self.__read_colmap_model()
+        self._build_image_shapes_cache()
 
     def __len__(self) -> int:
         """


### PR DESCRIPTION
prevent repeated I/O to get image shapes, for intrinsics etc. Read image shapes only once at startup.

I/O for 4k x 3k images (12 MP) is very slow for Skydio Crane Mast images.