### PR TITLE
Plumbing pose priors and supporting fisheye calibration

### DIFF
--- a/gtsfm/bundle/bundle_adjustment.py
+++ b/gtsfm/bundle/bundle_adjustment.py
@@ -4,7 +4,7 @@ Authors: Xiaolong Wu, John Lambert, Ayush Baid
 """
 from collections import Counter
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import dask
 import gtsam
@@ -12,19 +12,24 @@ import numpy as np
 from dask.delayed import Delayed
 from gtsam import (
     GeneralSFMFactor2Cal3Bundler,
+    GeneralSFMFactor2Cal3Fisheye,
     NonlinearFactorGraph,
     PinholeCameraCal3Bundler,
+    PinholeCameraCal3Fisheye,
     PriorFactorCal3Bundler,
+    PriorFactorCal3Fisheye,
     PriorFactorPose3,
     SfmTrack,
     Values,
     symbol_shorthand,
 )
 
+import gtsfm.common.types as gtsfm_types
 import gtsfm.utils.logger as logger_utils
 import gtsfm.utils.metrics as metrics_utils
 import gtsfm.utils.tracks as track_utils
 from gtsfm.common.gtsfm_data import GtsfmData
+from gtsfm.common.pose_prior import PosePrior
 from gtsfm.evaluation.metrics import GtsfmMetric, GtsfmMetricsGroup
 
 METRICS_GROUP = "bundle_adjustment_metrics"
@@ -41,6 +46,7 @@ K = symbol_shorthand.K  # calibration
 
 CAM_POSE3_DOF = 6  # 6 dof for pose of camera
 CAM_CAL3BUNDLER_DOF = 3  # 3 dof for f, k1, k2 for intrinsics of camera
+CAM_CAL3FISHEYE_DOF = 9
 IMG_MEASUREMENT_DIM = 2  # 2d measurements (u,v) have 2 dof
 POINT3_DOF = 3  # 3d points have 3 dof
 
@@ -48,6 +54,7 @@ POINT3_DOF = 3  # 3d points have 3 dof
 # noise model params
 CAM_POSE3_PRIOR_NOISE_SIGMA = 0.1
 CAM_CAL3BUNDLER_PRIOR_NOISE_SIGMA = 1e-5  # essentially fixed
+CAM_CAL3FISHEYE_PRIOR_NOISE_SIGMA = 1e-5  # essentially fixed
 MEASUREMENT_NOISE_SIGMA = 1.0  # in pixels
 
 logger = logger_utils.get_logger()
@@ -85,7 +92,12 @@ class BundleAdjustmentOptimizer:
     def __map_to_calibration_variable(self, camera_idx: int) -> int:
         return 0 if self._shared_calib else camera_idx
 
-    def __construct_factor_graph(self, initial_data: GtsfmData) -> NonlinearFactorGraph:
+    def __construct_factor_graph(
+        self,
+        initial_data: GtsfmData,
+        absolute_pose_priors: List[Optional[PosePrior]],
+        relative_pose_priors: Dict[Tuple[int, int], Optional[PosePrior]],
+    ) -> NonlinearFactorGraph:
         graph = NonlinearFactorGraph()
 
         # noise model for measurements -- one pixel in u and v
@@ -93,9 +105,12 @@ class BundleAdjustmentOptimizer:
         if self._robust_measurement_noise:
             measurement_noise = gtsam.noiseModel.Robust(gtsam.noiseModel.mEstimator.Huber(1.345), measurement_noise)
 
+        is_fisheye_calibration = isinstance(initial_data.get_camera(0), PinholeCameraCal3Fisheye)
+
         # Create a factor graph
 
         # Add measurements to the factor graph
+        sfm_factor_class = GeneralSFMFactor2Cal3Fisheye if is_fisheye_calibration else GeneralSFMFactor2Cal3Bundler
         for j in range(initial_data.number_tracks()):
             track = initial_data.get_track(j)  # SfmTrack
             # retrieve the SfmMeasurement objects
@@ -104,7 +119,7 @@ class BundleAdjustmentOptimizer:
                 i, uv = track.measurement(m_idx)
                 # note use of shorthand symbols C and P
                 graph.add(
-                    GeneralSFMFactor2Cal3Bundler(
+                    sfm_factor_class(
                         uv,
                         measurement_noise,
                         X(i),
@@ -114,8 +129,9 @@ class BundleAdjustmentOptimizer:
                 )
 
         # get all the valid camera indices, which need to be added to the graph.
-        valid_camera_indices = initial_data.get_valid_camera_indices()
+        valid_camera_indices: List[int] = initial_data.get_valid_camera_indices()
 
+        # TODO: add pose priors to the graph
         # Add a prior on first pose. This indirectly specifies where the origin is.
         graph.push_back(
             PriorFactorPose3(
@@ -126,12 +142,17 @@ class BundleAdjustmentOptimizer:
         )
 
         # add prior on all calibrations
+        calibration_prior_factor_class = PriorFactorCal3Fisheye if is_fisheye_calibration else PriorFactorCal3Bundler
+        calibration_prior_factor_dof = CAM_CAL3FISHEYE_DOF if is_fisheye_calibration else CAM_CAL3BUNDLER_DOF
+        calibration_prior_noise_sigma = (
+            CAM_CAL3FISHEYE_PRIOR_NOISE_SIGMA if is_fisheye_calibration else CAM_CAL3BUNDLER_PRIOR_NOISE_SIGMA
+        )
         for i in valid_camera_indices[: 1 if self._shared_calib else len(valid_camera_indices)]:
             graph.push_back(
-                PriorFactorCal3Bundler(
+                calibration_prior_factor_class(
                     K(self.__map_to_calibration_variable(i)),
                     initial_data.get_camera(i).calibration(),
-                    gtsam.noiseModel.Isotropic.Sigma(CAM_CAL3BUNDLER_DOF, CAM_CAL3BUNDLER_PRIOR_NOISE_SIGMA),
+                    gtsam.noiseModel.Isotropic.Sigma(calibration_prior_factor_dof, calibration_prior_noise_sigma),
                 )
             )
 
@@ -177,13 +198,16 @@ class BundleAdjustmentOptimizer:
     def run(
         self,
         initial_data: GtsfmData,
+        absolute_pose_priors: List[Optional[PosePrior]],
+        relative_pose_priors: Dict[Tuple[int, int], Optional[PosePrior]],
         verbose: bool = True,
     ) -> Tuple[GtsfmData, GtsfmData]:
         """Run the bundle adjustment by forming factor graph and optimizing using Levenberg–Marquardt optimization.
 
         Args:
             initial_data: initialized cameras, tracks w/ their 3d landmark from triangulation.
-            cameras_gt: list of GT cameras, ordered by camera index.
+            absolute_pose_priors: priors to be used on cameras.
+            relative_pose_priors: priors on the pose between two cameras.
             verbose: Boolean flag to print out additional info for debugging.
 
         Results:
@@ -200,7 +224,11 @@ class BundleAdjustmentOptimizer:
             )
             return initial_data, initial_data
 
-        graph = self.__construct_factor_graph(initial_data=initial_data)
+        graph = self.__construct_factor_graph(
+            initial_data=initial_data,
+            absolute_pose_priors=absolute_pose_priors,
+            relative_pose_priors=relative_pose_priors,
+        )
         initial_values = self.__construct_initial_values(initial_data=initial_data)
         result_values = self.__optimize_factor_graph(graph, initial_values)
 
@@ -228,7 +256,7 @@ class BundleAdjustmentOptimizer:
         return optimized_data, filtered_result
 
     def evaluate(
-        self, unfiltered_data: GtsfmData, filtered_data: GtsfmData, cameras_gt: List[PinholeCameraCal3Bundler] = None
+        self, unfiltered_data: GtsfmData, filtered_data: GtsfmData, cameras_gt: List[Optional[gtsfm_types.CAMERA_TYPE]]
     ) -> GtsfmMetricsGroup:
         """
         Args:
@@ -243,50 +271,59 @@ class BundleAdjustmentOptimizer:
             name=METRICS_GROUP, metrics=metrics_utils.get_stats_for_sfmdata(unfiltered_data, suffix="_unfiltered")
         )
 
-        if cameras_gt is not None:
-            poses_gt = [cam.pose() for cam in cameras_gt]
+        poses_gt = [cam.pose() if cam is not None else None for cam in cameras_gt]
 
-            # align the sparse multi-view estimate after BA to the ground truth pose graph.
-            aligned_filtered_data = filtered_data.align_via_Sim3_to_poses(wTi_list_ref=poses_gt)
-            ba_pose_error_metrics = metrics_utils.compute_ba_pose_metrics(
-                gt_wTi_list=poses_gt, ba_output=aligned_filtered_data
-            )
-            ba_metrics.extend(metrics_group=ba_pose_error_metrics)
+        non_none_poses_count = len(poses_gt) - poses_gt.count(None)
 
-            output_tracks_exit_codes = track_utils.classify_tracks3d_with_gt_cameras(
-                tracks=aligned_filtered_data.get_tracks(), cameras_gt=cameras_gt
-            )
-            output_tracks_exit_codes_distribution = Counter(output_tracks_exit_codes)
+        if non_none_poses_count == 0:
+            return ba_metrics
 
-            for exit_code, count in output_tracks_exit_codes_distribution.items():
-                metric_name = "Filtered tracks triangulated with GT cams: {}".format(exit_code.name)
-                ba_metrics.add_metric(GtsfmMetric(name=metric_name, data=count))
+        # align the sparse multi-view estimate after BA to the ground truth pose graph.
+        aligned_filtered_data = filtered_data.align_via_Sim3_to_poses(wTi_list_ref=poses_gt)
+        ba_pose_error_metrics = metrics_utils.compute_ba_pose_metrics(
+            gt_wTi_list=poses_gt, ba_output=aligned_filtered_data
+        )
+        ba_metrics.extend(metrics_group=ba_pose_error_metrics)
 
-            ba_metrics.add_metrics(metrics_utils.get_stats_for_sfmdata(aligned_filtered_data, suffix="_filtered"))
-            # ba_metrics.save_to_json(os.path.join(METRICS_PATH, "bundle_adjustment_metrics.json"))
+        output_tracks_exit_codes = track_utils.classify_tracks3d_with_gt_cameras(
+            tracks=aligned_filtered_data.get_tracks(), cameras_gt=cameras_gt
+        )
+        output_tracks_exit_codes_distribution = Counter(output_tracks_exit_codes)
 
-            logger.info("[Result] Mean track length %.3f", np.mean(aligned_filtered_data.get_track_lengths()))
-            logger.info("[Result] Median track length %.3f", np.median(aligned_filtered_data.get_track_lengths()))
-            aligned_filtered_data.log_scene_reprojection_error_stats()
+        for exit_code, count in output_tracks_exit_codes_distribution.items():
+            metric_name = "Filtered tracks triangulated with GT cams: {}".format(exit_code.name)
+            ba_metrics.add_metric(GtsfmMetric(name=metric_name, data=count))
+
+        ba_metrics.add_metrics(metrics_utils.get_stats_for_sfmdata(aligned_filtered_data, suffix="_filtered"))
+        # ba_metrics.save_to_json(os.path.join(METRICS_PATH, "bundle_adjustment_metrics.json"))
+
+        logger.info("[Result] Mean track length %.3f", np.mean(aligned_filtered_data.get_track_lengths()))
+        logger.info("[Result] Median track length %.3f", np.median(aligned_filtered_data.get_track_lengths()))
+        aligned_filtered_data.log_scene_reprojection_error_stats()
 
         return ba_metrics
 
     def create_computation_graph(
         self,
         sfm_data_graph: Delayed,
+        absolute_pose_priors: List[Delayed],
+        relative_pose_priors: Dict[Tuple[int, int], Delayed],
         gt_cameras_graph: Optional[List[Delayed]] = None,
     ) -> Tuple[Delayed, Delayed]:
         """Create the computation graph for performing bundle adjustment.
 
         Args:
             sfm_data_graph: an GtsfmData object wrapped up using dask.delayed
