### PR TITLE
Fixing stack of delayed calls inside two-view-estimator

### DIFF
--- a/gtsfm/runner/frontend_runner.py
+++ b/gtsfm/runner/frontend_runner.py
@@ -62,9 +62,6 @@ def run_frontend(
             camera_intrinsics_i2=camera_intrinsics[i2],
             im_shape_i1=image_shapes[i1],
             im_shape_i2=image_shapes[i2],
-            i2Ti1_prior=dask.delayed(None),
-            gt_wTi1_graph=dask.delayed(None),
-            gt_wTi2_graph=dask.delayed(None),
         )
         i2Ri1_graph_dict[(i1, i2)] = i2Ri1
         i2Ui1_graph_dict[(i1, i2)] = i2Ui1

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -217,8 +217,8 @@ class SceneOptimizer:
             i2Ri1_graph_dict[(i1, i2)] = i2Ri1
             i2Ui1_graph_dict[(i1, i2)] = i2Ui1
             v_corr_idxs_graph_dict[(i1, i2)] = v_corr_idxs
-            for token, report in two_view_reports.items():
-                two_view_reports_dict[token][(i1, i2)] = report
+            for token in (PRE_BA_REPORT_TAG, POST_BA_REPORT_TAG, POST_ISP_REPORT_TAG):
+                two_view_reports_dict[token][(i1, i2)] = two_view_reports[token]
 
             # Visualize verified two-view correspondences.
             if self._save_two_view_correspondences_viz:

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -374,9 +374,9 @@ class TwoViewEstimator:
         camera_intrinsics_i2: Optional[gtsfm_types.CALIBRATION_TYPE],
         im_shape_i1: Tuple[int, int],
         im_shape_i2: Tuple[int, int],
-        i2Ti1_prior: Optional[PosePrior],
-        gt_wTi1: Optional[Pose3],
-        gt_wTi2: Optional[Pose3],
+        i2Ti1_prior: Optional[PosePrior] = None,
+        gt_wTi1: Optional[Pose3] = None,
+        gt_wTi2: Optional[Pose3] = None,
         gt_scene_mesh_graph: Optional[Delayed] = None,
     ) -> Tuple[Delayed, Delayed, Delayed, Delayed]:
         """Create delayed tasks for matching and verification.

--- a/tests/test_two_view_estimator.py
+++ b/tests/test_two_view_estimator.py
@@ -70,7 +70,6 @@ class TestTwoViewEstimator(unittest.TestCase):
             keypoints_i1=self.keypoints_i1,
             keypoints_i2=self.keypoints_i2,
             verified_corr_idxs=self.corr_idxs,
-            putative_corr_idxs=self.corr_idxs,
             camera_intrinsics_i1=Cal3Bundler(),
             camera_intrinsics_i2=Cal3Bundler(),
             i2Ri1_initial=i2Ei1.rotation(),


### PR DESCRIPTION
Replacing 10 `dask.delayed` task creations (and many more `getitem` tasks due to `nout` > 1 ) with a single `dask.delayed` use and 4 `getitem` calls. 

Anecdotally, my waiting time in building the dask graph for 100 rig indices (500 images) has dropped from ~10mins to 2.5 mins.