### PR TITLE
Temporarily remove lettuce CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,8 +24,8 @@ jobs:
             [deep_front_end,           notre-dame-20,         20,  jpg,  gdrive,     colmap-loader,  760, false],
             [sift_front_end_astronet,  2011205_rc3,           65,  png,  wget,       astronet,       1024, true],
             [deep_front_end_astronet,  2011205_rc3,           65,  png,  wget,       astronet,       1024, true],
-            [sift_front_end,           lettuce-18,            12,  jpg,  gdrive,     colmap-loader,  760, false],
-            [deep_front_end,           lettuce-18,            12,  jpg,  gdrive,     colmap-loader,  760, false],
+            # [sift_front_end,           lettuce-18,            12,  jpg,  gdrive,     colmap-loader,  760, false], # TODO: camera models with distortion
+            # [deep_front_end,           lettuce-18,            12,  jpg,  gdrive,     colmap-loader,  760, false],
           ]
     defaults:
       run:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,7 +24,7 @@ jobs:
             [deep_front_end,           notre-dame-20,         20,  jpg,  gdrive,     colmap-loader,  760, false],
             [sift_front_end_astronet,  2011205_rc3,           65,  png,  wget,       astronet,       1024, true],
             [deep_front_end_astronet,  2011205_rc3,           65,  png,  wget,       astronet,       1024, true],
-            # [sift_front_end,           lettuce-18,            12,  jpg,  gdrive,     colmap-loader,  760, false], # TODO: camera models with distortion
+            # [sift_front_end,           lettuce-18,            12,  jpg,  gdrive,     colmap-loader,  760, false], # TODO(gerry): camera models with distortion
             # [deep_front_end,           lettuce-18,            12,  jpg,  gdrive,     colmap-loader,  760, false],
           ]
     defaults:


### PR DESCRIPTION
Lettuce CI fails because camera models with distortion are not supported.

Temporarily taking this out since it's not on anyone's A->B.  (See https://github.com/borglab/gtsfm/pull/540#issuecomment-1229300655)

Potential fixes:
* Support other camera models
* rerun colmap with a simple camera model for baseline/gt (IIRC, this dataset is from plant 018 "experiment 3" (Spring 2022) and that camera should have not had much distortion, i.e. it wasn't wide-angle/fisheye)