### PR TITLE
Allow passing custom output directory for results

### DIFF
--- a/gtsfm/frontend/inlier_support_processor.py
+++ b/gtsfm/frontend/inlier_support_processor.py
@@ -44,7 +44,7 @@ class InlierSupportProcessor:
         v_corr_idxs: np.ndarray,
         two_view_report: TwoViewEstimationReport,
     ) -> Tuple[Optional[Rot3], Optional[Unit3], np.ndarray, Optional[TwoViewEstimationReport]]:
-        """Check for sufficient support among correspondences to estimate a trustworthy relative pose for this image pair.
+        """Checks for sufficient support among correspondences to estimate a trustworthy relative pose for image pair.
 
         We don't modify the report (to stay functional), but report InlierSupportProcessor metrics separately.
 

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -1,6 +1,9 @@
+"""Base class for runner that executes SfM."""
+
 import argparse
 import time
 from abc import abstractmethod
+from pathlib import Path
 
 import dask
 import hydra
@@ -98,7 +101,8 @@ class GtsfmRunnerBase:
             "--output_root",
             type=str,
             default=DEFAULT_OUTPUT_ROOT,
-            help="Root directory. Results, plots and metrics will be stored in subdirectories, e.g. {output_root}/results",
+            help="Root directory. Results, plots and metrics will be stored in subdirectories,"
+            "e.g. {output_root}/results",
         )
         return parser
 

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -24,6 +24,8 @@ from gtsfm.retriever.sequential_retriever import SequentialRetriever
 
 logger = logger_utils.get_logger()
 
+DEFAULT_OUTPUT_ROOT = Path(__file__).resolve().parent.parent.parent
+
 
 class GtsfmRunnerBase:
     def __init__(self, tag: str):
@@ -92,7 +94,12 @@ class GtsfmRunnerBase:
         parser.add_argument(
             "--share_intrinsics", action="store_true", help="Shares the intrinsics between all the cameras"
         )
-
+        parser.add_argument(
+            "--output_root",
+            type=str,
+            default=DEFAULT_OUTPUT_ROOT,
+            help="Root directory. Results, plots and metrics will be stored in subdirectories, e.g. {output_root}/results",
+        )
         return parser
 
     @abstractmethod
@@ -102,12 +109,14 @@ class GtsfmRunnerBase:
     def construct_scene_optimizer(self) -> SceneOptimizer:
         """Construct scene optimizer."""
         with hydra.initialize_config_module(config_module="gtsfm.configs"):
+            overrides = ["+SceneOptimizer.output_root=" + str(self.parsed_args.output_root)]
+            if self.parsed_args.share_intrinsics:
+                overrides.append("SceneOptimizer.multiview_optimizer.bundle_adjustment_module.shared_calib=True")
+            
             # config is relative to the gtsfm module
             cfg = hydra.compose(
                 config_name=self.parsed_args.config_name,
-                overrides=["SceneOptimizer.multiview_optimizer.bundle_adjustment_module.shared_calib=True"]
-                if self.parsed_args.share_intrinsics
-                else [],
+                overrides=overrides,
             )
             logger.info("Using config: ")
             logger.info(OmegaConf.to_yaml(cfg))

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -297,7 +297,15 @@ class SceneOptimizer:
         )
 
         if self._save_3d_viz:
-            delayed_results.extend(save_visualizations(ba_input_graph, ba_output_graph, gt_wTi_list))
+            delayed_results.extend(
+                save_visualizations(
+                    ba_input_graph,
+                    ba_output_graph,
+                    gt_wTi_list,
+                    plot_ba_input_path=self.plot_ba_input_path,
+                    plot_results_path=self.plot_results_path,
+                )
+            )
 
         if self._save_gtsfm_data:
             delayed_results.extend(save_gtsfm_data(image_graph, ba_input_graph, ba_output_graph))