-            gt_cameras_graph: list of GT cameras, ordered by camera index, each object wrapped up as Delayed.
+            absolute_pose_priors: priors on the poses of the cameras.
+            relative_pose_priors: priors on poses between cameras.
 
         Returns:
             GtsfmData aligned to GT (if provided), wrapped up using dask.delayed
             Metrics group for BA results, wrapped up using dask.delayed
         """
-        optimized_sfm_data, filtered_sfm_data = dask.delayed(self.run, nout=2)(sfm_data_graph)
+        optimized_sfm_data, filtered_sfm_data = dask.delayed(self.run, nout=2)(
+            sfm_data_graph, absolute_pose_priors, relative_pose_priors
+        )
         metrics_graph = dask.delayed(self.evaluate)(optimized_sfm_data, filtered_sfm_data, gt_cameras_graph)
         return filtered_sfm_data, metrics_graph
 
@@ -305,14 +342,18 @@ def values_to_gtsfm_data(values: Values, initial_data: GtsfmData, shared_calib: 
     """
     result = GtsfmData(initial_data.number_images())
 
+    is_fisheye_calibration = isinstance(initial_data.get_camera(0), PinholeCameraCal3Fisheye)
+    if is_fisheye_calibration:
+        cal3_value_extraction_lambda = lambda i: values.atCal3Fisheye(K(0 if shared_calib else i))
+    else:
+        cal3_value_extraction_lambda = lambda i: values.atCal3Bundler(K(0 if shared_calib else i))
+    camera_class = PinholeCameraCal3Fisheye if is_fisheye_calibration else PinholeCameraCal3Bundler
+
     # add cameras
     for i in initial_data.get_valid_camera_indices():
         result.add_camera(
             i,
-            PinholeCameraCal3Bundler(
-                values.atPose3(X(i)),
-                values.atCal3Bundler(K(0 if shared_calib else i)),
-            ),
+            camera_class(values.atPose3(X(i)), cal3_value_extraction_lambda(i)),
         )
 
     # add tracks

--- a/gtsfm/bundle/bundle_adjustment.py
+++ b/gtsfm/bundle/bundle_adjustment.py
@@ -273,9 +273,8 @@ class BundleAdjustmentOptimizer:
 
         poses_gt = [cam.pose() if cam is not None else None for cam in cameras_gt]
 
-        non_none_poses_count = len(poses_gt) - poses_gt.count(None)
-
-        if non_none_poses_count == 0:
+        valid_poses_gt_count = len(poses_gt) - poses_gt.count(None)
+        if valid_poses_gt_count == 0:
             return ba_metrics
 
         # align the sparse multi-view estimate after BA to the ground truth pose graph.

--- a/gtsfm/common/gtsfm_data.py
+++ b/gtsfm/common/gtsfm_data.py
@@ -7,8 +7,9 @@ import itertools
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
-from gtsam import PinholeCameraCal3Bundler, Pose3, SfmTrack, Similarity3
+from gtsam import Pose3, SfmTrack, Similarity3
 
+import gtsfm.common.types as gtsfm_types
 import gtsfm.utils.geometry_comparisons as geometry_comparisons
 import gtsfm.utils.graph as graph_utils
 import gtsfm.utils.logger as logger_utils
@@ -33,7 +34,7 @@ class GtsfmData:
         Args:
             number_images: number of images/cameras in the scene.
         """
-        self._cameras: Dict[int, PinholeCameraCal3Bundler] = {}
+        self._cameras: Dict[int, gtsfm_types.CAMERA_TYPE] = {}
         self._tracks: List[SfmTrack] = []
         self._number_images = number_images
 
@@ -93,7 +94,7 @@ class GtsfmData:
         """
         return list(self._cameras.keys())
 
-    def get_camera(self, index: int) -> Optional[PinholeCameraCal3Bundler]:
+    def get_camera(self, index: int) -> Optional[gtsfm_types.CAMERA_TYPE]:
         """Getter for camera.
 
         Args:
@@ -156,7 +157,7 @@ class GtsfmData:
         """
         return self._tracks
 
-    def add_camera(self, index: int, camera: PinholeCameraCal3Bundler) -> None:
+    def add_camera(self, index: int, camera: gtsfm_types.CAMERA_TYPE) -> None:
         """Adds a camera.
 
         Args:
@@ -229,7 +230,7 @@ class GtsfmData:
 
     @classmethod
     def from_cameras_and_tracks(
-        cls, cameras: Dict[int, PinholeCameraCal3Bundler], tracks: List[SfmTrack], number_images: int
+        cls, cameras: Dict[int, gtsfm_types.CAMERA_TYPE], tracks: List[SfmTrack], number_images: int
     ) -> "GtsfmData":
         """Creates a GtsfmData object from a pre-existing set of cameras and tracks."""
         new_data = cls(number_images=number_images)
@@ -408,7 +409,8 @@ class GtsfmData:
             if aTi is None:
                 continue
             calibration = self.get_camera(i).calibration()
-            aligned_data.add_camera(i, PinholeCameraCal3Bundler(aTi, calibration))
+            camera_type = gtsfm_types.get_camera_class_for_calibration(calibration)
+            aligned_data.add_camera(i, camera_type(aTi, calibration))
         # Align estimated tracks to ground truth.
         for j in range(self.number_tracks()):
             # Align each 3d point

--- a/gtsfm/common/sfm_track.py
+++ b/gtsfm/common/sfm_track.py
@@ -169,7 +169,7 @@ class SfmTrack2d(NamedTuple):
             else:
                 erroneous_track_count += 1
 
-        erroneous_track_pct = erroneous_track_count / len(key_set) * 100
+        erroneous_track_pct = erroneous_track_count / len(key_set) * 100 if len(key_set) > 0 else np.NaN
         logger.info(
             f"DSF Union-Find: {erroneous_track_pct:.2f}% of tracks discarded from multiple obs. in a single image."
         )

--- a/gtsfm/configs/deep_front_end.yaml
+++ b/gtsfm/configs/deep_front_end.yaml
@@ -4,7 +4,6 @@ SceneOptimizer:
   save_two_view_correspondences_viz: False
   save_3d_viz: True
   pose_angular_error_thresh: 5 # degrees
-  run_dense_optimizer: False
 
   feature_extractor:
     _target_: gtsfm.feature_extractor.FeatureExtractor

--- a/gtsfm/configs/deep_front_end.yaml
+++ b/gtsfm/configs/deep_front_end.yaml
@@ -38,8 +38,8 @@ SceneOptimizer:
 
   multiview_optimizer:
     _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer
-    run_view_graph_estimator: True
 
+    # comment out to not run
     view_graph_estimator:
       _target_: gtsfm.view_graph_estimator.cycle_consistent_rotation_estimator.CycleConsistentRotationViewGraphEstimator
       edge_error_aggregation_criterion: MEDIAN_EDGE_ERROR
@@ -70,5 +70,6 @@ SceneOptimizer:
       robust_measurement_noise: True
       shared_calib: False
 
+  # comment out to not run
   dense_multiview_optimizer:
     _target_: gtsfm.densify.mvs_patchmatchnet.MVSPatchmatchNet

--- a/gtsfm/configs/deep_front_end.yaml
+++ b/gtsfm/configs/deep_front_end.yaml
@@ -4,6 +4,7 @@ SceneOptimizer:
   save_two_view_correspondences_viz: False
   save_3d_viz: True
   pose_angular_error_thresh: 5 # degrees
+  run_dense_optimizer: False
 
   feature_extractor:
     _target_: gtsfm.feature_extractor.FeatureExtractor
@@ -37,6 +38,8 @@ SceneOptimizer:
 
   multiview_optimizer:
     _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer
+    run_view_graph_estimator: True
+
     view_graph_estimator:
       _target_: gtsfm.view_graph_estimator.cycle_consistent_rotation_estimator.CycleConsistentRotationViewGraphEstimator
       edge_error_aggregation_criterion: MEDIAN_EDGE_ERROR

--- a/gtsfm/configs/sift_front_end.yaml
+++ b/gtsfm/configs/sift_front_end.yaml
@@ -3,6 +3,7 @@ SceneOptimizer:
   save_gtsfm_data: True
   save_two_view_correspondences_viz: False
   save_3d_viz: True
+  run_dense_optimizer: False
   pose_angular_error_thresh: 5 # degrees
 
   feature_extractor:
@@ -37,6 +38,8 @@ SceneOptimizer:
 
   multiview_optimizer:
     _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer
+    run_view_graph_estimator: False
+
     view_graph_estimator:
       _target_: gtsfm.view_graph_estimator.cycle_consistent_rotation_estimator.CycleConsistentRotationViewGraphEstimator
       edge_error_aggregation_criterion: MEDIAN_EDGE_ERROR

--- a/gtsfm/configs/sift_front_end.yaml
+++ b/gtsfm/configs/sift_front_end.yaml
@@ -3,7 +3,6 @@ SceneOptimizer:
   save_gtsfm_data: True
   save_two_view_correspondences_viz: False
   save_3d_viz: True
-  run_dense_optimizer: False
   pose_angular_error_thresh: 5 # degrees
 
   feature_extractor:
@@ -38,8 +37,8 @@ SceneOptimizer:
 
   multiview_optimizer:
     _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer
-    run_view_graph_estimator: False
 
+    # comment out to not run
     view_graph_estimator:
       _target_: gtsfm.view_graph_estimator.cycle_consistent_rotation_estimator.CycleConsistentRotationViewGraphEstimator
       edge_error_aggregation_criterion: MEDIAN_EDGE_ERROR
@@ -70,5 +69,6 @@ SceneOptimizer:
       robust_measurement_noise: True
       shared_calib: False
 
+  # comment out to not run
   dense_multiview_optimizer:
     _target_: gtsfm.densify.mvs_patchmatchnet.MVSPatchmatchNet

--- a/gtsfm/loader/hilti_loader.py
+++ b/gtsfm/loader/hilti_loader.py
@@ -15,7 +15,7 @@ Authors: Ayush Baid
 """
 import glob
 import yaml
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from pathlib import Path
 
 import dask
@@ -273,15 +273,18 @@ class HiltiLoader(LoaderBase):
     def map_image_idx_to_rig(self, index: int) -> int:
         return index // NUM_CAMS
 
-    def create_computation_graph_for_relative_pose_priors(self) -> Dict[Tuple[int, int], Delayed]:
-        pairs = set(self.get_valid_pairs())
-        # just add all possible pairs which belong to the same rig (as it will have hard relative prior)
-        for i in range(len(self)):
-            for j in range(i + 1, i + len(self._cams_to_use) - 1):
-                if self.map_image_idx_to_rig(i) == self.map_image_idx_to_rig(j):
-                    pairs.add((i, j))
-                else:
-                    break
+    def create_computation_graph_for_relative_pose_priors(
+        self, pairs: Optional[List[Tuple[int, int]]] = None
+    ) -> Dict[Tuple[int, int], Delayed]:
+        if pairs is None:
+            pairs = set(self.get_valid_pairs())
+            # just add all possible pairs which belong to the same rig (as it will have hard relative prior)
+            for i in range(len(self)):
+                for j in range(i + 1, i + NUM_CAMS - 1):
+                    if self.map_image_idx_to_rig(i) == self.map_image_idx_to_rig(j):
+                        pairs.add((i, j))
+                    else:
+                        break
 
         return {(i1, i2): dask.delayed(self.get_relative_pose_prior)(i1, i2) for i1, i2 in pairs}
 
@@ -289,7 +292,7 @@ class HiltiLoader(LoaderBase):
         pairs = set(self.get_valid_pairs())
         # just add all possible pairs which belong to the same rig (as it will have hard relative prior)
         for i in range(len(self)):
-            for j in range(i + 1, i + len(self._cams_to_use) - 1):
+            for j in range(i + 1, i + NUM_CAMS - 1):
                 if self.map_image_idx_to_rig(i) == self.map_image_idx_to_rig(j):
                     pairs.add((i, j))
                 else:

--- a/gtsfm/loader/hilti_loader.py
+++ b/gtsfm/loader/hilti_loader.py
@@ -274,17 +274,16 @@ class HiltiLoader(LoaderBase):
         return index // NUM_CAMS
 
     def create_computation_graph_for_relative_pose_priors(
-        self, pairs: Optional[List[Tuple[int, int]]] = None
+        self, pairs: List[Tuple[int, int]]
     ) -> Dict[Tuple[int, int], Delayed]:
-        if pairs is None:
-            pairs = set(self.get_valid_pairs())
-            # just add all possible pairs which belong to the same rig (as it will have hard relative prior)
-            for i in range(len(self)):
-                for j in range(i + 1, i + NUM_CAMS - 1):
-                    if self.map_image_idx_to_rig(i) == self.map_image_idx_to_rig(j):
-                        pairs.add((i, j))
-                    else:
-                        break
+        # Hack: just add all possible pairs which belong to the same rig (as it will have hard relative prior)
+        pairs = set(pairs)
+        for i in range(len(self)):
+            for j in range(i + 1, i + NUM_CAMS - 1):
+                if self.map_image_idx_to_rig(i) == self.map_image_idx_to_rig(j):
+                    pairs.add((i, j))
+                else:
+                    break
 
         return {(i1, i2): dask.delayed(self.get_relative_pose_prior)(i1, i2) for i1, i2 in pairs}
 

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -277,11 +277,8 @@ class LoaderBase(metaclass=abc.ABCMeta):
         return [dask.delayed(self.get_absolute_pose_prior)(i) for i in range(N)]
 
     def create_computation_graph_for_relative_pose_priors(
-        self, pairs: Optional[List[Tuple[int, int]]] = None
+        self, pairs: List[Tuple[int, int]]
     ) -> Dict[Tuple[int, int], Delayed]:
-        # TODO: deprecate this logic.
-        if pairs is None:
-            pairs = self.get_valid_pairs()
         return {(i1, i2): dask.delayed(self.get_relative_pose_prior)(i1, i2) for i1, i2 in pairs}
 
     def get_valid_pairs(self) -> List[Tuple[int, int]]:

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -276,8 +276,12 @@ class LoaderBase(metaclass=abc.ABCMeta):
         N = len(self)
         return [dask.delayed(self.get_absolute_pose_prior)(i) for i in range(N)]
 
-    def create_computation_graph_for_relative_pose_priors(self) -> Dict[Tuple[int, int], Delayed]:
-        pairs = self.get_valid_pairs()
+    def create_computation_graph_for_relative_pose_priors(
+        self, pairs: Optional[List[Tuple[int, int]]] = None
+    ) -> Dict[Tuple[int, int], Delayed]:
+        # TODO: deprecate this logic.
+        if pairs is None:
+            pairs = self.get_valid_pairs()
         return {(i1, i2): dask.delayed(self.get_relative_pose_prior)(i1, i2) for i1, i2 in pairs}
 
     def get_valid_pairs(self) -> List[Tuple[int, int]]:

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -23,19 +23,18 @@ from gtsfm.view_graph_estimator.view_graph_estimator_base import ViewGraphEstima
 class MultiViewOptimizer:
     def __init__(
         self,
-        view_graph_estimator: ViewGraphEstimatorBase,
         rot_avg_module: RotationAveragingBase,
         trans_avg_module: TranslationAveragingBase,
         data_association_module: DataAssociation,
         bundle_adjustment_module: BundleAdjustmentOptimizer,
-        run_view_graph_estimator: bool = True,
+        view_graph_estimator: Optional[ViewGraphEstimatorBase] = None,
     ) -> None:
         self.view_graph_estimator = view_graph_estimator
         self.rot_avg_module = rot_avg_module
         self.trans_avg_module = trans_avg_module
         self.data_association_module = data_association_module
         self.ba_optimizer = bundle_adjustment_module
-        self._run_view_graph_estimator: bool = run_view_graph_estimator
+        self._run_view_graph_estimator: bool = self.view_graph_estimator is not None
 
     def create_computation_graph(
         self,

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -6,14 +6,16 @@ from typing import Dict, List, Optional, Tuple
 
 import dask
 from dask.delayed import Delayed
-from gtsam import Cal3Bundler, PinholeCameraCal3Bundler, Point3, Pose3, Rot3
+from gtsam import Point3, Pose3, Rot3
 
+import gtsfm.common.types as gtsfm_types
 import gtsfm.utils.graph as graph_utils
 import gtsfm.utils.metrics as metrics_utils
 from gtsfm.averaging.rotation.rotation_averaging_base import RotationAveragingBase
 from gtsfm.averaging.translation.translation_averaging_base import TranslationAveragingBase
 from gtsfm.bundle.bundle_adjustment import BundleAdjustmentOptimizer
 from gtsfm.data_association.data_assoc import DataAssociation
+from gtsfm.evaluation.metrics import GtsfmMetricsGroup
 from gtsfm.two_view_estimator import TwoViewEstimationReport
 from gtsfm.view_graph_estimator.view_graph_estimator_base import ViewGraphEstimatorBase
 
@@ -26,12 +28,14 @@ class MultiViewOptimizer:
         trans_avg_module: TranslationAveragingBase,
         data_association_module: DataAssociation,
         bundle_adjustment_module: BundleAdjustmentOptimizer,
+        run_view_graph_estimator: bool = True,
     ) -> None:
         self.view_graph_estimator = view_graph_estimator
         self.rot_avg_module = rot_avg_module
         self.trans_avg_module = trans_avg_module
         self.data_association_module = data_association_module
         self.ba_optimizer = bundle_adjustment_module
+        self._run_view_graph_estimator: bool = run_view_graph_estimator
 
     def create_computation_graph(
         self,
@@ -42,8 +46,11 @@ class MultiViewOptimizer:
         i2Ui1_graph: Dict[Tuple[int, int], Delayed],
         v_corr_idxs_graph: Dict[Tuple[int, int], Delayed],
         intrinsics_graph: List[Delayed],
+        absolute_pose_priors: List[Delayed],
+        relative_pose_priors: Dict[Tuple[int, int], Delayed],
         two_view_reports_dict: Optional[Dict[Tuple[int, int], TwoViewEstimationReport]],
-        gt_cameras_graph: Optional[List[Delayed]] = None,
+        gt_cameras_graph: List[Delayed],
+        gt_poses_graph: List[Delayed],
     ) -> Tuple[Delayed, Delayed, Delayed]:
         """Creates a computation graph for multi-view optimization.
 
@@ -54,8 +61,11 @@ class MultiViewOptimizer:
             i2Ui1_graph: relative unit-translations for image pairs, each value wrapped up as Delayed.
             v_corr_idxs_graph: indices of verified correspondences for image pairs, wrapped up as Delayed.
             intrinsics_graph: intrinsics for images, wrapped up as Delayed.
+            absolute_pose_priors: priors on the camera poses.
+            relative_pose_priors: priors on the pose between camera pairs.
             two_view_reports_dict: Dict of TwoViewEstimationReports after inlier support processor.
             gt_cameras_graph: list of GT cameras (if they exist), ordered by camera index, wrapped up as Delayed.
+            gt_poses_graph: list of GT poses of the camera.
 
         Returns:
             The GtsfmData input to bundle adjustment, aligned to GT (if provided), wrapped up as Delayed.
@@ -63,23 +73,27 @@ class MultiViewOptimizer:
             Dict of TwoViewEstimationReports after view graph estimation.
             List of GtsfmMetricGroups from different modules, wrapped up as Delayed.
         """
-        (
-            viewgraph_i2Ri1_graph,
-            viewgraph_i2Ui1_graph,
-            viewgraph_v_corr_idxs_graph,
-            viewgraph_two_view_reports_graph,
-            viewgraph_estimation_metrics,
-        ) = self.view_graph_estimator.create_computation_graph(
-            i2Ri1_graph, i2Ui1_graph, intrinsics_graph, v_corr_idxs_graph, keypoints_graph, two_view_reports_dict
-        )
+
+        if self._run_view_graph_estimator:
+            (
+                viewgraph_i2Ri1_graph,
+                viewgraph_i2Ui1_graph,
+                viewgraph_v_corr_idxs_graph,
+                viewgraph_two_view_reports_graph,
+                viewgraph_estimation_metrics,
+            ) = self.view_graph_estimator.create_computation_graph(
+                i2Ri1_graph, i2Ui1_graph, intrinsics_graph, v_corr_idxs_graph, keypoints_graph, two_view_reports_dict
+            )
+        else:
+            viewgraph_i2Ri1_graph = dask.delayed(i2Ri1_graph)
+            viewgraph_i2Ui1_graph = dask.delayed(i2Ui1_graph)
+            viewgraph_v_corr_idxs_graph = dask.delayed(v_corr_idxs_graph)
+            viewgraph_two_view_reports_graph = dask.delayed(two_view_reports_dict)
+            viewgraph_estimation_metrics = dask.delayed(GtsfmMetricsGroup("view_graph_estimation_metrics", []))
 
         # prune the graph to a single connected component.
         pruned_i2Ri1_graph, pruned_i2Ui1_graph = dask.delayed(graph_utils.prune_to_largest_connected_component, nout=2)(
-            viewgraph_i2Ri1_graph, viewgraph_i2Ui1_graph
-        )
-
-        gt_poses_graph = (
-            [dask.delayed(lambda x: x.pose())(cam) for cam in gt_cameras_graph] if gt_cameras_graph else None
+            viewgraph_i2Ri1_graph, viewgraph_i2Ui1_graph, relative_pose_priors
         )
 
         wRi_graph = self.rot_avg_module.create_computation_graph(num_images, pruned_i2Ri1_graph)
@@ -94,15 +108,13 @@ class MultiViewOptimizer:
             init_cameras_graph,
             viewgraph_v_corr_idxs_graph,
             keypoints_graph,
-            images_graph,
             gt_cameras_graph,
+            images_graph,
         )
 
-        ba_result_graph, ba_metrics_graph = self.ba_optimizer.create_computation_graph(ba_input_graph, gt_cameras_graph)
-
-        if gt_cameras_graph is None:
-            return ba_input_graph, ba_result_graph, None
-
+        ba_result_graph, ba_metrics_graph = self.ba_optimizer.create_computation_graph(
+            ba_input_graph, absolute_pose_priors, relative_pose_priors, gt_cameras_graph
+        )
         # TODO: move to rotation averaging
         rot_avg_metrics = dask.delayed(metrics_utils.compute_global_rotation_metrics)(
             wRi_graph, wti_graph, gt_poses_graph
@@ -125,8 +137,8 @@ class MultiViewOptimizer:
 def init_cameras(
     wRi_list: List[Optional[Rot3]],
     wti_list: List[Optional[Point3]],
-    intrinsics_list: List[Cal3Bundler],
-) -> Dict[int, PinholeCameraCal3Bundler]:
+    intrinsics_list: List[gtsfm_types.CALIBRATION_TYPE],
+) -> Dict[int, gtsfm_types.CAMERA_TYPE]:
     """Generate camera from valid rotations and unit-translations.
 
     Args:
@@ -139,8 +151,9 @@ def init_cameras(
     """
     cameras = {}
 
+    camera_class = gtsfm_types.get_camera_class_for_calibration(intrinsics_list[0])
     for idx, (wRi, wti) in enumerate(zip(wRi_list, wti_list)):
         if wRi is not None and wti is not None:
-            cameras[idx] = PinholeCameraCal3Bundler(Pose3(wRi, wti), intrinsics_list[idx])
+            cameras[idx] = camera_class(Pose3(wRi, wti), intrinsics_list[idx])
 
     return cameras

--- a/gtsfm/retriever/retriever_base.py
+++ b/gtsfm/retriever/retriever_base.py
@@ -16,13 +16,14 @@ from gtsfm.loader.loader_base import LoaderBase
 class ImageMatchingRegime(str, Enum):
     SEQUENTIAL: str = "sequential"
     EXHAUSTIVE: str = "exhaustive"
