### PR TITLE
Loose covariance for filtered priors

### DIFF
--- a/gtsfm/loader/hilti_loader.py
+++ b/gtsfm/loader/hilti_loader.py
@@ -129,7 +129,7 @@ class HiltiLoader(LoaderBase):
 
         filtered_constraints = {}
         rot_sigma = np.deg2rad(60)
-        trans_sigma = 50 # meters
+        trans_sigma = 10 # meters
         FILTERED_COVARIANCE = np.diag([rot_sigma, rot_sigma, rot_sigma, trans_sigma, trans_sigma, trans_sigma])
         for (a, b), constraint in constraints.items():
             # Accept all constraint with step > 1

--- a/tests/loader/test_hilti_loader.py
+++ b/tests/loader/test_hilti_loader.py
@@ -118,6 +118,7 @@ class TestHiltiLoader(unittest.TestCase):
         self.assertEqual(len(actual), len(expected))
         self.assertEqual(actual, expected)
 
+    # TODO (akshay-krishnan): update this test, values are not removed, covariance is reduced.
     def test_filters_constraints(self) -> None:
         constraints = {
             (0, 1): Constraint(0, 1, Pose3(Rot3(), Point3(5, 0, 0))), # outlier, has both 2 & 3 step


### PR DESCRIPTION
Instead of removing outlier priors, and a high covariance edge, so that the graph does not break. 