@@ -362,7 +370,11 @@ def align_estimated_gtsfm_data(
 
 
 def save_visualizations(
-    ba_input_graph: Delayed, ba_output_graph: Delayed, gt_pose_graph: List[Optional[Delayed]]
+    ba_input_graph: Delayed,
+    ba_output_graph: Delayed,
+    gt_pose_graph: List[Optional[Delayed]],
+    plot_ba_input_path: Path,
+    plot_results_path: Path,
 ) -> List[Delayed]:
     """Save SfmData before and after bundle adjustment and camera poses for visualization.
 
@@ -373,6 +385,8 @@ def save_visualizations(
         ba_input_graph: Delayed GtsfmData input to bundle adjustment.
         ba_output_graph: Delayed GtsfmData output from bundle adjustment.
         gt_pose_graph: Delayed ground truth poses.
+        plot_ba_input_path: path to directory where visualizations of bundle adjustment input data will be saved.
+        plot_results_path: path to directory where visualizations of bundle adjustment output data will be saved.
 
     Returns:
         A list of Delayed objects after saving the different visualizations.
@@ -380,11 +394,11 @@ def save_visualizations(
     aligned_ba_input_graph = dask.delayed(lambda x, y: x.align_via_Sim3_to_poses(y))(ba_input_graph, gt_pose_graph)
     aligned_ba_output_graph = dask.delayed(lambda x, y: x.align_via_Sim3_to_poses(y))(ba_output_graph, gt_pose_graph)
     viz_graph_list = []
-    viz_graph_list.append(dask.delayed(viz_utils.save_sfm_data_viz)(aligned_ba_input_graph, PLOT_BA_INPUT_PATH))
-    viz_graph_list.append(dask.delayed(viz_utils.save_sfm_data_viz)(aligned_ba_output_graph, PLOT_RESULTS_PATH))
+    viz_graph_list.append(dask.delayed(viz_utils.save_sfm_data_viz)(aligned_ba_input_graph, plot_ba_input_path))
+    viz_graph_list.append(dask.delayed(viz_utils.save_sfm_data_viz)(aligned_ba_output_graph, plot_results_path))
     viz_graph_list.append(
         dask.delayed(viz_utils.save_camera_poses_viz)(
-            aligned_ba_input_graph, aligned_ba_output_graph, gt_pose_graph, PLOT_RESULTS_PATH
+            aligned_ba_input_graph, aligned_ba_output_graph, gt_pose_graph, plot_results_path
         )
     )
     return viz_graph_list

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -93,24 +93,24 @@ class SceneOptimizer:
     def _create_output_directories(self) -> None:
         """Create various output directories for GTSFM results, metrics, and plots."""
         # base paths for storage
-        self.plot_base_path = self.output_root / "plots"
-        self.metrics_path = self.output_root / "result_metrics"
-        self.results_path = self.output_root / "results"
+        self._plot_base_path = self.output_root / "plots"
+        self._metrics_path = self.output_root / "result_metrics"
+        self._results_path = self.output_root / "results"
 
         # plot paths
-        self.plot_correspondence_path = self.plot_base_path / "correspondences"
-        self.plot_ba_input_path = self.plot_base_path / "ba_input"
-        self.plot_results_path = self.plot_base_path / "results"
-        self.mvs_ply_save_fpath = self.results_path / "mvs_output" / "dense_pointcloud.ply"
+        self._plot_correspondence_path = self._plot_base_path / "correspondences"
+        self._plot_ba_input_path = self._plot_base_path / "ba_input"
+        self._plot_results_path = self._plot_base_path / "results"
+        self._mvs_ply_save_fpath = self._results_path / "mvs_output" / "dense_pointcloud.ply"
 
         # make directories for persisting data
-        os.makedirs(self.plot_base_path, exist_ok=True)
-        os.makedirs(self.metrics_path, exist_ok=True)
-        os.makedirs(self.results_path, exist_ok=True)
+        os.makedirs(self._plot_base_path, exist_ok=True)
+        os.makedirs(self._metrics_path, exist_ok=True)
+        os.makedirs(self._results_path, exist_ok=True)
 
-        os.makedirs(self.plot_correspondence_path, exist_ok=True)
-        os.makedirs(self.plot_ba_input_path, exist_ok=True)
-        os.makedirs(self.plot_results_path, exist_ok=True)
+        os.makedirs(self._plot_correspondence_path, exist_ok=True)
+        os.makedirs(self._plot_ba_input_path, exist_ok=True)
+        os.makedirs(self._plot_results_path, exist_ok=True)
 
         # Save duplicate directories within React folders.
         os.makedirs(REACT_RESULTS_PATH, exist_ok=True)
@@ -238,7 +238,7 @@ class SceneOptimizer:
                         delayed_keypoints[i2],
                         v_corr_idxs,
                         two_view_report=two_view_reports[PRE_BA_REPORT_TAG],
-                        file_path=os.path.join(self.plot_correspondence_path, f"{i1}_{i2}.jpg"),
+                        file_path=os.path.join(self._plot_correspondence_path, f"{i1}_{i2}.jpg"),
                     )
                 )
 
@@ -275,8 +275,8 @@ class SceneOptimizer:
                     image_graph,
                     filename="two_view_report_{}.json".format(tag),
                     matching_regime=matching_regime,
-                    metrics_path=self.metrics_path,
-                    plot_base_path=self.plot_base_path
+                    metrics_path=self._metrics_path,
+                    plot_base_path=self._plot_base_path,
                 )
             )
             metrics_graph_list.append(
@@ -302,14 +302,14 @@ class SceneOptimizer:
                     ba_input_graph,
                     ba_output_graph,
                     gt_wTi_list,
-                    plot_ba_input_path=self.plot_ba_input_path,
-                    plot_results_path=self.plot_results_path,
+                    plot_ba_input_path=self._plot_ba_input_path,
+                    plot_results_path=self._plot_results_path,
                 )
             )
 
         if self._save_gtsfm_data:
             delayed_results.extend(
-                save_gtsfm_data(image_graph, ba_input_graph, ba_output_graph, results_path=self.results_path)
+                save_gtsfm_data(image_graph, ba_input_graph, ba_output_graph, results_path=self._results_path)
             )
 
         if self._run_dense_optimizer:
@@ -324,8 +324,7 @@ class SceneOptimizer:
             # Cast to string as Open3d cannot use PosixPath's for I/O -- only string file paths are accepted.
             delayed_results.append(
                 dask.delayed(io_utils.save_point_cloud_as_ply)(
-                    save_fpath=str(self.mvs_ply_save_fpath), points=dense_points_graph, rgb=dense_point_colors_graph
-
+                    save_fpath=str(self._mvs_ply_save_fpath), points=dense_points_graph, rgb=dense_point_colors_graph
                 )
             )
 
@@ -336,7 +335,7 @@ class SceneOptimizer:
                 metrics_graph_list.append(downsampling_metrics_graph)
 
         # Save metrics to JSON and generate HTML report.
-        delayed_results.extend(save_metrics_reports(metrics_graph_list, metrics_path=self.metrics_path))
+        delayed_results.extend(save_metrics_reports(metrics_graph_list, metrics_path=self._metrics_path))
 
         # return the entry with just the sfm result
         return ba_output_graph, delayed_results
@@ -449,7 +448,7 @@ def save_metrics_reports(metrics_graph_list: List[Delayed], metrics_path: Path) 
     Args:
         metrics_graph: List of GtsfmMetricsGroup from different modules wrapped as Delayed.
         metrics_path: path to directory where computed metrics will be saved.
-        
+
     Returns:
         List of delayed objects after saving metrics.
     """
@@ -479,7 +478,7 @@ def save_full_frontend_metrics(
     filename: str,
     matching_regime: ImageMatchingRegime,
     metrics_path: Path,
-    plot_base_path: Path
+    plot_base_path: Path,
 ) -> None:
     """Converts the TwoViewEstimationReports for all image pairs to a Dict and saves it as JSON.
 

--- a/tests/utils/test_io_utils.py
+++ b/tests/utils/test_io_utils.py
@@ -96,9 +96,11 @@ class TestIoUtils(unittest.TestCase):
         self.assertIsNone(calibrations)
 
     def test_round_trip_images_txt(self) -> None:
-        """Starts with a pose. Writes the pose to images.txt (in a temporary directory). Then reads images.txt to recover
-        that same pose. Checks if the original wTc and recovered wTc match up."""
-
+        """Verifies that round-trip saving and reading a COLMAP-style `images.txt` file yields input poses.
+        
+        Starts with a pose. Writes the pose to images.txt (in a temporary directory). Then reads images.txt to recover
+        that same pose. Checks if the original wTc and recovered wTc match up.
+        """
         # fmt: off
         # Rotation 45 degrees about the z-axis.
         original_wRc = np.array(

--- a/tests/utils/test_metric_utils.py
+++ b/tests/utils/test_metric_utils.py
@@ -1,6 +1,6 @@
 """Unit tests for metrics utilities.
 
-Author: Travis Driver
+Authors: Travis Driver, John Lambert
 """
 
 import unittest
@@ -70,11 +70,12 @@ class TestMetricUtils(unittest.TestCase):
         np.testing.assert_allclose(expected_intersections, estimated_intersections)
 
     def test_get_stats_for_sfmdata_skydio32(self) -> None:
-        """Real data, from Skydio-32 sequence with the SIFT front-end, if Sim(3) object is corrupted with negative scale.
-
+        """Verifies that track reprojection errors are returned as NaN if given degenerate input.
+        
+        The data used below corresponds to camera poses aligned to GT from Skydio-32 sequence with the SIFT front-end,
+        if the Sim(3) object used for alignment is corrupted with negative scale.
         All tracks should have NaN reprojection error, from cheirality errors from the negative scale.
         """
-
         fx, k1, k2, px, py = 609.94, -8.82687675e-07, -4.25111629e-06, 507, 380
         calib = Cal3Bundler(fx, k1, k2, px, py)
 


### PR DESCRIPTION
Previously `results` always appeared in the top-level repo directory. This doesn't make sense for large-scale experiments, however, so this PR adds CLI to specify a custom output directory for results.

To get CI to pass, I also had to fix line-length overages in a few other files, which flake8 was complaining about.