+    SEQUENTIAL_HILTI: str = "sequential_hilti"
 
 
 class RetrieverBase:
     """Base class for image retriever implementations."""
 
     @abc.abstractmethod
-    def run(loader: LoaderBase) -> List[Tuple[int, int]]:
+    def run(self, loader: LoaderBase) -> List[Tuple[int, int]]:
         """Compute potential image pairs.
 
         Args:

--- a/gtsfm/retriever/sequential_hilti_retriever.py
+++ b/gtsfm/retriever/sequential_hilti_retriever.py
@@ -1,8 +1,6 @@
-"""Sequential retriever, that uses a sliding window/fixed lookahead to propose image pairs.
+"""Sequential retriever, that uses a sliding window/fixed lookahead and hardcoded rig structure to propose image pairs.
 
-Only useful for temporally ordered data.
-
-Authors: John Lambert
+Authors: Ayush Baid.
 """
 from typing import List, Tuple
 

--- a/gtsfm/retriever/sequential_hilti_retriever.py
+++ b/gtsfm/retriever/sequential_hilti_retriever.py
@@ -1,0 +1,39 @@
+"""Sequential retriever, that uses a sliding window/fixed lookahead to propose image pairs.
+
+Only useful for temporally ordered data.
+
+Authors: John Lambert
+"""
+from typing import List, Tuple
+
+import gtsfm.utils.logger as logger_utils
+from gtsfm.loader.hilti_loader import HiltiLoader
+from gtsfm.retriever.retriever_base import RetrieverBase
+
+logger = logger_utils.get_logger()
+
+
+class SequentialHiltiRetriever(RetrieverBase):
+    """Temporary class for the hilti loader."""
+
+    def __init__(self, max_frame_lookahead: int) -> None:
+        """
+        Args:
+            max_frame_lookahead: maximum number of consecutive frames to consider for matching/co-visibility.
+        """
+        self._max_frame_lookahead = max_frame_lookahead
+
+    def run(self, loader: HiltiLoader) -> List[Tuple[int, int]]:
+        """Compute potential image pairs.
+
+        Args:
+            loader: image loader. The length of this loader will provide the total number of images
+                for exhaustive global descriptor matching.
+
+        Return:
+            pair_indices: (i1,i2) image pairs.
+        """
+        pairs = loader.get_valid_pairs()  # TODO: move this logic here.
+
+        logger.info("Found %d pairs from the SequentialHiltiRetriever", len(pairs))
+        return pairs

--- a/gtsfm/runner/frontend_runner.py
+++ b/gtsfm/runner/frontend_runner.py
@@ -17,7 +17,9 @@ from gtsfm.two_view_estimator import TwoViewEstimator
 
 def run_frontend(
     loader: LoaderBase, feature_extractor: FeatureExtractor, two_view_estimator: TwoViewEstimator
-) -> Tuple[List[Keypoints], Dict[Tuple[int,int], Rot3], Dict[Tuple[int,int], Unit3], Dict[Tuple[int,int], np.ndarray]]:
+) -> Tuple[
+    List[Keypoints], Dict[Tuple[int, int], Rot3], Dict[Tuple[int, int], Unit3], Dict[Tuple[int, int], np.ndarray]
+]:
     """Creates the front-end computation graph, and then runs it.
 
     Note: Copied from SceneOptimizer class, without back-end code.
@@ -60,6 +62,9 @@ def run_frontend(
             camera_intrinsics_graph[i2],
             image_shape_graph[i1],
             image_shape_graph[i2],
+            dask.delayed(None),
+            dask.delayed(None),
+            dask.delayed(None),
         )
         i2Ri1_graph_dict[(i1, i2)] = i2Ri1
         i2Ui1_graph_dict[(i1, i2)] = i2Ui1

--- a/gtsfm/runner/frontend_runner.py
+++ b/gtsfm/runner/frontend_runner.py
@@ -54,17 +54,17 @@ def run_frontend(
     v_corr_idxs_graph_dict: Dict[Tuple[int, int], Delayed] = {}
     for (i1, i2) in image_pair_indices:
         (i2Ri1, i2Ui1, v_corr_idxs, two_view_report) = two_view_estimator.create_computation_graph(
-            keypoints_graph_list[i1],
-            keypoints_graph_list[i2],
-            descriptors_graph_list[i1],
-            descriptors_graph_list[i2],
-            camera_intrinsics_graph[i1],
-            camera_intrinsics_graph[i2],
-            image_shape_graph[i1],
-            image_shape_graph[i2],
-            dask.delayed(None),
-            dask.delayed(None),
-            dask.delayed(None),
+            keypoints_i1_graph=keypoints_graph_list[i1],
+            keypoints_i2_graph=keypoints_graph_list[i2],
+            descriptors_i1_graph=descriptors_graph_list[i1],
+            descriptors_i2_graph=descriptors_graph_list[i2],
+            camera_intrinsics_i1_graph=camera_intrinsics_graph[i1],
+            camera_intrinsics_i2_graph=camera_intrinsics_graph[i2],
+            im_shape_i1_graph=image_shape_graph[i1],
+            im_shape_i2_graph=image_shape_graph[i2],
+            i2Ti1_prior=dask.delayed(None),
+            gt_wTi1_graph=dask.delayed(None),
+            gt_wTi2_graph=dask.delayed(None),
         )
         i2Ri1_graph_dict[(i1, i2)] = i2Ri1
         i2Ui1_graph_dict[(i1, i2)] = i2Ui1

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -14,6 +14,7 @@ from gtsfm.scene_optimizer import SceneOptimizer
 
 from gtsfm.retriever.exhaustive_retriever import ExhaustiveRetriever
 from gtsfm.retriever.retriever_base import ImageMatchingRegime
+from gtsfm.retriever.sequential_hilti_retriever import SequentialHiltiRetriever
 from gtsfm.retriever.sequential_retriever import SequentialRetriever
 
 
@@ -67,7 +68,7 @@ class GtsfmRunnerBase:
         parser.add_argument(
             "--matching_regime",
             type=str,
-            choices=["exhaustive", "sequential"],
+            choices=["exhaustive", "sequential", "sequential_hilti"],
             default="sequential",
             help="Choose mode for matching.",
         )
@@ -106,6 +107,9 @@ class GtsfmRunnerBase:
         elif matching_regime == ImageMatchingRegime.SEQUENTIAL:
             retriever = SequentialRetriever(max_frame_lookahead=self.parsed_args.max_frame_lookahead)
 
+        elif matching_regime == ImageMatchingRegime.SEQUENTIAL_HILTI:
+            retriever = SequentialHiltiRetriever(max_frame_lookahead=self.parsed_args.max_frame_lookahead)
+
         return retriever
 
     def run(self) -> None:
@@ -127,7 +131,10 @@ class GtsfmRunnerBase:
             image_graph=self.loader.create_computation_graph_for_images(),
             camera_intrinsics_graph=self.loader.create_computation_graph_for_intrinsics(),
             image_shape_graph=self.loader.create_computation_graph_for_image_shapes(),
+            relative_pose_priors=self.loader.create_computation_graph_for_relative_pose_priors(image_pair_indices),
+            absolute_pose_priors=self.loader.create_computation_graph_for_absolute_pose_priors(),
             gt_cameras_graph=self.loader.create_computation_graph_for_cameras(),
+            gt_poses_graph=self.loader.create_computation_graph_for_poses(),
             matching_regime=ImageMatchingRegime(self.parsed_args.matching_regime),
         )
 

--- a/gtsfm/runner/run_scene_optimizer_astronet.py
+++ b/gtsfm/runner/run_scene_optimizer_astronet.py
@@ -11,6 +11,7 @@ import gtsfm.utils.logger as logger_utils
 from gtsfm.common.gtsfm_data import GtsfmData
 from gtsfm.loader.loader_base import LoaderBase
 from gtsfm.loader.astronet_loader import AstronetLoader
+from gtsfm.retriever.retriever_base import ImageMatchingRegime
 from gtsfm.runner.gtsfm_runner_base import GtsfmRunnerBase
 
 logger = logger_utils.get_logger()
@@ -71,8 +72,12 @@ class GtsfmRunnerAstronetLoader(GtsfmRunnerBase):
                 image_graph=self.loader.create_computation_graph_for_images(),
                 camera_intrinsics_graph=self.loader.create_computation_graph_for_intrinsics(),
                 image_shape_graph=self.loader.create_computation_graph_for_image_shapes(),
-                gt_cameras_graph=self.loader.create_computation_graph_for_cameras(),
                 gt_scene_mesh=gt_scene_trimesh_future,
+                gt_cameras_graph=self.loader.create_computation_graph_for_cameras(),
+                gt_poses_graph=self.loader.create_computation_graph_for_poses(),
+                matching_regime=ImageMatchingRegime(self.parsed_args.matching_regime),
+                absolute_pose_priors=self.loader.create_computation_graph_for_absolute_pose_priors(),
+                relative_pose_priors=self.loader.create_computation_graph_for_relative_pose_priors(image_pair_indices),
             )
 
             # Run SfM pipeline.

--- a/gtsfm/runner/run_scene_optimizer_hilti.py
+++ b/gtsfm/runner/run_scene_optimizer_hilti.py
@@ -1,3 +1,7 @@
+"""Runner for the hilti dataset.
+
+Authors: Ayush Baid
+"""
 import argparse
 
 import gtsfm.utils.logger as logger_utils
@@ -8,6 +12,7 @@ from gtsfm.runner.gtsfm_runner_base import GtsfmRunnerBase
 logger = logger_utils.get_logger()
 
 # Note: max_frame_lookahead pertains to rig indices and not image indices.
+
 
 class GtsfmRunnerHiltiLoader(GtsfmRunnerBase):
     def __init__(self):

--- a/gtsfm/runner/run_scene_optimizer_hilti.py
+++ b/gtsfm/runner/run_scene_optimizer_hilti.py
@@ -1,0 +1,42 @@
+import argparse
+
+import gtsfm.utils.logger as logger_utils
+from gtsfm.loader.hilti_loader import HiltiLoader
+from gtsfm.loader.loader_base import LoaderBase
+from gtsfm.runner.gtsfm_runner_base import GtsfmRunnerBase
+
+logger = logger_utils.get_logger()
+
+# Note: max_frame_lookahead pertains to rig indices and not image indices.
+
+class GtsfmRunnerHiltiLoader(GtsfmRunnerBase):
+    def __init__(self):
+        super(GtsfmRunnerHiltiLoader, self).__init__(tag="GTSFM for the hilti loader")
+
+    def construct_argparser(self) -> argparse.ArgumentParser:
+        parser = super(GtsfmRunnerHiltiLoader, self).construct_argparser()
+
+        parser.add_argument(
+            "--dataset_dirpath",
+            type=str,
+            required=True,
+            help="path to directory containing the calibration files and the images",
+        )
+
+        parser.add_argument("--max_length", type=int, default=50, help="Max number of timestamps to process")
+
+        return parser
+
+    def construct_loader(self) -> LoaderBase:
+        loader = HiltiLoader(
+            base_folder=self.parsed_args.dataset_dirpath,
+            max_frame_lookahead=self.parsed_args.max_frame_lookahead,
+            max_length=self.parsed_args.max_length,
+        )
+
+        return loader
+
+
+if __name__ == "__main__":
+    runner = GtsfmRunnerHiltiLoader()
+    runner.run()

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -78,6 +78,7 @@ class SceneOptimizer:
         save_two_view_correspondences_viz: bool,
         save_3d_viz: bool,
         save_gtsfm_data: bool,
+        run_dense_optimizer: bool,
         pose_angular_error_thresh: float,
     ) -> None:
         """pose_angular_error_thresh is given in degrees"""
@@ -88,6 +89,7 @@ class SceneOptimizer:
 
         self._save_two_view_correspondences_viz = save_two_view_correspondences_viz
         self._save_3d_viz = save_3d_viz
+        self._run_dense_optimizer = run_dense_optimizer
 
         self._save_gtsfm_data = save_gtsfm_data
         self._pose_angular_error_thresh = pose_angular_error_thresh
@@ -112,7 +114,10 @@ class SceneOptimizer:
         image_graph: List[Delayed],
         camera_intrinsics_graph: List[Delayed],
         image_shape_graph: List[Delayed],
-        gt_cameras_graph: Optional[List[Delayed]] = None,
+        relative_pose_priors: Dict[Tuple[int, int], Delayed],
+        absolute_pose_priors: List[Delayed],
+        gt_cameras_graph: List[Delayed],
+        gt_poses_graph: List[Delayed],
         gt_scene_mesh: Optional[Trimesh] = None,
         matching_regime: ImageMatchingRegime = ImageMatchingRegime.SEQUENTIAL,
     ) -> Delayed:
@@ -143,13 +148,6 @@ class SceneOptimizer:
         for (i1, i2) in image_pair_indices:
             # Collect ground truth relative and absolute poses if available.
             # TODO(johnwlambert): decompose this method -- name it as "calling_the_plate()"
-            if gt_cameras_graph is not None:
-                gt_wTi1, gt_wTi2 = (
-                    gt_cameras_graph[i1].pose(),
-                    gt_cameras_graph[i2].pose(),
-                )
-            else:
-                gt_wTi1, gt_wTi2 = None, None
 
             # TODO(johnwlambert): decompose this so what happens in the loop is a separate method
             i2Ri1, i2Ui1, v_corr_idxs, two_view_reports = self.two_view_estimator.create_computation_graph(
@@ -161,8 +159,9 @@ class SceneOptimizer:
                 camera_intrinsics_graph[i2],
                 image_shape_graph[i1],
                 image_shape_graph[i2],
-                gt_wTi1,
-                gt_wTi2,
+                relative_pose_priors[(i1, i2)],
+                gt_poses_graph[i1],
+                gt_poses_graph[i2],
                 gt_scene_mesh,
             )
 
@@ -208,8 +207,11 @@ class SceneOptimizer:
             i2Ui1_graph_dict,
             v_corr_idxs_graph_dict,
             camera_intrinsics_graph,
+            absolute_pose_priors,
+            relative_pose_priors,
             two_view_reports_dict[POST_ISP_REPORT_TAG],
             gt_cameras_graph,
+            gt_poses_graph,
         )
         if view_graph_two_view_reports is not None:
             two_view_reports_dict[VIEWGRAPH_REPORT_TAG] = view_graph_two_view_reports
@@ -225,24 +227,19 @@ class SceneOptimizer:
                     matching_regime=matching_regime,
                 )
             )
-            if gt_cameras_graph is not None:
-                metrics_graph_list.append(
-                    dask.delayed(two_view_estimator.aggregate_frontend_metrics)(
-                        report_dict,
-                        self._pose_angular_error_thresh,
-                        metric_group_name="verifier_summary_{}".format(tag),
-                    )
+            metrics_graph_list.append(
+                dask.delayed(two_view_estimator.aggregate_frontend_metrics)(
+                    report_dict,
+                    self._pose_angular_error_thresh,
+                    metric_group_name="verifier_summary_{}".format(tag),
                 )
+            )
 
         # aggregate metrics for multiview optimizer
         if optimizer_metrics_graph is not None:
             metrics_graph_list.extend(optimizer_metrics_graph)
 
         # Modify BA input, BA output, and GT poses to have point clouds and frustums aligned with x,y,z axes.
-        gt_poses_graph = (
-            [dask.delayed(lambda x: x.pose())(cam) for cam in gt_cameras_graph] if gt_cameras_graph else None
-        )
-
         ba_input_graph, ba_output_graph, gt_poses_graph = dask.delayed(align_estimated_gtsfm_data, nout=3)(
             ba_input_graph, ba_output_graph, gt_poses_graph
         )
@@ -253,26 +250,27 @@ class SceneOptimizer:
         if self._save_gtsfm_data:
             auxiliary_graph_list.extend(save_gtsfm_data(image_graph, ba_input_graph, ba_output_graph))
 
-        img_dict_graph = dask.delayed(get_image_dictionary)(image_graph)
-        (
-            dense_points_graph,
-            dense_point_colors_graph,
-            densify_metrics_graph,
-            downsampling_metrics_graph,
-        ) = self.dense_multiview_optimizer.create_computation_graph(img_dict_graph, ba_output_graph)
+        if self._run_dense_optimizer:
+            img_dict_graph = dask.delayed(get_image_dictionary)(image_graph)
+            (
+                dense_points_graph,
+                dense_point_colors_graph,
+                densify_metrics_graph,
+                downsampling_metrics_graph,
+            ) = self.dense_multiview_optimizer.create_computation_graph(img_dict_graph, ba_output_graph)
 
-        # Cast to string as Open3d cannot use PosixPath's for I/O -- only string file paths are accepted.
-        auxiliary_graph_list.append(
-            dask.delayed(io_utils.save_point_cloud_as_ply)(
-                save_fpath=str(MVS_PLY_SAVE_FPATH), points=dense_points_graph, rgb=dense_point_colors_graph
+            # Cast to string as Open3d cannot use PosixPath's for I/O -- only string file paths are accepted.
+            auxiliary_graph_list.append(
+                dask.delayed(io_utils.save_point_cloud_as_ply)(
+                    save_fpath=str(MVS_PLY_SAVE_FPATH), points=dense_points_graph, rgb=dense_point_colors_graph
+                )
             )
-        )
 
-        # Add metrics for dense reconstruction and voxel downsampling
-        if densify_metrics_graph is not None:
-            metrics_graph_list.append(densify_metrics_graph)
-        if downsampling_metrics_graph is not None:
-            metrics_graph_list.append(downsampling_metrics_graph)
+            # Add metrics for dense reconstruction and voxel downsampling
+            if densify_metrics_graph is not None:
+                metrics_graph_list.append(densify_metrics_graph)
+            if downsampling_metrics_graph is not None:
+                metrics_graph_list.append(downsampling_metrics_graph)
 
         # Save metrics to JSON and generate HTML report.
         auxiliary_graph_list.extend(save_metrics_reports(metrics_graph_list))
@@ -294,8 +292,8 @@ def get_image_dictionary(image_list: List[Image]) -> Dict[int, Image]:
 
 
 def align_estimated_gtsfm_data(
-    ba_input: GtsfmData, ba_output: GtsfmData, gt_pose_graph: List[Pose3]
-) -> Tuple[GtsfmData, GtsfmData, List[Pose3]]:
+    ba_input: GtsfmData, ba_output: GtsfmData, gt_pose_graph: List[Optional[Pose3]]
+) -> Tuple[GtsfmData, GtsfmData, List[Optional[Pose3]]]:
     """Creates modified GtsfmData objects that emulate ba_input and ba_output but with point cloud and camera
     frustums aligned to the x,y,z axes. Also transforms GT camera poses to be aligned to axes.
 
