### PR TITLE
align naming of error angle deg

### DIFF
--- a/gtsfm/utils/metrics.py
+++ b/gtsfm/utils/metrics.py
@@ -223,13 +223,13 @@ def compute_rotation_angle_metric(wRi_list: List[Optional[Rot3]], gt_wRi_list: L
         gt_wRi_list: List of ground truth camera rotations.
 
     Returns:
-        A statistics dict of the metrics errors in degrees.
+        A GtsfmMetric for the rotation angle errors, in degrees.
     """
     errors = []
     for (wRi, gt_wRi) in zip(wRi_list, gt_wRi_list):
         if wRi is not None and gt_wRi is not None:
             errors.append(comp_utils.compute_relative_rotation_angle(wRi, gt_wRi))
-    return GtsfmMetric("rotation_error_angle_deg", errors)
+    return GtsfmMetric("rotation_angle_error_deg", errors)
 
 
 def compute_translation_distance_metric(


### PR DESCRIPTION
The "translation angle error, in degrees" is named `translation_angle_error_deg` in the `translation_averaging_metrics.json`. (See [this line](https://github.com/kfu02/gtsfm/blob/00ee74982d859158966729f2adb98b406fa2d4cb/gtsfm/utils/metrics.py#L273) of the `utils/metrics.py` file.) However, the "rotation angle error, in degrees" is named `rotation_error_angle_deg` instead of `rotation_angle_error_deg`.

This PR aligns both to `*_angle_error_deg` which fits the description more accurately.