### PR TITLE
Add lettuce data to benchmarks

### DIFF
--- a/.github/scripts/download_single_benchmark.sh
+++ b/.github/scripts/download_single_benchmark.sh
@@ -60,6 +60,11 @@ function download_and_unzip_dataset_files {
     #   Vesta.
     WGET_URL1=https://www.dropbox.com/s/q02mgq1unbw068t/2011205_rc3.zip
     ZIP_FNAME=2011205_rc3.zip
+
+  elif [ "$DATASET_NAME" == "lettuce" ]; then
+    # Description: images captured from BORG lab hydroponics experiments
+    export GDRIVE_FILEID='1W-O8C5ONWs2GDSD07BpEVWAGzIfx0LnM'
+    ZIP_FNAME=lettuce.zip
   fi
 
   # Download the data.
@@ -122,6 +127,9 @@ function download_and_unzip_dataset_files {
 
   elif [ "$DATASET_NAME" == "2011205_rc3" ]; then
     unzip -qq 2011205_rc3.zip
+
+  elif [ "$DATASET_NAME" == "lettuce" ]; then
+    unzip -qq lettuce.zip
   fi
 }
 

--- a/.github/scripts/execute_single_benchmark.sh
+++ b/.github/scripts/execute_single_benchmark.sh
@@ -27,6 +27,8 @@ elif [ "$DATASET_NAME" == "skydio-501" ]; then
 elif [ "$DATASET_NAME" == "notre-dame-20" ]; then
   IMAGES_DIR=notre-dame-20/images
   COLMAP_FILES_DIRPATH=notre-dame-20/notre-dame-20-colmap
+elif [ "$DATASET_NAME" == "lettuce" ]; then
+  DATASET_ROOT="lettuce"
 fi
 
 echo "Config: ${CONFIG_NAME}, Loader: ${LOADER_NAME}"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,6 +24,8 @@ jobs:
             [deep_front_end,           notre-dame-20,         20,  jpg,  gdrive,     colmap-loader,  760, false],
             [sift_front_end_astronet,  2011205_rc3,           65,  png,  wget,       astronet,       1024, true],
             [deep_front_end_astronet,  2011205_rc3,           20,  png,  wget,       astronet,       1024, true],
+            [sift_front_end,           lettuce,               12,  jpg,  gdrive,  olsson-loader,  760, false],
+            [deep_front_end,           lettuce,               12,  jpg,  gdrive,  olsson-loader,  760, false],
           ]
     defaults:
       run:


### PR DESCRIPTION
Added the data from Gerry's recent hydroponics experiments as a new benchmark for CI tests. This downloads from my personal Google Drive account, because I don't have access to the shared Dropbox linked in Slack.

On my machine, running 

`python gtsfm/runner/run_scene_optimizer_olssonloader.py --dataset_root tests/data/lettuce --image_extension jpg --config_name deep_front_end.yaml`

results in:

![Screenshot from 2022-05-23 22-55-36](https://user-images.githubusercontent.com/30275369/169940241-6c5558e3-f32e-48f0-af79-e9da437d7aea.png)
![Screenshot from 2022-05-23 22-54-52](https://user-images.githubusercontent.com/30275369/169940246-6b93d690-9176-4988-b8c7-fb56e206a6c8.png)