@@ -309,18 +307,18 @@ def align_estimated_gtsfm_data(
         Updated ba_output GtsfmData object aligned to axes.
         Updated gt_pose_graph with GT poses aligned to axes.
     """
+    if gt_pose_graph is None:
+        return ba_input, ba_output, gt_pose_graph
     walignedTw = ellipsoid_utils.get_ortho_axis_alignment_transform(ba_output)
     walignedSw = Similarity3(R=walignedTw.rotation(), t=walignedTw.translation(), s=1.0)
     ba_input = ba_input.apply_Sim3(walignedSw)
     ba_output = ba_output.apply_Sim3(walignedSw)
-    gt_pose_graph = [walignedSw.transformFrom(wTi) for wTi in gt_pose_graph]
+    gt_pose_graph = [walignedSw.transformFrom(wTi) if wTi is not None else None for wTi in gt_pose_graph]
     return ba_input, ba_output, gt_pose_graph
 
 
 def save_visualizations(
-    ba_input_graph: Delayed,
-    ba_output_graph: Delayed,
-    gt_pose_graph: Optional[List[Delayed]],
+    ba_input_graph: Delayed, ba_output_graph: Delayed, gt_pose_graph: List[Optional[Delayed]]
 ) -> List[Delayed]:
     """Save SfmData before and after bundle adjustment and camera poses for visualization.
 

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -74,12 +74,11 @@ class SceneOptimizer:
         feature_extractor: FeatureExtractor,
         two_view_estimator: TwoViewEstimator,
         multiview_optimizer: MultiViewOptimizer,
-        dense_multiview_optimizer: MVSBase,
-        save_two_view_correspondences_viz: bool,
-        save_3d_viz: bool,
-        save_gtsfm_data: bool,
-        run_dense_optimizer: bool,
-        pose_angular_error_thresh: float,
+        dense_multiview_optimizer: Optional[MVSBase] = None,
+        save_two_view_correspondences_viz: bool = False,
+        save_3d_viz: bool = True,
+        save_gtsfm_data: bool = True,
+        pose_angular_error_thresh: float = 3,
     ) -> None:
         """pose_angular_error_thresh is given in degrees"""
         self.feature_extractor = feature_extractor
@@ -89,7 +88,7 @@ class SceneOptimizer:
 
         self._save_two_view_correspondences_viz = save_two_view_correspondences_viz
         self._save_3d_viz = save_3d_viz
