### PR TITLE
add dependabot yml config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,5 @@ updates:
     labels:
       - "npm dependencies"
     reviewers:
-      - "kfu02"
-      - "ayushbaid"
-
-  # TODO: pip dependencies?
+      - "stepanyanhayk"
+      - "johnwlambert"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# Dependabot config file. See:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#about-the-dependabotyml-file
+
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/rtf_vis_tool"
+    schedule:
+      interval: "daily"
+    target-branch: "rtf-dependencies"
+    labels:
+      - "npm dependencies"
+    reviewers:
+      - "kfu02"
+
+  # TODO: pip dependencies?

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,5 +20,6 @@ updates:
       - "npm dependencies"
     reviewers:
       - "kfu02"
+      - "ayushbaid"
 
   # TODO: pip dependencies?


### PR DESCRIPTION
Added Dependabot config file for checking dependencies installed via npm, and for .github_actions. Any npm dependencies errors will now cause Dependabot to:
 * create a PR to branch `rtf-dependencies`
 * add a label "rtf dependencies"
 * tag me as a reviewer

Unfortunately there is no way to test this without simply merging it in and waiting for Dependabot PRs to come in. I will hotfix PR it if any issues come up.