### PR TITLE
Improvements, no MFAS

### DIFF
--- a/gtsfm/averaging/rotation/rotation_averaging_base.py
+++ b/gtsfm/averaging/rotation/rotation_averaging_base.py
@@ -24,7 +24,7 @@ class RotationAveragingBase(metaclass=abc.ABCMeta):
 
     # ignored-abstractmethod
     @abc.abstractmethod
-    def run(
+    def run_rotation_averaging(
         self,
         num_images: int,
         i2Ri1_dict: Dict[Tuple[int, int], Optional[Rot3]],
@@ -86,7 +86,7 @@ class RotationAveragingBase(metaclass=abc.ABCMeta):
             global rotations wrapped using dask.delayed.
         """
 
-        wRis = dask.delayed(self.run)(num_images, i2Ri1_graph, i2Ti1_priors)
+        wRis = dask.delayed(self.run_rotation_averaging)(num_images, i2Ri1_graph, i2Ti1_priors)
         metrics = dask.delayed(self.evaluate)(wRis, gt_wTi_list)
 
         return wRis, metrics

--- a/gtsfm/averaging/rotation/shonan.py
+++ b/gtsfm/averaging/rotation/shonan.py
@@ -100,13 +100,13 @@ class ShonanRotationAveraging(RotationAveragingBase):
                 not be computed (either underconstrained system or ill-constrained system).
         """
 
-        logger.info(f"Running Shonan with {len(between_factors)} constraints on {num_connected_nodes} nodes")
+        logger.info(f"[Shonan] Running Shonan with {len(between_factors)} constraints on {num_connected_nodes} nodes")
         shonan = ShonanAveraging3(between_factors, self.__get_shonan_params())
 
         initial = shonan.initializeRandomly()
-        logger.info(f"Initial cost: {shonan.cost(initial)}")
+        logger.info(f"[Shonan] Initial cost: {shonan.cost(initial)}")
         result, _ = shonan.run(initial, self._p_min, self._p_max)
-        logger.info(f"Final cost: {shonan.cost(result)}")
+        logger.info(f"[Shonan] Final cost: {shonan.cost(result)}")
 
         wRi_list_consecutive = [None] * num_connected_nodes
         for i in range(num_connected_nodes):

--- a/gtsfm/averaging/rotation/shonan.py
+++ b/gtsfm/averaging/rotation/shonan.py
@@ -100,15 +100,18 @@ class ShonanRotationAveraging(RotationAveragingBase):
                 not be computed (either underconstrained system or ill-constrained system).
         """
 
-        obj = ShonanAveraging3(between_factors, self.__get_shonan_params())
+        logger.info(f"Running Shonan with {len(between_factors)} constraints on {num_connected_nodes} nodes")
+        shonan = ShonanAveraging3(between_factors, self.__get_shonan_params())
 
-        initial = obj.initializeRandomly()
-        result_values, _ = obj.run(initial, self._p_min, self._p_max)
+        initial = shonan.initializeRandomly()
+        logger.info(f"Initial cost: {shonan.cost(initial)}")
+        result, _ = shonan.run(initial, self._p_min, self._p_max)
+        logger.info(f"Final cost: {shonan.cost(result)}")
 
         wRi_list_consecutive = [None] * num_connected_nodes
         for i in range(num_connected_nodes):
-            if result_values.exists(i):
-                wRi_list_consecutive[i] = result_values.atRot3(i)
+            if result.exists(i):
+                wRi_list_consecutive[i] = result.atRot3(i)
 
         return wRi_list_consecutive
 
@@ -124,7 +127,7 @@ class ShonanRotationAveraging(RotationAveragingBase):
 
         return unique_nodes_with_edges
 
-    def run(
+    def run_rotation_averaging(
         self,
         num_images: int,
         i2Ri1_dict: Dict[Tuple[int, int], Optional[Rot3]],
@@ -132,7 +135,7 @@ class ShonanRotationAveraging(RotationAveragingBase):
     ) -> List[Optional[Rot3]]:
         """Run the rotation averaging on a connected graph with arbitrary keys, where each key is a image/pose index.
 
-        Note: run() functions as a wrapper that re-orders keys to prepare a graph w/ N keys ordered [0,...,N-1].
+        Note: functions as a wrapper that re-orders keys to prepare a graph w/ N keys ordered [0,...,N-1].
         All input nodes must belong to a single connected component, in order to obtain an absolute pose for each
         camera in a single, global coordinate frame.
 
@@ -145,7 +148,7 @@ class ShonanRotationAveraging(RotationAveragingBase):
             Global rotations for each camera pose, i.e. wRi, as a list. The number of entries in the list is
                 `num_images`. The list may contain `None` where the global rotation could not be computed (either
                 underconstrained system or ill-constrained system), or where the camera pose had no valid observation
-                in the input to run().
+                in the input to run_rotation_averaging().
         """
         if len(i2Ri1_dict) == 0:
             logger.warning("Shonan cannot proceed: No cycle-consistent triplets found after filtering.")

--- a/gtsfm/averaging/translation/averaging_1dsfm.py
+++ b/gtsfm/averaging/translation/averaging_1dsfm.py
@@ -70,7 +70,7 @@ class TranslationAveraging1DSFM(TranslationAveragingBase):
         self,
         robust_measurement_noise: bool = True,
         projection_sampling_method: ProjectionSamplingMethod = ProjectionSamplingMethod.SAMPLE_WITH_UNIFORM_DENSITY,
-        MFAS_outlier_rejection=True,
+        MFAS_outlier_rejection: bool = True,
     ) -> None:
         """Initializes the 1DSFM averaging instance.
 

--- a/gtsfm/averaging/translation/rig_1dsfm.py
+++ b/gtsfm/averaging/translation/rig_1dsfm.py
@@ -90,5 +90,5 @@ class RigTranslationAveraging1DSFM(TranslationAveraging1DSFM):
                             noise_model,
                         )
                     )
-        logger.info("Added {} priors in rig translation averaging".format(len(w_i2ti1_priors)))
+        logger.info("[1dfsm] Added {} priors in rig translation averaging".format(len(w_i2ti1_priors)))
         return w_i2ti1_priors

--- a/gtsfm/averaging/translation/translation_averaging_base.py
+++ b/gtsfm/averaging/translation/translation_averaging_base.py
@@ -29,7 +29,7 @@ class TranslationAveragingBase(metaclass=abc.ABCMeta):
 
     # ignored-abstractmethod
     @abc.abstractmethod