-        self._run_dense_optimizer = run_dense_optimizer
+        self._run_dense_optimizer = self.dense_multiview_optimizer is not None
 
         self._save_gtsfm_data = save_gtsfm_data
         self._pose_angular_error_thresh = pose_angular_error_thresh

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -306,8 +306,6 @@ def align_estimated_gtsfm_data(
         Updated ba_output GtsfmData object aligned to axes.
         Updated gt_pose_graph with GT poses aligned to axes.
     """
-    if gt_pose_graph is None:
-        return ba_input, ba_output, gt_pose_graph
     walignedTw = ellipsoid_utils.get_ortho_axis_alignment_transform(ba_output)
     walignedSw = Similarity3(R=walignedTw.rotation(), t=walignedTw.translation(), s=1.0)
     ba_input = ba_input.apply_Sim3(walignedSw)

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -218,6 +218,20 @@ class TwoViewEstimator:
     def __generate_initial_pose_for_bundle_adjustment(
         self, i2Ti1_from_verifier: Optional[Pose3], i2Ti1_prior: Optional[PosePrior]
     ) -> Optional[Pose3]:
+        """Use the combination of pose recovered from the verifier and the prior information to get the pose
+        initialization for 2-view BA.
+
+        Logic:
+        1. If the prior value exists, use the prior as the initial value.
+        2. Otherwise, use the verifier output as initial value.
+
+        Args:
+            i2Ti1_from_verifier: relative pose recovered from verifier.
+            i2Ti1_prior: relative pose prior.
+
+        Returns:
+            Pose to be used for initialization.
+        """
         if i2Ti1_prior is None and i2Ti1_from_verifier is None:
             return None
         elif i2Ti1_prior is not None:

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -11,22 +11,24 @@ import gtsam
 import numpy as np
 from dask.delayed import Delayed
 from gtsam import (
-    Cal3Bundler,
     CameraSetCal3Bundler,
+    CameraSetCal3Fisheye,
+    PinholeCameraCal3Bundler,
     Point2Vector,
     Pose3,
-    PinholeCameraCal3Bundler,
     Rot3,
     SfmTrack,
     Unit3,
 )
 
+import gtsfm.common.types as gtsfm_types
 import gtsfm.utils.geometry_comparisons as comp_utils
 import gtsfm.utils.logger as logger_utils
 import gtsfm.utils.metrics as metric_utils
 from gtsfm.bundle.bundle_adjustment import BundleAdjustmentOptimizer
 from gtsfm.common.gtsfm_data import GtsfmData
 from gtsfm.common.keypoints import Keypoints
+from gtsfm.common.pose_prior import PosePrior, PosePriorType
 from gtsfm.common.two_view_estimation_report import TwoViewEstimationReport
 from gtsfm.data_association.point3d_initializer import SVD_DLT_RANK_TOL
 from gtsfm.frontend.inlier_support_processor import InlierSupportProcessor
@@ -84,12 +86,12 @@ class TwoViewEstimator:
     @classmethod
     def triangulate_two_view_correspondences(
         cls,
-        camera_i1: PinholeCameraCal3Bundler,
-        camera_i2: PinholeCameraCal3Bundler,
+        camera_i1: gtsfm_types.CAMERA_TYPE,
+        camera_i2: gtsfm_types.CAMERA_TYPE,
         keypoints_i1: Keypoints,
         keypoints_i2: Keypoints,
         corr_idxs: np.ndarray,
-    ):
+    ) -> List[SfmTrack]:
         """Triangulate 2-view correspondences to form 3d tracks.
 
         Args:
@@ -100,9 +102,11 @@ class TwoViewEstimator:
             corr_idxs: indices of corresponding keypoints.
 
         Returns:
-            Triangulated 3D points.
+            Triangulated 3D points as tracks.
         """
-        camera_set = CameraSetCal3Bundler()
+        camera_set = (
+            CameraSetCal3Bundler() if isinstance(camera_i1, PinholeCameraCal3Bundler) else CameraSetCal3Fisheye()
+        )
         camera_set.append(camera_i1)
         camera_set.append(camera_i2)
 
@@ -123,6 +127,7 @@ class TwoViewEstimator:
                 tracks_3d.append(track_3d)
             except RuntimeError:
                 pass
+                # logger.error(e)
 
         return tracks_3d
 
@@ -131,10 +136,12 @@ class TwoViewEstimator:
         keypoints_i1: Keypoints,
         keypoints_i2: Keypoints,
         verified_corr_idxs: np.ndarray,
-        camera_intrinsics_i1: Cal3Bundler,
-        camera_intrinsics_i2: Cal3Bundler,
+        putative_corr_idxs: np.ndarray,
+        camera_intrinsics_i1: gtsfm_types.CALIBRATION_TYPE,
+        camera_intrinsics_i2: gtsfm_types.CALIBRATION_TYPE,
         i2Ri1_initial: Optional[Rot3],
         i2Ui1_initial: Optional[Unit3],
+        i2Ti1_prior: Optional[PosePrior],
     ) -> Tuple[Optional[Rot3], Optional[Unit3], np.ndarray]:
         """Refine the relative pose using bundle adjustment on the 2-view scene.
 
@@ -142,27 +149,36 @@ class TwoViewEstimator:
             keypoints_i1: keypoints from image i1.
             keypoints_i2: keypoints from image i2.
             verified_corr_idxs: indices of verified correspondences between i1 and i2.
+            putative_corr_idxs: putative correspondences between i1 and i2.
             camera_intrinsics_i1: intrinsics for i1.
             camera_intrinsics_i2: intrinsics for i2.
             i2Ri1_initial: the relative rotation to be used as initial rotation between cameras.
             i2Ui1_initial: the relative unit direction, to be used to initialize initial translation between cameras.
+            i2Ti1_prior: prior on the relative pose for cameras (i1, i2).
         Returns:
             Optimized relative rotation i2Ri1.
             Optimized unit translation i2Ui1.
             Optimized verified_corr_idxs.
         """
-        if i2Ri1_initial is None or i2Ui1_initial is None:
+        i2Ti1_from_verifier: Optional[Pose3] = (
+            Pose3(i2Ri1_initial, i2Ui1_initial.point3()) if i2Ri1_initial is not None else None
+        )
+        i2Ti1_initial: Optional[Pose3] = self.__generate_initial_pose_for_bundle_adjustment(
+            i2Ti1_from_verifier, i2Ti1_prior
+        )
+
+        if i2Ti1_initial is None:
             return None, None, verified_corr_idxs
 
-        i2Ti1_initial = Pose3(i2Ri1_initial, i2Ui1_initial.point3())
-
         # Set the i1 camera pose as the global coordinate system.
-        camera_i1 = PinholeCameraCal3Bundler(Pose3(), camera_intrinsics_i1)
-        camera_i2 = PinholeCameraCal3Bundler(i2Ti1_initial.inverse(), camera_intrinsics_i2)
+        camera_class = gtsfm_types.get_camera_class_for_calibration(camera_intrinsics_i1)
+        camera_i1 = camera_class(Pose3(), camera_intrinsics_i1)
+        camera_i2 = camera_class(i2Ti1_initial.inverse(), camera_intrinsics_i2)
 
         # Perform data association to construct 2-view BA input.
         start_time = timeit.default_timer()
-        triangulated_tracks: List[SfmTrack] = self.triangulate_two_view_correspondences(
+        # TODO: add flag to switch between verified and putative correspondences.
+        triangulated_tracks = self.triangulate_two_view_correspondences(
             camera_i1=camera_i1,
             camera_i2=camera_i2,
             keypoints_i1=keypoints_i1,
@@ -171,6 +187,9 @@ class TwoViewEstimator:
         )
         logger.debug("Performed DA in %.6f seconds.", timeit.default_timer() - start_time)
 
+        if len(triangulated_tracks) == 0:
+            return i2Ti1_initial.rotation(), Unit3(i2Ti1_initial.translation()), np.array([], dtype=np.uint32)
+
         # Perform 2-view BA.
         start_time = timeit.default_timer()
         ba_input = GtsfmData(number_images=2)
@@ -178,7 +197,15 @@ class TwoViewEstimator:
         ba_input.add_camera(1, camera_i2)
         for track in triangulated_tracks:
             ba_input.add_track(track)
-        ba_output, _ = self._ba_optimizer.run(ba_input, verbose=False)
+
+        relative_pose_prior_for_ba = {}
+        # TODO: should we model soft pose prior differently?
+        if i2Ti1_prior is not None:
+            relative_pose_prior_for_ba = {(0, 1): i2Ti1_prior}
+
+        ba_output, _ = self._ba_optimizer.run(
+            ba_input, absolute_pose_priors=[], relative_pose_priors=relative_pose_prior_for_ba, verbose=False
+        )
         wTi1, wTi2 = ba_output.get_camera_poses()  # extract the camera poses
         if wTi1 is None or wTi2 is None:
             logger.warning("2-view BA failed")
@@ -187,6 +214,16 @@ class TwoViewEstimator:
         logger.debug("Performed 2-view BA in %.6f seconds.", timeit.default_timer() - start_time)
 
         return i2Ti1_optimized.rotation(), Unit3(i2Ti1_optimized.translation()), verified_corr_idxs
+
+    def __generate_initial_pose_for_bundle_adjustment(
+        self, i2Ti1_from_verifier: Optional[Pose3], i2Ti1_prior: Optional[PosePrior]
+    ) -> Optional[Pose3]:
+        if i2Ti1_prior is None and i2Ti1_from_verifier is None:
+            return None
+        elif i2Ti1_prior is not None:
+            return i2Ti1_prior.value
+        else:
+            return i2Ti1_from_verifier
 
     def get_corr_metric_dist_threshold(self) -> float:
         """Getter for the distance threshold used in the metric for correct correspondences."""
@@ -202,8 +239,9 @@ class TwoViewEstimator:
         camera_intrinsics_i2_graph: Delayed,
         im_shape_i1_graph: Delayed,
         im_shape_i2_graph: Delayed,
-        gt_wTi1_graph: Optional[Delayed] = None,
-        gt_wTi2_graph: Optional[Delayed] = None,
+        i2Ti1_prior: Delayed,
+        gt_wTi1_graph: Delayed,
+        gt_wTi2_graph: Delayed,
         gt_scene_mesh_graph: Optional[Delayed] = None,
     ) -> Tuple[Delayed, Delayed, Delayed, Dict[str, Delayed]]:
         """Create delayed tasks for matching and verification.
@@ -217,6 +255,7 @@ class TwoViewEstimator:
             camera_intrinsics_i2_graph: intrinsics for camera i2.
             im_shape_i1_graph: image shape for image i1.
             im_shape_i2_graph: image shape for image i2.
+            i2Ti1_prior: the prior on relative pose i2Ti1.
             i2Ti1_expected_graph (optional): ground truth relative pose, used for evaluation if available. Defaults to
                                              None.
 
@@ -257,10 +296,12 @@ class TwoViewEstimator:
                 keypoints_i1_graph,
                 keypoints_i2_graph,
                 pre_ba_v_corr_idxs,
+                putative_corr_idxs,
                 camera_intrinsics_i1_graph,
                 camera_intrinsics_i2_graph,
                 pre_ba_i2Ri1,
                 pre_ba_i2Ui1,
+                i2Ti1_prior,
             )
         else:
             post_ba_i2Ri1 = pre_ba_i2Ri1
@@ -268,45 +309,39 @@ class TwoViewEstimator:
             post_ba_v_corr_idxs = pre_ba_v_corr_idxs
 
         # if we have the expected GT data, evaluate the computed relative pose
