### PR TITLE
Detect when using new version of TranslationRecovery

### DIFF
--- a/gtsfm/averaging/translation/averaging_1dsfm.py
+++ b/gtsfm/averaging/translation/averaging_1dsfm.py
@@ -184,7 +184,12 @@ class TranslationAveraging1DSFM(TranslationAveragingBase):
                 w_i2Ui1_inlier_measurements.append(w_i2Ui1)
 
         # Run the optimizer
-        wti_values = TranslationRecovery(w_i2Ui1_inlier_measurements).run(scale_factor)
+        try:
+            wti_values = TranslationRecovery(w_i2Ui1_inlier_measurements).run(scale_factor)
+        except TypeError:
+            params = gtsam.LevenbergMarquardtParams()
+            recovery = TranslationRecovery(params)
+            wti_values = recovery.run(w_i2Ui1_inlier_measurements, scale_factor)
 
         # transforming the result to the list of Point3
         wti_list: List[Optional[Point3]] = [None] * num_images


### PR DESCRIPTION
When compiling GTSAM from source, the current develop has a different interface from before. This quick hack detects when that is the case and calls the translation recovery module with the right arguments.