### PR TITLE
Add assert_all_results to repro test base

### DIFF
--- a/tests/repro_tests/test_repro_base.py
+++ b/tests/repro_tests/test_repro_base.py
@@ -34,7 +34,7 @@ class ReproducibilityTestBase(metaclass=abc.ABCMeta):
             all_results.append(current_result)
             self.assert_results(current_result, reference_result)
         
-        self.assert_all_results(all_results)
+        self.assert_results_statistics(all_results)
 
     def assert_results_statistics(self, all_results: List[Any]) -> None:
         """Check for any statistics across all_results.

--- a/tests/repro_tests/test_repro_base.py
+++ b/tests/repro_tests/test_repro_base.py
@@ -13,7 +13,7 @@ class ReproducibilityTestBase(metaclass=abc.ABCMeta):
     
     The class provides two ways to test reproducibility:
         - assert_results(): To compare the result at each iteration to a reference.
-        - assert_all_results() (Optional): To check statistics on all results together.
+        - assert_results_statistics() (Optional): To check statistics on all results together.
     """
 
     @abc.abstractmethod
@@ -36,7 +36,7 @@ class ReproducibilityTestBase(metaclass=abc.ABCMeta):
         
         self.assert_all_results(all_results)
 
-    def assert_all_results(self, all_results: List[Any]) -> None:
+    def assert_results_statistics(self, all_results: List[Any]) -> None:
         """Check for any statistics across all_results.
         
         This default implementation does not check anything, but can be overrided by derived classes."""

--- a/tests/repro_tests/test_repro_base.py
+++ b/tests/repro_tests/test_repro_base.py
@@ -3,12 +3,19 @@
 Authors: Ayush Baid
 """
 import abc
-from typing import Any
+from typing import Any, List
 
 NUM_REPETITIONS = 10
 
 
 class ReproducibilityTestBase(metaclass=abc.ABCMeta):
+    """A base class to define reproducibility tests.
+    
+    The class provides two ways to test reproducibility:
+        - assert_results(): To compare the result at each iteration to a reference.
+        - assert_all_results() (Optional): To check statistics on all results together.
+    """
+
     @abc.abstractmethod
     def run_once(self) -> Any:
         """Run the function under test once"""
@@ -20,7 +27,17 @@ class ReproducibilityTestBase(metaclass=abc.ABCMeta):
     def test_repeatability(self) -> None:
         """Tests the repeatability of the function under test."""
         reference_result = self.run_once()
+        all_results = [reference_result]
 
         for _ in range(NUM_REPETITIONS):
             current_result = self.run_once()
+            all_results.append(current_result)
             self.assert_results(current_result, reference_result)
+        
+        self.assert_all_results(all_results)
+
+    def assert_all_results(self, all_results: List[Any]) -> None:
+        """Check for any statistics across all_results.
+        
+        This default implementation does not check anything, but can be overrided by derived classes."""
+        return None


### PR DESCRIPTION
Adding an optional method to the repro test base class to check statistics on all results. This is useful for translation averaging. 