-    def run(
+    def run_translation_averaging(
         self,
         num_images: int,
         i2Ui1_dict: Dict[Tuple[int, int], Optional[Unit3]],
@@ -81,6 +81,6 @@ class TranslationAveragingBase(metaclass=abc.ABCMeta):
             Global unit translations wrapped as Delayed.
             A GtsfmMetricsGroup with translation averaging metrics wrapped as Delayed.
         """
-        return dask.delayed(self.run, nout=2)(
+        return dask.delayed(self.run_translation_averaging, nout=2)(
             num_images, i2Ui1_graph, wRi_graph, absolute_pose_priors, relative_pose_priors, scale_factor, gt_wTi_list
         )

--- a/gtsfm/bundle/bundle_adjustment.py
+++ b/gtsfm/bundle/bundle_adjustment.py
@@ -277,7 +277,7 @@ class BundleAdjustmentOptimizer:
 
         return sorted(list(cameras))
 
-    def run(
+    def run_ba(
         self,
         initial_data: GtsfmData,
         absolute_pose_priors: List[Optional[PosePrior]],
@@ -408,7 +408,7 @@ class BundleAdjustmentOptimizer:
             GtsfmData aligned to GT (if provided), wrapped up using dask.delayed
             Metrics group for BA results, wrapped up using dask.delayed
         """
-        optimized_sfm_data, filtered_sfm_data, _ = dask.delayed(self.run, nout=3)(
+        optimized_sfm_data, filtered_sfm_data, _ = dask.delayed(self.run_ba, nout=3)(
             sfm_data_graph, absolute_pose_priors, relative_pose_priors
         )
         metrics_graph = dask.delayed(self.evaluate)(optimized_sfm_data, filtered_sfm_data, cameras_gt)

--- a/gtsfm/bundle/bundle_adjustment.py
+++ b/gtsfm/bundle/bundle_adjustment.py
@@ -299,7 +299,7 @@ class BundleAdjustmentOptimizer:
                 threshold.
         """
         logger.info(
-            f"Input: {initial_data.number_tracks()} tracks on {len(initial_data.get_valid_camera_indices())} cameras\n"
+            f"[BA] Input: {initial_data.number_tracks()} tracks on {len(initial_data.get_valid_camera_indices())} cameras\n"
         )
         if initial_data.number_tracks() == 0 or len(initial_data.get_valid_camera_indices()) == 0:
             # no cameras or tracks to optimize, so bundle adjustment is not possible
@@ -323,14 +323,14 @@ class BundleAdjustmentOptimizer:
 
         # Error drops from ~2764.22 to ~0.046
         if verbose:
-            logger.info(f"initial error: {graph.error(initial_values):.2f}")
-            logger.info(f"final error: {final_error:.2f}")
+            logger.info(f"[BA] initial error: {graph.error(initial_values):.2f}")
+            logger.info(f"[BA] final error: {final_error:.2f}")
 
         # construct the results
         optimized_data = values_to_gtsfm_data(result_values, initial_data, self._shared_calib)
 
         if verbose:
-            logger.info("[Result] Number of tracks before filtering: %d", optimized_data.number_tracks())
+            logger.info("[BA] Number of tracks before filtering: %d", optimized_data.number_tracks())
 
         # filter the largest errors
         if self._output_reproj_error_thresh:
@@ -339,7 +339,7 @@ class BundleAdjustmentOptimizer:
             valid_mask = [True] * optimized_data.number_tracks()
             filtered_result = optimized_data
 
-        logger.info("[Result] Number of tracks after filtering: %d", filtered_result.number_tracks())
+        logger.info("[BA] Number of tracks after filtering: %d", filtered_result.number_tracks())
 
         return optimized_data, filtered_result, valid_mask
 
@@ -384,9 +384,9 @@ class BundleAdjustmentOptimizer:
         ba_metrics.add_metrics(metrics_utils.get_stats_for_sfmdata(aligned_filtered_data, suffix="_filtered"))
         # ba_metrics.save_to_json(os.path.join(METRICS_PATH, "bundle_adjustment_metrics.json"))
 
-        logger.info("[Result] Mean track length %.3f", np.mean(aligned_filtered_data.get_track_lengths()))
-        logger.info("[Result] Median track length %.3f", np.median(aligned_filtered_data.get_track_lengths()))
-        aligned_filtered_data.log_scene_reprojection_error_stats()
+        logger.info("[BA] Mean track length %.3f", np.mean(aligned_filtered_data.get_track_lengths()))
+        logger.info("[BA] Median track length %.3f", np.median(aligned_filtered_data.get_track_lengths()))
+        aligned_filtered_data.log_scene_reprojection_error_stats("BA")
 
         return ba_metrics
 

--- a/gtsfm/bundle/rig_bundle_adjustment.py
+++ b/gtsfm/bundle/rig_bundle_adjustment.py
@@ -64,7 +64,7 @@ class RigBundleAdjustmentOptimizer(BundleAdjustmentOptimizer):
                     X(i2), X(i1), i2Ti1_prior.value, gtsam.noiseModel.Diagonal.Sigmas(i2Ti1_prior.covariance)
                 )
 
-        logger.info("Added %d between factors for BA", len(between_factors))
+        logger.info("[BA] Added %d between factors for BA", len(between_factors))
 
         for factor in between_factors.values():
             graph.push_back(factor)

--- a/gtsfm/common/gtsfm_data.py
+++ b/gtsfm/common/gtsfm_data.py
@@ -355,20 +355,24 @@ class GtsfmData:
         scene_avg_reproj_error = np.nan if np.isnan(scene_reproj_errors).all() else np.nanmean(scene_reproj_errors)
         return scene_avg_reproj_error
 
-    def log_scene_reprojection_error_stats(self) -> None:
+    def log_scene_reprojection_error_stats(self, module: str = "") -> None:
         """Logs reprojection error stats for all 3d points in the entire scene."""
         scene_reproj_errors = self.get_scene_reprojection_errors()
         logger.info(
-            "Min scene reproj error: %.3f", np.nanmin(scene_reproj_errors) if len(scene_reproj_errors) else np.NaN
+            f"[{module}] Min scene reproj error: %.3f",
+            np.nanmin(scene_reproj_errors) if len(scene_reproj_errors) else np.NaN,
         )
         logger.info(
-            "Avg scene reproj error: %.3f", np.nanmean(scene_reproj_errors) if len(scene_reproj_errors) else np.NaN
+            f"[{module}] Avg scene reproj error: %.3f",
+            np.nanmean(scene_reproj_errors) if len(scene_reproj_errors) else np.NaN,
         )
         logger.info(
-            "Median scene reproj error: %.3f", np.nanmedian(scene_reproj_errors) if len(scene_reproj_errors) else np.NaN
+            f"[{module}] Median scene reproj error: %.3f",
+            np.nanmedian(scene_reproj_errors) if len(scene_reproj_errors) else np.NaN,
         )
         logger.info(
-            "Max scene reproj error: %.3f", np.nanmax(scene_reproj_errors) if len(scene_reproj_errors) else np.NaN
+            f"[{module}] Max scene reproj error: %.3f",
+            np.nanmax(scene_reproj_errors) if len(scene_reproj_errors) else np.NaN,
         )
 
     def __validate_track(self, track: SfmTrack, reproj_err_thresh: float) -> bool:

--- a/gtsfm/configs/deep_front_end_hilti.yaml
+++ b/gtsfm/configs/deep_front_end_hilti.yaml
@@ -52,6 +52,7 @@ SceneOptimizer:
       _target_: gtsfm.averaging.translation.rig_1dsfm.RigTranslationAveraging1DSFM
       robust_measurement_noise: True
       projection_sampling_method: SAMPLE_INPUT_MEASUREMENTS
+      MFAS_outlier_rejection: False
 
     data_association_module:
       _target_: gtsfm.data_association.data_assoc.DataAssociation

--- a/gtsfm/configs/sift_front_end.yaml
+++ b/gtsfm/configs/sift_front_end.yaml
@@ -39,9 +39,9 @@ SceneOptimizer:
     _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer
 
     # comment out to not run
-    view_graph_estimator:
-      _target_: gtsfm.view_graph_estimator.cycle_consistent_rotation_estimator.CycleConsistentRotationViewGraphEstimator
-      edge_error_aggregation_criterion: MEDIAN_EDGE_ERROR
+    # view_graph_estimator:
+    #   _target_: gtsfm.view_graph_estimator.cycle_consistent_rotation_estimator.CycleConsistentRotationViewGraphEstimator
+    #   edge_error_aggregation_criterion: MEDIAN_EDGE_ERROR
 
     rot_avg_module:
       _target_: gtsfm.averaging.rotation.shonan.ShonanRotationAveraging

--- a/gtsfm/data_association/data_assoc.py
+++ b/gtsfm/data_association/data_assoc.py
@@ -52,7 +52,7 @@ class DataAssociation(NamedTuple):
         """Validate the track by checking its length."""
         return sfm_track is not None and sfm_track.numberMeasurements() >= self.min_track_len
 
-    def run(
+    def run_da(
         self,
         num_images: int,
         cameras: Dict[int, gtsfm_types.CAMERA_TYPE],
@@ -210,7 +210,7 @@ class DataAssociation(NamedTuple):
             data_assoc_metrics_graph: dictionary with different statistics about the data
                 association result
         """
-        ba_input_graph, data_assoc_metrics_graph = dask.delayed(self.run, nout=2)(
+        ba_input_graph, data_assoc_metrics_graph = dask.delayed(self.run_da, nout=2)(
             num_images, cameras, corr_idxs_graph, keypoints_graph, cameras_gt, relative_pose_priors, images_graph
         )
 

--- a/gtsfm/data_association/point3d_initializer.py
+++ b/gtsfm/data_association/point3d_initializer.py
@@ -194,7 +194,7 @@ class Point3dInitializer:
             except RuntimeError:
                 # TODO: handle cheirality exception properly?
                 logger.debug(
-                    "Cheirality exception from GTSAM's triangulatePoint3() likely due to outlier, skipping track"
+                    "[initializer] Cheirality exception from GTSAM's triangulatePoint3() likely due to outlier, skipping track"
                 )
                 continue
 

--- a/gtsfm/frontend/cacher/two_view_cacher.py
+++ b/gtsfm/frontend/cacher/two_view_cacher.py
@@ -121,7 +121,7 @@ class TwoViewCacher(TwoViewEstimator):
         )
         io_utils.write_to_bz2_file(data, cache_path)
 
-    def run(
+    def run_2view(
         self,
         keypoints_i1: Keypoints,
         keypoints_i2: Keypoints,
@@ -149,7 +149,7 @@ class TwoViewCacher(TwoViewEstimator):
         if cached_data is not None:
             return cached_data[ROT_KEY], cached_data[DIRECTION_KEY], cached_data[CORR_IDXES_KEY]
 
-        i2Ri1, i2Ui1, v_corr_idxs = self._two_view_estimator.run(
+        i2Ri1, i2Ui1, v_corr_idxs = self._two_view_estimator.run_2view(
             keypoints_i1,
             keypoints_i2,
             descriptors_i1,

--- a/gtsfm/frontend/inlier_support_processor.py
+++ b/gtsfm/frontend/inlier_support_processor.py
@@ -37,7 +37,7 @@ class InlierSupportProcessor:
         self._min_num_inliers_est_model = min_num_inliers_est_model
         self._min_inlier_ratio_est_model = min_inlier_ratio_est_model
 
-    def run(
+    def run_inlier_support(
         self,
         i2Ri1: Optional[Rot3],
         i2Ui1: Optional[Unit3],
@@ -117,4 +117,6 @@ class InlierSupportProcessor:
                 May now be an empty array, if insufficient support.
             two_view_report_pp_graph: Post-processed two-view report (may now be None, if insufficient support).
         """
-        return dask.delayed(self.run, nout=4)(i2Ri1_graph, i2Ui1_graph, v_corr_idxs_graph, two_view_report_graph)
+        return dask.delayed(self.run_inlier_support, nout=4)(
+            i2Ri1_graph, i2Ui1_graph, v_corr_idxs_graph, two_view_report_graph
+        )

--- a/gtsfm/frontend/inlier_support_processor.py
+++ b/gtsfm/frontend/inlier_support_processor.py
@@ -71,7 +71,7 @@ class InlierSupportProcessor:
         # no need to extract the relative pose if we have insufficient inliers.
         if two_view_report.inlier_ratio_est_model < self._min_inlier_ratio_est_model:
             logger.debug(
-                "Insufficient inlier ratio. %d vs. %d",
+                "[inlier_support] Insufficient inlier ratio. %d vs. %d",
                 two_view_report.inlier_ratio_est_model,
                 self._min_inlier_ratio_est_model,
             )
@@ -83,7 +83,7 @@ class InlierSupportProcessor:
 
         if valid_model and insufficient_inliers:
             logger.debug(
-                "Insufficient number of inliers. %d vs. %d",
+                "[inlier_support] Insufficient number of inliers. %d vs. %d",
                 two_view_report.num_inliers_est_model,
                 self._min_num_inliers_est_model,
             )

--- a/gtsfm/loader/hilti_loader.py
+++ b/gtsfm/loader/hilti_loader.py
@@ -62,12 +62,12 @@ class HiltiLoader(LoaderBase):
         """Initializes, loads calibration, constraints, and pose priors.
 
         Args:
-            base_folder (str): top-level folder, expects calibration, images and lidar subfolders.
-            max_length (Optional[int]): limit poses to read. Defaults to None.
+            base_folder: top-level folder, expects calibration, images and lidar subfolders.
+            max_length: limit poses to read. Defaults to None.
             max_resolution: integer representing maximum length of image's short side
                e.g. for 1080p (1920 x 1080), max_resolution would be 1080
-            subsample (Optional[int]): subsample along the time axis (except cam2), default 1 (none).
-            old_style (Optional[bool]): Use old-style sequential image numbering.
+            subsample: subsample along the time axis (except cam2), default 1 (none).
+            old_style: Use old-style sequential image numbering.
         """
         super().__init__(max_resolution)
         self._base_folder: Path = Path(base_folder)

--- a/gtsfm/retriever/rig_retriever.py
+++ b/gtsfm/retriever/rig_retriever.py
@@ -51,7 +51,9 @@ class RigRetriever(RetrieverBase):
         constraints: List[Constraint] = loader.get_all_constraints()
 
         # Get pairs from those constraints.
-        unique_pairs = set(sum([c.predicted_pairs(self._threshold) for c in constraints if self.__accept_constraint(c)], []))
+        unique_pairs = set(
+            sum([c.predicted_pairs(self._threshold) for c in constraints if self.__accept_constraint(c)], [])
+        )
 
         num_cam2_pairs = list(filter(lambda edge: edge[0] % 5 == 2 or edge[1] % 5 == 2, unique_pairs))
 

--- a/gtsfm/retriever/rig_retriever.py
+++ b/gtsfm/retriever/rig_retriever.py
@@ -5,7 +5,7 @@ Author: Frank Dellaert
 
 from typing import List, Tuple
 
-from gtsfm.loader.hilti_loader import HiltiLoader, SUBSAMPLE_FACTOR
+from gtsfm.loader.hilti_loader import HiltiLoader
 
 import gtsfm.utils.logger as logger_utils
 from gtsfm.common.constraint import Constraint
@@ -35,7 +35,7 @@ class RigRetriever(RetrieverBase):
         if not self._subsample:
             return True
 
-        return constraint.a % SUBSAMPLE_FACTOR == 0 and constraint.b % SUBSAMPLE_FACTOR == 0
+        return constraint.a % self._subsample == 0 and constraint.b % self._subsample == 0
 
     def run(self, loader: LoaderBase) -> List[Tuple[int, int]]:
         """Compute potential image pairs.
@@ -59,7 +59,7 @@ class RigRetriever(RetrieverBase):
         logger.info("Found %d pairs with cam2 from the constraints file", len(num_cam2_pairs))
 
         # Add all intra-rig pairs even if no LIDAR signal.
-        for rig_index in range(0, loader.num_rig_poses, SUBSAMPLE_FACTOR if self._subsample else 1):
+        for rig_index in range(0, loader.num_rig_poses, self._subsample if self._subsample else 1):
             for c1, c2 in INTRA_RIG_VALID_PAIRS:
                 pairs.add(
                     (loader.image_from_rig_and_camera(rig_index, c1), loader.image_from_rig_and_camera(rig_index, c2))

--- a/gtsfm/retriever/rig_retriever.py
+++ b/gtsfm/retriever/rig_retriever.py
@@ -51,27 +51,27 @@ class RigRetriever(RetrieverBase):
         constraints: List[Constraint] = loader.get_all_constraints()
 
         # Get pairs from those constraints.
-        pairs = set(sum([c.predicted_pairs(self._threshold) for c in constraints if self.__accept_constraint(c)], []))
+        unique_pairs = set(sum([c.predicted_pairs(self._threshold) for c in constraints if self.__accept_constraint(c)], []))
 
-        num_cam2_pairs = list(filter(lambda edge: edge[0] % 5 == 2 or edge[1] % 5 == 2, pairs))
+        num_cam2_pairs = list(filter(lambda edge: edge[0] % 5 == 2 or edge[1] % 5 == 2, unique_pairs))
 
-        logger.info("Found %d pairs from the constraints file", len(pairs))
-        logger.info("Found %d pairs with cam2 from the constraints file", len(num_cam2_pairs))
+        logger.info(f"Found {len(unique_pairs)} pairs in the constraints file")
+        logger.info(f"Found {len(num_cam2_pairs)} pairs with cam2 in the constraints file")
 
         # Add all intra-rig pairs even if no LIDAR signal.
         for rig_index in range(0, loader.num_rig_poses, self._subsample if self._subsample else 1):
             for c1, c2 in INTRA_RIG_VALID_PAIRS:
-                pairs.add(
+                unique_pairs.add(
                     (loader.image_from_rig_and_camera(rig_index, c1), loader.image_from_rig_and_camera(rig_index, c2))
                 )
         # Add all inter frames CAM2 pairs
         for rig_index in range(0, loader.num_rig_poses, 1):
             for next_rig_idx in range(rig_index + 1, min(rig_index + 1 + CAM2_FRAME_LOOKAHEAD, loader.num_rig_poses)):
-                pairs.add(
+                unique_pairs.add(
                     (loader.image_from_rig_and_camera(rig_index, 2), loader.image_from_rig_and_camera(next_rig_idx, 2))
                 )
 
-        pairs = list(pairs)
+        pairs = list(unique_pairs)
         pairs.sort()
 
         # check on pairs
@@ -79,5 +79,5 @@ class RigRetriever(RetrieverBase):
             if i1 > i2:
                 raise ValueError("Ordering not imposed on i1, i2")
 
-        logger.info("Found %d pairs from the RigRetriever", len(pairs))
+        logger.info(f"RigRetriever finally created {len(pairs)} pairs.")
         return pairs

--- a/gtsfm/runner/run_scene_optimizer_hilti.py
+++ b/gtsfm/runner/run_scene_optimizer_hilti.py
@@ -34,8 +34,12 @@ class GtsfmRunnerHiltiLoader(GtsfmRunnerBase):
 
         parser.add_argument("--max_length", type=int, default=None, help="Max number of timestamps to process")
         parser.add_argument(
-            "--subsample", action="store_true", help="Subsample the timestamps by 5 (pick every 5th rig for visual SfM"
+            "--subsample",
+            type=int,
+            default=1,
+            help="Subsample the timestamps by given value n (pick every nth rig for visual SfM)",
         )
+        parser.add_argument("--old_style", action="store_true", help="Use sequentially numbered images")
 
         return parser
 
@@ -43,7 +47,8 @@ class GtsfmRunnerHiltiLoader(GtsfmRunnerBase):
         loader = HiltiLoader(
             base_folder=self.parsed_args.dataset_dirpath,
             max_length=self.parsed_args.max_length,
-            subsample=self.parsed_args.subsample is True,
+            subsample=self.parsed_args.subsample,
+            old_style=self.parsed_args.old_style,
         )
 
         return loader

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -207,7 +207,7 @@ class TwoViewEstimator:
         if i2Ti1_prior is not None:
             relative_pose_prior_for_ba = {(0, 1): i2Ti1_prior}
 
-        _, ba_output, valid_mask = self._ba_optimizer.run(
+        _, ba_output, valid_mask = self._ba_optimizer.run_ba(
             ba_input, absolute_pose_priors=[], relative_pose_priors=relative_pose_prior_for_ba, verbose=False
         )
         valid_corr_idxs = verified_corr_idxs[triangulated_indices][valid_mask]

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -297,14 +297,14 @@ class TwoViewEstimator:
             gt_wTi2,
             gt_scene_mesh,
         )
-        pre_ba_report = generate_two_view_report(
-            inlier_ratio_wrt_estimate,
-            verified_corr_idxs,
-            R_error_deg=pre_ba_R_error_deg,
-            U_error_deg=pre_ba_U_error_deg,
-            v_corr_idxs_inlier_mask_gt=pre_ba_inlier_mask_wrt_gt,
-            reproj_error_gt_model=pre_ba_reproj_error_wrt_gt,
-        )
+        # pre_ba_report = generate_two_view_report(
+        #     inlier_ratio_wrt_estimate,
+        #     verified_corr_idxs,
+        #     R_error_deg=pre_ba_R_error_deg,
+        #     U_error_deg=pre_ba_U_error_deg,
+        #     v_corr_idxs_inlier_mask_gt=pre_ba_inlier_mask_wrt_gt,
+        #     reproj_error_gt_model=pre_ba_reproj_error_wrt_gt,
+        # )
 
         # Optionally, do two-view bundle adjustment
         if self._bundle_adjust_2view:

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -189,8 +189,8 @@ class TwoViewEstimator:
             keypoints_i2=keypoints_i2,
             corr_idxs=verified_corr_idxs,
         )
-        logger.debug("Performed DA in %.6f seconds.", timeit.default_timer() - start_time)
-        logger.debug("Triangulated %d correspondences out of %d.", len(triangulated_tracks), len(verified_corr_idxs))
+        logger.debug("[Two view optimizer] Performed DA in %.6f seconds.", timeit.default_timer() - start_time)
+        logger.debug("[Two view optimizer] Triangulated %d correspondences out of %d.", len(triangulated_tracks), len(verified_corr_idxs))
 
         if len(triangulated_tracks) == 0:
             return i2Ti1_initial.rotation(), Unit3(i2Ti1_initial.translation()), np.array([], dtype=np.uint32)
@@ -216,7 +216,7 @@ class TwoViewEstimator:
             logger.warning("2-view BA failed")
             return i2Ri1_initial, i2Ui1_initial, valid_corr_idxs
         i2Ti1_optimized = wTi2.between(wTi1)
-        logger.debug("Performed 2-view BA in %.6f seconds.", timeit.default_timer() - start_time)
+        logger.debug("[Two view optimizer] Performed 2-view BA in %.6f seconds.", timeit.default_timer() - start_time)
 
         return i2Ti1_optimized.rotation(), Unit3(i2Ti1_optimized.translation()), valid_corr_idxs
 

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -248,7 +248,7 @@ class TwoViewEstimator:
         """Getter for the distance threshold used in the metric for correct correspondences."""
         return self._corr_metric_dist_threshold
 
-    def run(
+    def run_2view(
         self,
         keypoints_i1: Keypoints,
         keypoints_i2: Keypoints,
@@ -354,7 +354,7 @@ class TwoViewEstimator:
             post_isp_i2Ui1,
             post_isp_v_corr_idxs,
             _,
-        ) = self.processor.run(post_ba_i2Ri1, post_ba_i2Ui1, post_ba_v_corr_idxs, post_ba_report)
+        ) = self.processor.run_inlier_support(post_ba_i2Ri1, post_ba_i2Ui1, post_ba_v_corr_idxs, post_ba_report)
 
         return post_isp_i2Ri1, post_isp_i2Ui1, post_isp_v_corr_idxs
 
@@ -392,7 +392,7 @@ class TwoViewEstimator:
             Computed relative translation direction wrapped as Delayed.
             Indices of verified correspondences wrapped as Delayed.
         """
-        return dask.delayed(self.run, nout=3)(
+        return dask.delayed(self.run_2view, nout=3)(
             keypoints_i1=keypoints_i1_graph,
             keypoints_i2=keypoints_i2_graph,
             descriptors_i1=descriptors_i1_graph,

--- a/gtsfm/utils/metrics.py
+++ b/gtsfm/utils/metrics.py
@@ -207,7 +207,7 @@ def compute_keypoint_intersections(
     start_time = timeit.default_timer()
     intersections, keypoint_ind, _ = gt_scene_mesh.ray.intersects_location(src, drc, multiple_hits=False)
     if verbose:
-        logger.debug("Case %d rays in %.6f seconds.", num_kpts, timeit.default_timer() - start_time)
+        logger.debug("[metrics] Case %d rays in %.6f seconds.", num_kpts, timeit.default_timer() - start_time)
 
     return keypoint_ind, intersections
 

--- a/gtsfm/utils/reprojection.py
+++ b/gtsfm/utils/reprojection.py
@@ -21,7 +21,7 @@ def compute_track_reprojection_errors(
 
     Returns:
         reprojection errors for each measurement (measured in pixels).
-        avg_track_reproj_error: average reprojection error of all meausurements in track.
+        average_reprojection_error: average reprojection error of all meausurements in track.
     """
     errors = []
     for k in range(track.numberMeasurements()):
@@ -41,44 +41,34 @@ def compute_track_reprojection_errors(
             errors.append(np.nan)
 
     errors = np.array(errors)
-    avg_track_reproj_error = np.nan if np.isnan(errors).all() else np.nanmean(errors)
-    return errors, avg_track_reproj_error
+    average_reprojection_error = np.nan if np.isnan(errors).all() else np.nanmean(errors)
+    return errors, average_reprojection_error
 
 
 def compute_point_reprojection_errors(
-    track_camera_dict: Dict[int, PinholeCameraCal3Bundler], point3d: np.ndarray, measurements: List[SfmMeasurement]
+    cameras: Dict[int, PinholeCameraCal3Bundler], point3d: np.ndarray, measurements: List[SfmMeasurement]
 ) -> Tuple[np.ndarray, float]:
     """Compute reprojection errors for a hypothesized 3d point vs. 2d measurements.
 
     Args:
-        track_camera_dict: Dict of cameras, with camera indices as keys.
+        cameras: Dict of cameras, with camera indices as keys.
         point3d: hypothesized 3d point/landmark
         measurements: corresponding 2d measurements (of 3d point above) in various cameras
 
     Returns:
         reprojection errors for each measurement (measured in pixels).
-        avg_track_reproj_error: average reprojection error of all meausurements in track.
+        average_reprojection_error: average reprojection error of all measurements in track.
     """
-    errors = []
-    for (i, uv_measured) in measurements:
-
-        if i not in track_camera_dict:
-            # camera pose was not successfully estimated, PinholeCameraCal3Bundler was uninitialized
-            errors.append(np.nan)
-            continue
-
-        # get the camera associated with the measurement
-        camera = track_camera_dict[i]
-        # Project to camera
-        uv_reprojected, success_flag = camera.projectSafe(point3d)
-        # Projection error in camera
-        if success_flag:
-            errors.append(np.linalg.norm(uv_measured - uv_reprojected))
-        else:
-            # failure in projection
-            errors.append(np.nan)
-
-    errors = np.array(errors)
-    avg_track_reproj_error = np.nan if np.isnan(errors).all() else np.nanmean(errors)
-    return errors, avg_track_reproj_error
-
+    nan = np.array([np.nan, np.nan])
+    safe_projections = [
+        cameras[i].projectSafe(point3d) if i in cameras else (nan, False) for i, uv_measured in measurements
+    ]
+    valid_projections = np.array(
+        [
+            uv_projected - uv_measured
+            for (uv_projected, success), (i, uv_measured) in zip(safe_projections, measurements)
+        ]
+    )
+    errors = np.linalg.norm(valid_projections, axis=1)
+    average_reprojection_error = np.nan if np.isnan(errors).all() else np.nanmean(errors)
+    return errors, average_reprojection_error

--- a/gtsfm/visualization/view_scene.py
+++ b/gtsfm/visualization/view_scene.py
@@ -57,8 +57,12 @@ def view_scene(args: argparse.Namespace) -> None:
 
     if len(calibrations) == 1:
         calibrations = calibrations * len(img_fnames)
-    mean_pt = compute_point_cloud_center_robust(point_cloud)
 
+    if False:
+        mean_pt = compute_point_cloud_center_robust(point_cloud)
+    else:
+        mean_pt = compute_point_cloud_center_robust(np.array([T.translation() for T in wTi_list]))
+    
     # Zero-center the point cloud (about estimated center).
     zcwTw = Pose3(Rot3(np.eye(3)), -mean_pt)
     # expression below is equivalent to applying zcwTw.transformFrom() to each world point

--- a/gtsfm/visualization/view_scene.py
+++ b/gtsfm/visualization/view_scene.py
@@ -54,15 +54,14 @@ def view_scene(args: argparse.Namespace) -> None:
     if args.show_mvs_result:
         point_cloud, rgb = io_utils.read_point_cloud_from_ply(args.ply_fpath)
 
-
     if len(calibrations) == 1:
         calibrations = calibrations * len(img_fnames)
 
-    if False:
-        mean_pt = compute_point_cloud_center_robust(point_cloud)
-    else:
+    if args.center_trajectory:
         mean_pt = compute_point_cloud_center_robust(np.array([T.translation() for T in wTi_list]))
-    
+    else:
+        mean_pt = compute_point_cloud_center_robust(point_cloud)
+
     # Zero-center the point cloud (about estimated center).
     zcwTw = Pose3(Rot3(np.eye(3)), -mean_pt)
     # expression below is equivalent to applying zcwTw.transformFrom() to each world point
@@ -115,7 +114,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--show_mvs_result",
         action="store_true",
-        help="defaults to false.",
+        help="Show MVS result, defaults to false.",
+    )
+    parser.add_argument(
+        "--center_trajectory",
+        action="store_true",
+        help="Center point cloud on trajectory, defaults to false.",
     )
     parser.add_argument(
         "--ply_fpath",

--- a/tests/averaging/rotation/test_shonan.py
+++ b/tests/averaging/rotation/test_shonan.py
@@ -37,7 +37,7 @@ class TestShonanRotationAveraging(unittest.TestCase):
             wRi_expected: expected global rotations.
         """
         i2Ri1_priors = {edge: None for edge in i2Ri1_input.keys()}
-        wRi_computed = self.obj.run(len(wRi_expected), i2Ri1_input, i2Ri1_priors)
+        wRi_computed = self.obj.run_rotation_averaging(len(wRi_expected), i2Ri1_input, i2Ri1_priors)
         self.assertTrue(
             geometry_comparisons.compare_rotations(wRi_computed, wRi_expected, ROTATION_ANGLE_ERROR_THRESHOLD_DEG)
         )
@@ -100,7 +100,7 @@ class TestShonanRotationAveraging(unittest.TestCase):
 
         # use the GTSAM API directly (without dask) for rotation averaging
         i2Ri1_priors = {edge: None for edge in i2Ri1_dict.keys()}
-        expected_wRi_list = self.obj.run(num_poses, i2Ri1_dict, i2Ri1_priors)
+        expected_wRi_list = self.obj.run_rotation_averaging(num_poses, i2Ri1_dict, i2Ri1_priors)
 
         # use dask's computation graph
         gt_wTi_list = [None] * len(expected_wRi_list)
@@ -147,7 +147,7 @@ class TestShonanRotationAveraging(unittest.TestCase):
         }
 
         i2Ri1_priors = {edge: None for edge in i2Ri1_input.keys()}
-        wRi_computed = self.obj.run(num_images, i2Ri1_input, i2Ri1_priors)
+        wRi_computed = self.obj.run_rotation_averaging(num_images, i2Ri1_input, i2Ri1_priors)
         wRi_expected = [None, wTi1.rotation(), wTi2.rotation(), wTi3.rotation()]
         self.assertTrue(
             geometry_comparisons.compare_rotations(wRi_computed, wRi_expected, angular_error_threshold_degrees=0.1)

--- a/tests/bundle/test_bundle_adjustment.py
+++ b/tests/bundle/test_bundle_adjustment.py
@@ -29,7 +29,7 @@ class TestBundleAdjustmentOptimizer(unittest.TestCase):
     # def test_simple_scene(self):
     #     """Test the simple scene using the `run` API."""
 
-    #     computed_result = self.ba.run(self.test_data)
+    #     computed_result = self.ba.run_ba(self.test_data)
 
     #     expected_error = 0.046137573704557046
 
@@ -42,7 +42,7 @@ class TestBundleAdjustmentOptimizer(unittest.TestCase):
         absolute_pose_priors = [None] * EXAMPLE_DATA.number_images()
         relative_pose_priors = {}
 
-        expected_result, _, _ = self.ba.run(
+        expected_result, _, _ = self.ba.run_ba(
             self.test_data, absolute_pose_priors=absolute_pose_priors, relative_pose_priors=relative_pose_priors
         )
 

--- a/tests/data_association/test_data_association.py
+++ b/tests/data_association/test_data_association.py
@@ -137,7 +137,7 @@ class TestDataAssociation(GtsamTestCase):
             reproj_error_threshold=5, mode=triangulation_mode, min_num_hypotheses=20
         )
         da = DataAssociation(min_track_len=3, triangulation_options=triangulation_options)
-        triangulated_landmark_map, _ = da.run(
+        triangulated_landmark_map, _ = da.run_da(
             len(cameras),
             cameras,
             matches_dict,
@@ -176,7 +176,7 @@ class TestDataAssociation(GtsamTestCase):
         triangulation_options = TriangulationOptions(reproj_error_threshold=5, mode=TriangulationSamplingMode.NO_RANSAC)
         da = DataAssociation(min_track_len=2, triangulation_options=triangulation_options)
 
-        sfm_data, _ = da.run(
+        sfm_data, _ = da.run_da(
             len(cameras), cameras, matches_dict, keypoints_list, [None] * len(cameras), relative_pose_priors={}
         )
         estimated_landmark = sfm_data.get_track(0).point3()
@@ -226,7 +226,7 @@ class TestDataAssociation(GtsamTestCase):
             reproj_error_threshold=5, mode=triangulation_mode, min_num_hypotheses=20
         )
         da = DataAssociation(min_track_len=3, triangulation_options=triangulation_options)
-        sfm_data, _ = da.run(
+        sfm_data, _ = da.run_da(
             len(cameras),
             cameras,
             matches_dict,
@@ -265,7 +265,7 @@ class TestDataAssociation(GtsamTestCase):
 
         # will lead to a cheirality exception because keypoints are identical in two cameras
         # no track will be formed, and thus connected component will be empty
-        sfm_data, _ = da.run(
+        sfm_data, _ = da.run_da(
             num_images=3,
             cameras=cameras,
             corr_idxs_dict=corr_idxs_dict,
@@ -298,7 +298,7 @@ class TestDataAssociation(GtsamTestCase):
             reproj_error_threshold=5, mode=TriangulationSamplingMode.RANSAC_TOPK_BASELINES, min_num_hypotheses=20
         )
         da = DataAssociation(min_track_len=3, triangulation_options=triangulation_options)
-        expected_sfm_data, expected_metrics = da.run(
+        expected_sfm_data, expected_metrics = da.run_da(
             len(cameras), cameras, corr_idxs_graph, keypoints_list, cameras_gt=cameras_gt, relative_pose_priors={}
         )
 

--- a/tests/loader/test_hilti_loader.py
+++ b/tests/loader/test_hilti_loader.py
@@ -21,6 +21,7 @@ class TestHiltiLoader(unittest.TestCase):
         self.loader = HiltiLoader(
             base_folder=str(TEST_DATASET_DIR_PATH),
             max_length=None,
+            old_style=True,
         )
 
     def test_length(self) -> None:
@@ -58,22 +59,19 @@ class TestHiltiLoader(unittest.TestCase):
         # starting frames have no camera movement
         t0_cam0_prior = self.loader.get_absolute_pose_prior(0)
         t1_cam0_prior = self.loader.get_absolute_pose_prior(5)
+        self.assertIsNotNone(t0_cam0_prior)
+        if t0_cam0_prior is not None and t1_cam0_prior is not None:
+            self.assertLessEqual(
+                comp_utils.compute_relative_rotation_angle(
+                    t0_cam0_prior.value.rotation(), t1_cam0_prior.value.rotation()
+                ),
+                2,
+            )
 
-        self.assertLessEqual(
-            comp_utils.compute_relative_rotation_angle(t0_cam0_prior.value.rotation(), t1_cam0_prior.value.rotation()),
-            2,
-        )
-
-        self.assertLessEqual(
-            np.linalg.norm(t0_cam0_prior.value.translation() - t1_cam0_prior.value.translation()), 0.01
-        )
-
-        # self.assertLessEqual(
-        #     comp_utils.compute_relative_unit_translation_angle(
-        #         Unit3(t0_cam0_prior.value.translation()), Unit3(t1_cam0_prior.value.translation())
-        #     ),
-        #     2,
-        # )
+            self.assertIsNotNone(t1_cam0_prior)
+            self.assertLessEqual(
+                np.linalg.norm(t0_cam0_prior.value.translation() - t1_cam0_prior.value.translation()), 0.01
+            )
 
     def test_number_of_relative_pose_priors(self) -> None:
         """Check that 3 relative constraints translate into many relative pose priors."""

--- a/tests/repro_tests/averaging/translation/test_1dsfm_reproducibility.py
+++ b/tests/repro_tests/averaging/translation/test_1dsfm_reproducibility.py
@@ -37,7 +37,7 @@ class Test1DSFMReproducibility(ReproducibilityTestBase, unittest.TestCase):
             self._global_rotations_input: List[Optional[Rot3]] = pickle.load(f)
 
     def run_once(self) -> List[Optional[Point3]]:
-        return self._1dsfm_obj.run(
+        return self._1dsfm_obj.run_translation_averaging(
             num_images=NUM_IMAGES_IN_INPUT,
             i2Ui1_dict=self._relative_unit_translations_input,
             wRi_list=self._global_rotations_input,

--- a/tests/utils/test_reprojection.py
+++ b/tests/utils/test_reprojection.py
@@ -1,88 +1,96 @@
 import numpy as np
-from gtsam import Cal3Bundler, Rot3, PinholeCameraCal3Bundler, Pose3, SfmTrack
+import unittest
 
-from gtsfm.common.sfm_track import SfmMeasurement
 import gtsfm.utils.reprojection as reproj_utils
+from gtsam import Cal3Bundler, PinholeCameraCal3Bundler, Pose3, Rot3, SfmTrack
+from gtsfm.common.sfm_track import SfmMeasurement
 
 
-def test_compute_track_reprojection_errors():
-    """Ensure that reprojection error is computed properly within a track.
+class TestReprojection(unittest.TestCase):
+    def test_compute_track_reprojection_errors(self):
+        """Ensure that reprojection error is computed properly within a track.
 
-    # For camera 0:
-    # [13] = [10,0,3]   [1,0,0 | 0]  [1]
-    # [24] = [0,10,4] * [0,1,0 | 0] *[2]
-    #  [1] = [0, 0,1]   [0,0,1 | 0]  [1]
-    #                                [1]
+        # For camera 0:
+        # [13] = [10,0,3]   [1,0,0 | 0]  [1]
+        # [24] = [0,10,4] * [0,1,0 | 0] *[2]
+        #  [1] = [0, 0,1]   [0,0,1 | 0]  [1]
+        #                                [1]
 
-    # For camera 1:
-    # [-7] = [10,0,3]   [1,0,0 |-2]  [1]
-    # [44] = [0,10,4] * [0,1,0 | 2] *[2]
-    #  [1] = [0, 0,1]   [0,0,1 | 0]  [1]
-    #                                [1]
-    """
-    wTi0 = Pose3(Rot3.RzRyRx(0, 0, 0), np.zeros((3, 1)))
-    wTi1 = Pose3(Rot3.RzRyRx(0, 0, 0), np.array([2, -2, 0]))
+        # For camera 1:
+        # [-7] = [10,0,3]   [1,0,0 |-2]  [1]
+        # [44] = [0,10,4] * [0,1,0 | 2] *[2]
+        #  [1] = [0, 0,1]   [0,0,1 | 0]  [1]
+        #                                [1]
+        """
+        wTi0 = Pose3(Rot3.RzRyRx(0, 0, 0), np.zeros((3, 1)))
+        wTi1 = Pose3(Rot3.RzRyRx(0, 0, 0), np.array([2, -2, 0]))
 
-    f = 10
-    k1 = 0
-    k2 = 0
-    u0 = 3
-    v0 = 4
+        f = 10
+        k1 = 0
+        k2 = 0
+        u0 = 3
+        v0 = 4
 
-    K0 = Cal3Bundler(f, k1, k2, u0, v0)
-    K1 = Cal3Bundler(f, k1, k2, u0, v0)
+        K0 = Cal3Bundler(f, k1, k2, u0, v0)
+        K1 = Cal3Bundler(f, k1, k2, u0, v0)
 
-    track_camera_dict = {0: PinholeCameraCal3Bundler(wTi0, K0), 1: PinholeCameraCal3Bundler(wTi1, K1)}
+        track_camera_dict = {0: PinholeCameraCal3Bundler(wTi0, K0), 1: PinholeCameraCal3Bundler(wTi1, K1)}
 
-    triangulated_pt = np.array([1, 2, 1])
-    track_3d = SfmTrack(triangulated_pt)
+        triangulated_pt = np.array([1, 2, 1])
+        track_3d = SfmTrack(triangulated_pt)
 
-    # in camera 0
-    track_3d.addMeasurement(idx=0, m=np.array([13, 24]))
-    # in camera 1
-    track_3d.addMeasurement(idx=1, m=np.array([-8, 43]))  # should be (-7,44), 1 px error in each dim
+        # in camera 0
+        track_3d.addMeasurement(idx=0, m=np.array([13, 24]))
+        # in camera 1
+        track_3d.addMeasurement(idx=1, m=np.array([-8, 43]))  # should be (-7,44), 1 px error in each dim
 
-    errors, avg_track_reproj_error = reproj_utils.compute_track_reprojection_errors(track_camera_dict, track_3d)
+        errors, avg_track_reproj_error = reproj_utils.compute_track_reprojection_errors(track_camera_dict, track_3d)
 
-    expected_errors = np.array([0, np.sqrt(2)])
-    np.testing.assert_allclose(errors, expected_errors)
-    assert avg_track_reproj_error == np.sqrt(2) / 2
+        expected_errors = np.array([0, np.sqrt(2)])
+        np.testing.assert_allclose(errors, expected_errors)
+        assert avg_track_reproj_error == np.sqrt(2) / 2
+
+    def test_compute_point_reprojection_errors(self):
+        """Ensure a hypothesized 3d point is projected correctly and compared w/ 2 measurements.
+        # For camera 0:
+        # [13] = [10,0,3]   [1,0,0 | 0]  [1]
+        # [24] = [0,10,4] * [0,1,0 | 0] *[2]
+        #  [1] = [0, 0,1]   [0,0,1 | 0]  [1]
+        #                                [1]
+
+        # For camera 1:
+        # [-7] = [10,0,3]   [1,0,0 |-2]  [1]
+        # [44] = [0,10,4] * [0,1,0 | 2] *[2]
+        #  [1] = [0, 0,1]   [0,0,1 | 0]  [1]
+        #                                [1]
+        """
+        wTi0 = Pose3(Rot3.RzRyRx(0, 0, 0), np.zeros((3, 1)))
+        wTi1 = Pose3(Rot3.RzRyRx(0, 0, 0), np.array([2, -2, 0]))
+
+        f = 10
+        k1 = 0
+        k2 = 0
+        u0 = 3
+        v0 = 4
+
+        K0 = Cal3Bundler(f, k1, k2, u0, v0)
+        K1 = Cal3Bundler(f, k1, k2, u0, v0)
+
+        track_camera_dict = {0: PinholeCameraCal3Bundler(wTi0, K0), 1: PinholeCameraCal3Bundler(wTi1, K1)}
+        point3d = np.array([1, 2, 1])
+        measurements = [
+            SfmMeasurement(i=1, uv=np.array([-8, 43])),
+            SfmMeasurement(i=2, uv=np.array([0, 0])),  # not in track_camera_dict!
+            SfmMeasurement(i=0, uv=np.array([13, 24])),
+        ]
+
+        errors, avg_track_reproj_error = reproj_utils.compute_point_reprojection_errors(
+            track_camera_dict, point3d, measurements
+        )
+        expected_errors = np.array([np.sqrt(2), np.nan, 0])
+        np.testing.assert_allclose(errors, expected_errors)
+        assert avg_track_reproj_error == np.sqrt(2) / 2
 
 
-def test_compute_point_reprojection_errors():
-    """Ensure a hypothesized 3d point is projected correctly and compared w/ 2 measurements.
-    # For camera 0:
-    # [13] = [10,0,3]   [1,0,0 | 0]  [1]
-    # [24] = [0,10,4] * [0,1,0 | 0] *[2]
-    #  [1] = [0, 0,1]   [0,0,1 | 0]  [1]
-    #                                [1]
-
-    # For camera 1:
-    # [-7] = [10,0,3]   [1,0,0 |-2]  [1]
-    # [44] = [0,10,4] * [0,1,0 | 2] *[2]
-    #  [1] = [0, 0,1]   [0,0,1 | 0]  [1]
-    #                                [1]
-    """
-    wTi0 = Pose3(Rot3.RzRyRx(0, 0, 0), np.zeros((3, 1)))
-    wTi1 = Pose3(Rot3.RzRyRx(0, 0, 0), np.array([2, -2, 0]))
-
-    f = 10
-    k1 = 0
-    k2 = 0
-    u0 = 3
-    v0 = 4
-
-    K0 = Cal3Bundler(f, k1, k2, u0, v0)
-    K1 = Cal3Bundler(f, k1, k2, u0, v0)
-
-    track_camera_dict = {0: PinholeCameraCal3Bundler(wTi0, K0), 1: PinholeCameraCal3Bundler(wTi1, K1)}
-    point3d = np.array([1, 2, 1])
-    measurements = [SfmMeasurement(i=1, uv=np.array([-8, 43])), SfmMeasurement(i=0, uv=np.array([13, 24]))]
-
-    errors, avg_track_reproj_error = reproj_utils.compute_point_reprojection_errors(
-        track_camera_dict, point3d, measurements
-    )
-    expected_errors = np.array([np.sqrt(2), 0])
-    np.testing.assert_allclose(errors, expected_errors)
-    assert avg_track_reproj_error == np.sqrt(2) / 2
-
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I made a number of changes, mostly renaming of run methods (to make dashboard better) and logging. BUT, I also found that the major bottleneck was MFAS outlier rejection. Translation averaging went from 10 minutes to 2 seconds!

[2022-05-14 10:57:54,964 INFO averaging_1dsfm.py line 238 1185] Running translation averaging on 6021 unit translations.
[2022-05-14 10:57:54,983 DEBUG averaging_1dsfm.py line 247 1185] Created measurements in global frame.
[2022-05-14 10:57:54,983 DEBUG averaging_1dsfm.py line 271 1185] Constructed NEW TranslationRecovery, about to run.
[2022-05-14 10:57:55,019 INFO rig_1dsfm.py line 93 1185] Added 5718 priors in rig translation averaging
[2022-05-14 10:57:55,020 DEBUG averaging_1dsfm.py line 274 1185] Computed priors and initial values.
[2022-05-14 10:57:56,860 DEBUG averaging_1dsfm.py line 278 1185] Finished with priors.

That and the caching (yay Ayush!) now runs the medium exp4 in 3.5 minutes:

**GTSFM took 3.37 minutes to compute sparse multi-view result.**