-        if gt_wTi1_graph is not None and gt_wTi2_graph is not None:
-            i2Ti1_expected_graph = gt_wTi2_graph.between(gt_wTi1_graph)
-            pre_ba_R_error_deg, pre_ba_U_error_deg = dask.delayed(compute_relative_pose_metrics, nout=2)(
-                pre_ba_i2Ri1, pre_ba_i2Ui1, i2Ti1_expected_graph
-            )
-            post_ba_R_error_deg, post_ba_U_error_deg = dask.delayed(compute_relative_pose_metrics, nout=2)(
-                post_ba_i2Ri1, post_ba_i2Ui1, i2Ti1_expected_graph
-            )
-            pre_ba_inlier_mask_wrt_gt, pre_ba_reproj_error_wrt_gt = dask.delayed(
-                metric_utils.compute_correspondence_metrics, nout=2
-            )(
-                keypoints_i1_graph,
-                keypoints_i2_graph,
-                pre_ba_v_corr_idxs,
-                camera_intrinsics_i1_graph,
-                camera_intrinsics_i2_graph,
-                self._corr_metric_dist_threshold,
-                gt_wTi1_graph,
-                gt_wTi2_graph,
-                gt_scene_mesh_graph,
-            )
-            post_ba_inlier_mask_wrt_gt, post_ba_reproj_error_wrt_gt = dask.delayed(
-                metric_utils.compute_correspondence_metrics, nout=2
-            )(
-                keypoints_i1_graph,
-                keypoints_i2_graph,
-                post_ba_v_corr_idxs,
-                camera_intrinsics_i1_graph,
-                camera_intrinsics_i2_graph,
-                self._corr_metric_dist_threshold,
-                gt_wTi1_graph,
-                gt_wTi2_graph,
-                gt_scene_mesh_graph,
-            )
-        else:
-            pre_ba_R_error_deg, pre_ba_U_error_deg = None, None
-            post_ba_R_error_deg, post_ba_U_error_deg = None, None
-            pre_ba_inlier_mask_wrt_gt, pre_ba_reproj_error_wrt_gt = None, None
-            post_ba_inlier_mask_wrt_gt, post_ba_reproj_error_wrt_gt = None, None
+
+        pre_ba_R_error_deg, pre_ba_U_error_deg = dask.delayed(compute_relative_pose_metrics, nout=2)(
+            pre_ba_i2Ri1, pre_ba_i2Ui1, gt_wTi1_graph, gt_wTi2_graph
+        )
+        post_ba_R_error_deg, post_ba_U_error_deg = dask.delayed(compute_relative_pose_metrics, nout=2)(
+            post_ba_i2Ri1, post_ba_i2Ui1, gt_wTi1_graph, gt_wTi2_graph
+        )
+        pre_ba_inlier_mask_wrt_gt, pre_ba_reproj_error_wrt_gt = dask.delayed(
+            metric_utils.compute_correspondence_metrics, nout=2
+        )(
+            keypoints_i1_graph,
+            keypoints_i2_graph,
+            pre_ba_v_corr_idxs,
+            camera_intrinsics_i1_graph,
+            camera_intrinsics_i2_graph,
+            self._corr_metric_dist_threshold,
+            gt_wTi1_graph,
+            gt_wTi2_graph,
+            gt_scene_mesh_graph,
+        )
+        post_ba_inlier_mask_wrt_gt, post_ba_reproj_error_wrt_gt = dask.delayed(
+            metric_utils.compute_correspondence_metrics, nout=2
+        )(
+            keypoints_i1_graph,
+            keypoints_i2_graph,
+            post_ba_v_corr_idxs,
+            camera_intrinsics_i1_graph,
+            camera_intrinsics_i2_graph,
+            self._corr_metric_dist_threshold,
+            gt_wTi1_graph,
+            gt_wTi2_graph,
+            gt_scene_mesh_graph,
+        )
 
         pre_ba_report = dask.delayed(generate_two_view_report)(
             inlier_ratio_wrt_estimate,
@@ -385,7 +420,10 @@ def generate_two_view_report(
 
 
 def compute_relative_pose_metrics(
-    i2Ri1_computed: Optional[Rot3], i2Ui1_computed: Optional[Unit3], i2Ti1_expected: Pose3
+    i2Ri1_computed: Optional[Rot3],
+    i2Ui1_computed: Optional[Unit3],
+    wTi1_expected: Optional[Pose3],
+    wTi2_expected: Optional[Pose3],
 ) -> Tuple[Optional[float], Optional[float]]:
     """Compute the metrics on relative camera pose.
 
@@ -398,10 +436,14 @@ def compute_relative_pose_metrics(
         Rotation error, in degrees
         Unit translation error, in degrees
     """
-    R_error_deg = comp_utils.compute_relative_rotation_angle(i2Ri1_computed, i2Ti1_expected.rotation())
-    U_error_deg = comp_utils.compute_relative_unit_translation_angle(
-        i2Ui1_computed, Unit3(i2Ti1_expected.translation())
-    )
+    if wTi1_expected is not None and wTi2_expected is not None:
+        i2Ti1_expected = wTi2_expected.between(wTi1_expected)
+        R_error_deg = comp_utils.compute_relative_rotation_angle(i2Ri1_computed, i2Ti1_expected.rotation())
+        U_error_deg = comp_utils.compute_relative_unit_translation_angle(
+            i2Ui1_computed, Unit3(i2Ti1_expected.translation())
+        )
+    else:
+        return (None, None)
 
     return (R_error_deg, U_error_deg)
 

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -199,7 +199,6 @@ class TwoViewEstimator:
             ba_input.add_track(track)
 
         relative_pose_prior_for_ba = {}
-        # TODO: should we model soft pose prior differently?
         if i2Ti1_prior is not None:
             relative_pose_prior_for_ba = {(0, 1): i2Ti1_prior}
 

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -28,7 +28,7 @@ import gtsfm.utils.metrics as metric_utils
 from gtsfm.bundle.bundle_adjustment import BundleAdjustmentOptimizer
 from gtsfm.common.gtsfm_data import GtsfmData
 from gtsfm.common.keypoints import Keypoints
-from gtsfm.common.pose_prior import PosePrior, PosePriorType
+from gtsfm.common.pose_prior import PosePrior
 from gtsfm.common.two_view_estimation_report import TwoViewEstimationReport
 from gtsfm.data_association.point3d_initializer import SVD_DLT_RANK_TOL
 from gtsfm.frontend.inlier_support_processor import InlierSupportProcessor

--- a/gtsfm/utils/geometry_comparisons.py
+++ b/gtsfm/utils/geometry_comparisons.py
@@ -99,11 +99,19 @@ def align_poses_sim3(aTi_list: List[Pose3], bTi_list: List[Pose3]) -> Tuple[List
             have the same origin and scale as reference (now living in "a" frame)
         aSb: Similarity(3) object that aligns the two pose graphs.
     """
-    n_to_align = len(aTi_list)
     assert len(aTi_list) == len(bTi_list)
-    assert n_to_align >= 2, "SIM(3) alignment uses at least 2 frames"
 
-    ab_pairs = Pose3Pairs(list(zip(aTi_list, bTi_list)))
+    valid_pose_tuples = [
+        pose_tuple
+        for pose_tuple in list(zip(aTi_list, bTi_list))
+        if pose_tuple[0] is not None and pose_tuple[1] is not None
+    ]
+    n_to_align = len(valid_pose_tuples)
+    if n_to_align < 2:
+        logger.error("SIM(3) alignment uses at least 2 frames; Skipping")
+        return bTi_list, Similarity3(Rot3(), np.zeros((3,)), 1.0)
+
+    ab_pairs = Pose3Pairs(valid_pose_tuples)
 
     aSb = Similarity3.Align(ab_pairs)
 
@@ -114,10 +122,10 @@ def align_poses_sim3(aTi_list: List[Pose3], bTi_list: List[Pose3]) -> Tuple[List
 
         # align the rotations first, so that we can find the translation between the two panoramas
         aSb = Similarity3(aSb.rotation(), np.zeros((3,)), 1.0)
-        aTi_list_rot_aligned = [aSb.transformFrom(bTi) for bTi in bTi_list]
+        aTi_list_rot_aligned = [aSb.transformFrom(bTi) for _, bTi in valid_pose_tuples]
 
         # fit a single translation motion to the centroid
-        aTi_centroid = np.array([aTi.translation() for aTi in aTi_list]).mean(axis=0)
+        aTi_centroid = np.array([aTi.translation() for aTi, _ in valid_pose_tuples]).mean(axis=0)
         aTi_rot_aligned_centroid = np.array([aTi.translation() for aTi in aTi_list_rot_aligned]).mean(axis=0)
 
         # construct the final SIM3 transform
@@ -137,10 +145,11 @@ def align_poses_sim3(aTi_list: List[Pose3], bTi_list: List[Pose3]) -> Tuple[List
     logger.info("Sim(3) Scale `asb`: %.2f", float(aSb.scale()))
 
     aTi_list_ = []
-    for i in range(n_to_align):
-        bTi = bTi_list[i]
-
-        aTi_list_.append(aSb.transformFrom(bTi))
+    for bTi in bTi_list:
+        if bTi is None:
+            aTi_list_.append(None)
+        else:
+            aTi_list_.append(aSb.transformFrom(bTi))
 
     logger.info("Pose graph Sim(3) alignment complete.")
 
@@ -355,7 +364,7 @@ def compute_points_distance_l2(wti1: Optional[Point3], wti2: Optional[Point3]) -
 def compute_cyclic_rotation_error(i1Ri0: Rot3, i2Ri1: Rot3, i2Ri0: Rot3) -> float:
     """Computes the cycle error in degrees after composing the three input rotations.
 
-    The cyclic error is the angle between identity and the rotation obtained by composing the three input relative 
+    The cyclic error is the angle between identity and the rotation obtained by composing the three input relative
     rotations, i.e., (I - inv(i2Ri0) * i2Ri1 * i1Ri0).
 
     Args:

--- a/gtsfm/utils/graph.py
+++ b/gtsfm/utils/graph.py
@@ -10,6 +10,7 @@ import networkx as nx
 import numpy as np
 from gtsam import PinholeCameraCal3Bundler, Rot3, Unit3
 
+from gtsfm.common.pose_prior import PosePrior
 from gtsfm.common.two_view_estimation_report import TwoViewEstimationReport
 
 GREEN = [0, 1, 0]
@@ -41,6 +42,7 @@ def get_nodes_in_largest_connected_component(edges: List[Tuple[int, int]]) -> Li
 def prune_to_largest_connected_component(
     rotations: Dict[Tuple[int, int], Optional[Rot3]],
     unit_translations: Dict[Tuple[int, int], Optional[Unit3]],
+    pose_priors: Dict[Tuple[int, int], Optional[PosePrior]],
 ) -> Tuple[Dict[Tuple[int, int], Rot3], Dict[Tuple[int, int], Unit3]]:
     """Process the graph of image indices with Rot3s/Unit3s defining edges, and select the largest connected component.
 
@@ -53,6 +55,8 @@ def prune_to_largest_connected_component(
         Subset of unit_translations which are in the largest connected components.
     """
     input_edges = [k for (k, v) in rotations.items() if v is not None]
+    # TODO: start using pose priors by uncommenting the following line
+    # input_edges += [k for (k, v) in pose_priors.items() if v is not None]
     nodes_in_pruned_graph = get_nodes_in_largest_connected_component(input_edges)
 
     # select the edges with nodes in the pruned graph

--- a/gtsfm/utils/graph.py
+++ b/gtsfm/utils/graph.py
@@ -55,7 +55,7 @@ def prune_to_largest_connected_component(
         Subset of unit_translations which are in the largest connected components.
     """
     input_edges = [k for (k, v) in rotations.items() if v is not None]
-    # TODO: start using pose priors by uncommenting the following line
+    # TODO(Ayush): start using pose priors by uncommenting the following line
     # input_edges += [k for (k, v) in pose_priors.items() if v is not None]
     nodes_in_pruned_graph = get_nodes_in_largest_connected_component(input_edges)
 

--- a/gtsfm/utils/viz.py
+++ b/gtsfm/utils/viz.py
@@ -179,7 +179,7 @@ def plot_sfm_data_3d(sfm_data: GtsfmData, ax: Axes, max_plot_radius: float = 50)
 
 
 def plot_poses_3d(
-    wTi_list: List[Pose3], ax: Axes, center_marker_color: str = "k", label_name: Optional[str] = None
+    wTi_list: List[Optional[Pose3]], ax: Axes, center_marker_color: str = "k", label_name: Optional[str] = None
 ) -> None:
     """Plot poses in 3D as dots for centers and lines denoting the orthonormal
     coordinate system for each camera.
@@ -194,14 +194,18 @@ def plot_poses_3d(
     """
     spec = "{}.".format(center_marker_color)
 
-    for i, wTi in enumerate(wTi_list):
-        x, y, z = wTi.translation().squeeze()
+    is_label_added = False
+    for wTi in wTi_list:
+        if wTi is None:
+            continue
 
-        if i > 0:
-            # for the first loop iteration, add the label to the plot
+        if is_label_added:
             # for the rest of iterations, set label to None (otherwise would be duplicated in legend)
             label_name = None
+
+        x, y, z = wTi.translation().squeeze()
         ax.plot(x, y, z, spec, markersize=10, label=label_name)
+        is_label_added = True
 
         R = wTi.rotation().matrix()
 
@@ -292,7 +296,7 @@ def save_sfm_data_viz(sfm_data: GtsfmData, folder_name: str) -> None:
 
 
 def save_camera_poses_viz(
-    pre_ba_sfm_data: GtsfmData, post_ba_sfm_data: GtsfmData, gt_pose_graph: Optional[List[Pose3]], folder_name: str
+    pre_ba_sfm_data: GtsfmData, post_ba_sfm_data: GtsfmData, gt_pose_graph: List[Optional[Pose3]], folder_name: str
 ) -> None:
     """Visualize the camera pose and save to disk.
 
@@ -314,9 +318,7 @@ def save_camera_poses_viz(
     fig = plt.figure()
     ax = fig.add_subplot(projection="3d")
 
-    if gt_pose_graph is not None:
-        plot_poses_3d(gt_pose_graph, ax, center_marker_color="m", label_name="GT")
-
+    plot_poses_3d(gt_pose_graph, ax, center_marker_color="m", label_name="GT")
     plot_poses_3d(pre_ba_poses, ax, center_marker_color="c", label_name="Pre-BA")
     plot_poses_3d(post_ba_poses, ax, center_marker_color="k", label_name="Post-BA")
 

--- a/gtsfm/view_graph_estimator/view_graph_estimator_base.py
+++ b/gtsfm/view_graph_estimator/view_graph_estimator_base.py
@@ -164,20 +164,23 @@ class ViewGraphEstimatorBase(metaclass=abc.ABCMeta):
         inlier_i1_i2 = view_graph_edges
         outlier_i1_i2 = list(set(input_i1_i2) - set(inlier_i1_i2))
 
-        graph_utils.draw_view_graph_topology(
-            edges=list(input_i1_i2),
-            two_view_reports=two_view_reports,
-            title="ViewGraphEstimator input",
-            save_fpath=PLOT_BASE_PATH / "view_graph_estimator_input_topology.jpg",
-            cameras_gt=None,
-        )
-        graph_utils.draw_view_graph_topology(
-            edges=view_graph_edges,
-            two_view_reports=two_view_reports,
-            title="ViewGraphEstimator output",
-            save_fpath=PLOT_BASE_PATH / "view_graph_estimator_output_topology.jpg",
-            cameras_gt=None,
-        )
+        try:
+            graph_utils.draw_view_graph_topology(
+                edges=list(input_i1_i2),
+                two_view_reports=two_view_reports,
+                title="ViewGraphEstimator input",
+                save_fpath=PLOT_BASE_PATH / "view_graph_estimator_input_topology.jpg",
+                cameras_gt=None,
+            )
+            graph_utils.draw_view_graph_topology(
+                edges=view_graph_edges,
+                two_view_reports=two_view_reports,
+                title="ViewGraphEstimator output",
+                save_fpath=PLOT_BASE_PATH / "view_graph_estimator_output_topology.jpg",
+                cameras_gt=None,
+            )
+        except Exception as e:
+            logger.error(e)
 
         inlier_R_angular_errors = []
         outlier_R_angular_errors = []

--- a/gtsfm/view_graph_estimator/view_graph_estimator_base.py
+++ b/gtsfm/view_graph_estimator/view_graph_estimator_base.py
@@ -180,7 +180,8 @@ class ViewGraphEstimatorBase(metaclass=abc.ABCMeta):
                 cameras_gt=None,
             )
         except Exception as e:
-            logger.error(e)
+            # drawing the topology can fail in case of too many cameras
+            logger.info(e)
 
         inlier_R_angular_errors = []
         outlier_R_angular_errors = []

--- a/tests/bundle/test_bundle_adjustment.py
+++ b/tests/bundle/test_bundle_adjustment.py
@@ -39,9 +39,16 @@ class TestBundleAdjustmentOptimizer(unittest.TestCase):
         """Test the simple scene as dask computation graph."""
         sfm_data_graph = dask.delayed(self.test_data)
 
-        expected_result, _ = self.obj.run(self.test_data)
+        absolute_pose_priors = [None] * EXAMPLE_DATA.number_images()
+        relative_pose_priors = {}
 
-        computed_result, _ = self.obj.create_computation_graph(dask.delayed(sfm_data_graph))
+        expected_result, _ = self.obj.run(
+            self.test_data, absolute_pose_priors=absolute_pose_priors, relative_pose_priors=relative_pose_priors
+        )
+
+        computed_result, _ = self.obj.create_computation_graph(
+            dask.delayed(sfm_data_graph), dask.delayed(absolute_pose_priors), dask.delayed(relative_pose_priors)
+        )
 
         with dask.config.set(scheduler="single-threaded"):
             result = dask.compute(computed_result)[0]

--- a/tests/data_association/test_data_association.py
+++ b/tests/data_association/test_data_association.py
@@ -137,7 +137,9 @@ class TestDataAssociation(GtsamTestCase):
             reproj_error_threshold=5, mode=triangulation_mode, min_num_hypotheses=20
         )
         da = DataAssociation(min_track_len=3, triangulation_options=triangulation_options)
-        triangulated_landmark_map, _ = da.run(len(cameras), cameras, matches_dict, keypoints_list)
+        triangulated_landmark_map, _ = da.run(
+            len(cameras), cameras, matches_dict, keypoints_list, cameras_gt=[None] * len(cameras)
+        )
         # assert that we cannot obtain even 1 length-3 track if we have only 2 camera poses
         # result should be empty, since nb_measurements < min track length
         assert (
@@ -169,7 +171,7 @@ class TestDataAssociation(GtsamTestCase):
         triangulation_options = TriangulationOptions(reproj_error_threshold=5, mode=TriangulationSamplingMode.NO_RANSAC)
         da = DataAssociation(min_track_len=2, triangulation_options=triangulation_options)
 
-        sfm_data, _ = da.run(len(cameras), cameras, matches_dict, keypoints_list)
+        sfm_data, _ = da.run(len(cameras), cameras, matches_dict, keypoints_list, [None] * len(cameras))
         estimated_landmark = sfm_data.get_track(0).point3()
         self.gtsamAssertEquals(estimated_landmark, self.expected_landmark, 1e-2)
 
@@ -217,7 +219,7 @@ class TestDataAssociation(GtsamTestCase):
             reproj_error_threshold=5, mode=triangulation_mode, min_num_hypotheses=20
         )
         da = DataAssociation(min_track_len=3, triangulation_options=triangulation_options)
-        sfm_data, _ = da.run(len(cameras), cameras, matches_dict, keypoints_list)
+        sfm_data, _ = da.run(len(cameras), cameras, matches_dict, keypoints_list, cameras_gt=[None] * len(cameras))
 
         estimated_landmark = sfm_data.get_track(0).point3()
         # checks if computed 3D point is as expected
@@ -250,7 +252,11 @@ class TestDataAssociation(GtsamTestCase):
         # will lead to a cheirality exception because keypoints are identical in two cameras
         # no track will be formed, and thus connected component will be empty
         sfm_data, _ = da.run(
-            num_images=3, cameras=cameras, corr_idxs_dict=corr_idxs_dict, keypoints_list=[keypoints_shared] * 3
+            num_images=3,
+            cameras=cameras,
+            corr_idxs_dict=corr_idxs_dict,
+            keypoints_list=[keypoints_shared] * 3,
+            cameras_gt=[None] * 3,
         )
 
         self.assertEqual(len(sfm_data.get_valid_camera_indices()), 0)
@@ -266,6 +272,8 @@ class TestDataAssociation(GtsamTestCase):
             poses=get_pose3_vector(num_poses=3),
         )
 
+        cameras_gt = [None] * len(cameras)
+
         # create matches
         # since there is only one measurement in each image, both assigned feature index 0
         matches_dict = {(0, 1): np.array([[0, 0]]), (1, 2): np.array([[0, 0]])}
@@ -275,14 +283,13 @@ class TestDataAssociation(GtsamTestCase):
             reproj_error_threshold=5, mode=TriangulationSamplingMode.RANSAC_TOPK_BASELINES, min_num_hypotheses=20
         )
         da = DataAssociation(min_track_len=3, triangulation_options=triangulation_options)
-        expected_sfm_data, expected_metrics = da.run(len(cameras), cameras, matches_dict, keypoints_list)
+        expected_sfm_data, expected_metrics = da.run(
+            len(cameras), cameras, matches_dict, keypoints_list, cameras_gt=cameras_gt
+        )
 
         # Run with computation graph
         delayed_sfm_data, delayed_metrics = da.create_computation_graph(
-            len(cameras),
-            cameras,
-            matches_dict,
-            keypoints_list,
+            len(cameras), cameras, matches_dict, keypoints_list, dask.delayed(cameras_gt)
         )
 
         with dask.config.set(scheduler="single-threaded"):

--- a/tests/test_scene_optimizer.py
+++ b/tests/test_scene_optimizer.py
@@ -45,7 +45,9 @@ class TestSceneOptimizer(unittest.TestCase):
                 camera_intrinsics_graph=self.loader.create_computation_graph_for_intrinsics(),
                 image_shape_graph=self.loader.create_computation_graph_for_image_shapes(),
                 absolute_pose_priors=self.loader.create_computation_graph_for_absolute_pose_priors(),
-                relative_pose_priors=self.loader.create_computation_graph_for_relative_pose_priors(),
+                relative_pose_priors=self.loader.create_computation_graph_for_relative_pose_priors(
+                    self.loader.get_valid_pairs()
+                ),
                 gt_cameras_graph=self.loader.create_computation_graph_for_cameras(),
                 gt_poses_graph=self.loader.create_computation_graph_for_poses(),
             )

--- a/tests/test_scene_optimizer.py
+++ b/tests/test_scene_optimizer.py
@@ -44,7 +44,10 @@ class TestSceneOptimizer(unittest.TestCase):
                 image_graph=self.loader.create_computation_graph_for_images(),
                 camera_intrinsics_graph=self.loader.create_computation_graph_for_intrinsics(),
                 image_shape_graph=self.loader.create_computation_graph_for_image_shapes(),
+                absolute_pose_priors=self.loader.create_computation_graph_for_absolute_pose_priors(),
+                relative_pose_priors=self.loader.create_computation_graph_for_relative_pose_priors(),
                 gt_cameras_graph=self.loader.create_computation_graph_for_cameras(),
+                gt_poses_graph=self.loader.create_computation_graph_for_poses(),
             )
             # create dask client
             cluster = LocalCluster(n_workers=1, threads_per_worker=4)

