### PR TITLE
replace all instances of point_rendering_mode with rendering_style

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ where `COLMAP_FILES_DIRPATH` is a directory where .txt files such as `cameras.tx
 
 To visualize the result using Open3D, run:
 ```bash
-python gtsfm/visualization/view_scene.py --rendering_library open3d --point_rendering_mode point
+python gtsfm/visualization/view_scene.py --rendering_library open3d --rendering_style point
 ```
 
 For users that are working with the same dataset repeatedly, we provide functionality to cache front-end results for 

--- a/gtsfm/visualization/open3d_vis_utils.py
+++ b/gtsfm/visualization/open3d_vis_utils.py
@@ -195,10 +195,10 @@ def draw_scene_open3d(
         args: rendering options.
     """
     frustums = create_all_frustums_open3d(wTi_list, calibrations, args.frustum_ray_len)
-    if args.point_rendering_mode == "point":
+    if args.rendering_style == "point":
         pcd = create_colored_point_cloud_open3d(point_cloud, rgb)
         geometries = frustums + [pcd]
-    elif args.point_rendering_mode == "sphere":
+    elif args.rendering_style == "sphere":
         spheres = create_colored_spheres_open3d(point_cloud, rgb, args.sphere_radius)
         geometries = frustums + spheres
 

--- a/gtsfm/visualization/view_scene.py
+++ b/gtsfm/visualization/view_scene.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
         "This directory should contain 3 files: cameras.txt, images.txt, and points3D.txt",
     )
     parser.add_argument(
-        "--point_rendering_mode",
+        "--rendering_style",
         type=str,
         default="point",
         choices=["point", "sphere"],

--- a/gtsfm/visualization/view_scene_olsson.py
+++ b/gtsfm/visualization/view_scene_olsson.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
     parser.add_argument("--dataset_root", type=str, default=os.path.join(TEST_DATA_ROOT, "set1_lund_door"), help="")
     parser.add_argument("--image_extension", type=str, default="JPG", help="")
     parser.add_argument(
-        "--point_rendering_mode",
+        "--rendering_style",
         type=str,
         default="point",
         choices=["point", "sphere"],


### PR DESCRIPTION
As @ayushbaid  pointed out in [his review](https://github.com/borglab/gtsfm/pull/514#pullrequestreview-997573943) of #514, ``point_rendering_mode=sphere`` is a bit confusing. This short PR replaces all instances of point_rendering_mode with rendering_style.

Validation (on default door dataset, run with the default command given by the README):

``python gtsfm/visualization/view_scene.py --rendering_style point``

![Screenshot from 2022-06-08 16-50-45](https://user-images.githubusercontent.com/30275369/172714798-64d01597-d0d5-4221-b401-48184915796a.png)

``python gtsfm/visualization/view_scene.py --rendering_style sphere``

![Screenshot from 2022-06-08 16-50-26](https://user-images.githubusercontent.com/30275369/172714824-d56cd0ec-3050-4d94-a7de-6a575d762361.png)

