### PR TITLE
change lettuce test to use colmap loader

### DIFF
--- a/.github/scripts/download_single_benchmark.sh
+++ b/.github/scripts/download_single_benchmark.sh
@@ -61,10 +61,10 @@ function download_and_unzip_dataset_files {
     WGET_URL1=https://www.dropbox.com/s/q02mgq1unbw068t/2011205_rc3.zip
     ZIP_FNAME=2011205_rc3.zip
 
-  elif [ "$DATASET_NAME" == "lettuce" ]; then
+  elif [ "$DATASET_NAME" == "lettuce-18" ]; then
     # Description: images captured from BORG lab hydroponics experiments
-    export GDRIVE_FILEID='1W-O8C5ONWs2GDSD07BpEVWAGzIfx0LnM'
-    ZIP_FNAME=lettuce.zip
+    export GDRIVE_FILEID='12HW6a7moTXP9H66HiGZCsdRKdEWl8gWC'
+    ZIP_FNAME=lettuce-18.zip
   fi
 
   # Download the data.
@@ -128,8 +128,8 @@ function download_and_unzip_dataset_files {
   elif [ "$DATASET_NAME" == "2011205_rc3" ]; then
     unzip -qq 2011205_rc3.zip
 
-  elif [ "$DATASET_NAME" == "lettuce" ]; then
-    unzip -qq lettuce.zip
+  elif [ "$DATASET_NAME" == "lettuce-18" ]; then
+    unzip -qq lettuce-18.zip
   fi
 }
 

--- a/.github/scripts/execute_single_benchmark.sh
+++ b/.github/scripts/execute_single_benchmark.sh
@@ -28,8 +28,8 @@ elif [ "$DATASET_NAME" == "notre-dame-20" ]; then
   IMAGES_DIR=notre-dame-20/images
   COLMAP_FILES_DIRPATH=notre-dame-20/notre-dame-20-colmap
 elif [ "$DATASET_NAME" == "lettuce-18" ]; then
-  IMAGES_DIR=lettuce-18/images
-  COLMAP_FILES_DIRPATH=lettuce-18/colmap_files
+  IMAGES_DIR="lettuce-18/images"
+  COLMAP_FILES_DIRPATH="lettuce-18/colmap_files"
 fi
 
 echo "Config: ${CONFIG_NAME}, Loader: ${LOADER_NAME}"

--- a/.github/scripts/execute_single_benchmark.sh
+++ b/.github/scripts/execute_single_benchmark.sh
@@ -27,8 +27,9 @@ elif [ "$DATASET_NAME" == "skydio-501" ]; then
 elif [ "$DATASET_NAME" == "notre-dame-20" ]; then
   IMAGES_DIR=notre-dame-20/images
   COLMAP_FILES_DIRPATH=notre-dame-20/notre-dame-20-colmap
-elif [ "$DATASET_NAME" == "lettuce" ]; then
-  DATASET_ROOT="lettuce"
+elif [ "$DATASET_NAME" == "lettuce-18" ]; then
+  IMAGES_DIR=lettuce-18/images
+  COLMAP_FILES_DIRPATH=lettuce-18/colmap_files
 fi
 
 echo "Config: ${CONFIG_NAME}, Loader: ${LOADER_NAME}"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,8 +24,8 @@ jobs:
             [deep_front_end,           notre-dame-20,         20,  jpg,  gdrive,     colmap-loader,  760, false],
             [sift_front_end_astronet,  2011205_rc3,           65,  png,  wget,       astronet,       1024, true],
             [deep_front_end_astronet,  2011205_rc3,           20,  png,  wget,       astronet,       1024, true],
-            [sift_front_end,           lettuce-18,            32,  jpg,  gdrive,     colmap-loader,  760, true],
-            [deep_front_end,           lettuce-18,            32,  jpg,  gdrive,     colmap-loader,  760, true],
+            [sift_front_end,           lettuce-18,            12,  jpg,  gdrive,     colmap-loader,  760, true],
+            [deep_front_end,           lettuce-18,            12,  jpg,  gdrive,     colmap-loader,  760, true],
           ]
     defaults:
       run:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,8 +24,8 @@ jobs:
             [deep_front_end,           notre-dame-20,         20,  jpg,  gdrive,     colmap-loader,  760, false],
             [sift_front_end_astronet,  2011205_rc3,           65,  png,  wget,       astronet,       1024, true],
             [deep_front_end_astronet,  2011205_rc3,           20,  png,  wget,       astronet,       1024, true],
-            [sift_front_end,           lettuce-18,            12,  jpg,  gdrive,     colmap-loader,  760, true],
-            [deep_front_end,           lettuce-18,            12,  jpg,  gdrive,     colmap-loader,  760, true],
+            [sift_front_end,           lettuce-18,            12,  jpg,  gdrive,     colmap-loader,  760, false],
+            [deep_front_end,           lettuce-18,            12,  jpg,  gdrive,     colmap-loader,  760, false],
           ]
     defaults:
       run:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,8 +24,8 @@ jobs:
             [deep_front_end,           notre-dame-20,         20,  jpg,  gdrive,     colmap-loader,  760, false],
             [sift_front_end_astronet,  2011205_rc3,           65,  png,  wget,       astronet,       1024, true],
             [deep_front_end_astronet,  2011205_rc3,           20,  png,  wget,       astronet,       1024, true],
-            [sift_front_end,           lettuce,               12,  jpg,  gdrive,  olsson-loader,  760, false],
-            [deep_front_end,           lettuce,               12,  jpg,  gdrive,  olsson-loader,  760, false],
+            [sift_front_end,           lettuce-18,            32,  jpg,  gdrive,     colmap-loader,  760, true],
+            [deep_front_end,           lettuce-18,            32,  jpg,  gdrive,     colmap-loader,  760, true],
           ]
     defaults:
       run:


### PR DESCRIPTION
Modifies #511 slightly to use the colmap loader instead of the olsson loader. Still hosting the files on my personal GDrive, again, let me know if I can get access to some shared Dropbox/GDrive folder.

![Screenshot from 2022-06-06 00-27-46](https://user-images.githubusercontent.com/30275369/172095060-370e612a-fa8c-4b68-a321-19ee542ad83b.png)

This is the deep_front_end config. Results less impressive than with the olsson loader.