--- a/tests/test_two_view_estimator.py
+++ b/tests/test_two_view_estimator.py
@@ -52,10 +52,12 @@ class TestTwoViewEstimator(unittest.TestCase):
             keypoints_i1=Keypoints(normalized_coordinates_i1),
             keypoints_i2=Keypoints(normalized_coordinates_i2),
             verified_corr_idxs=np.hstack([np.arange(normalized_coordinates_i1.shape[0]).reshape(-1, 1)] * 2),
+            putative_corr_idxs=np.hstack([np.arange(normalized_coordinates_i1.shape[0]).reshape(-1, 1)] * 2),
             camera_intrinsics_i1=Cal3Bundler(),
             camera_intrinsics_i2=Cal3Bundler(),
             i2Ri1_initial=i2Ei1.rotation(),
             i2Ui1_initial=i2Ei1.direction(),
+            i2Ti1_prior=None,
         )
 
         # Assert

--- a/tests/utils/test_graph_utils.py
+++ b/tests/utils/test_graph_utils.py
@@ -48,6 +48,8 @@ class TestGraphUtils(unittest.TestCase):
             (6, 7): generate_random_essential_matrix(),
         }
 
+        relative_pose_priors = {pair_indices: None for pair_indices in input_essential_matrices.keys()}
+
         # generate Rot3 and Unit3 inputs
         input_relative_rotations = dict()
         input_relative_unit_translations = dict()
@@ -62,7 +64,9 @@ class TestGraphUtils(unittest.TestCase):
         (
             computed_relative_rotations,
             computed_relative_unit_translations,
-        ) = graph_utils.prune_to_largest_connected_component(input_relative_rotations, input_relative_unit_translations)
+        ) = graph_utils.prune_to_largest_connected_component(
+            input_relative_rotations, input_relative_unit_translations, pose_priors=relative_pose_priors
+        )
 
         # check the graph util function called with the edges defined by tracks
         graph_largest_cc_mock.assert_called_once_with([(0, 1), (3, 1), (3, 2), (4, 6), (6, 7)])
@@ -130,8 +134,8 @@ class TestGraphUtils(unittest.TestCase):
         triplets = graph_utils.extract_cyclic_triplets_from_edges(edges)
         assert isinstance(triplets, list)
         assert len(triplets) == 2
-        assert triplets[0] == (1, 2, 3)
-        assert triplets[1] == (1, 3, 5)
+        self.assertIn((1, 2, 3), triplets)
+        self.assertIn((1, 3, 5), triplets)
 
     def test_extract_triplets_3(self) -> None:
         """Ensure triplets are recovered accurately via intersection of adjacency lists.


### PR DESCRIPTION
Main changes:
1. Plumbing absolute and relative pose priors to all the plates. Note that we decided on not using absolute priors for now, but I am plumbing them just in case we need to use them
2. Supporting Cal3Fisheye calibration in the pipeline
3. Making view graph estimator optional
4. Making dense reconstruction optional
5. Other miscellaneous changes