### PR TITLE
Delete d2net weights file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ thirdparty/models/
 thirdparty/patchmatchnet/checkpoints/
 thirdparty/SuperGluePretrainedNetwork/models/weights/
 thirdparty/hloc/weights/VGG16-NetVLAD-Pitts30K.mat
+thirdparty/**/*.pth
 
 # Data folder
 data/


### PR DESCRIPTION
The weights file was supposed to be downloaded from a script, and got accidentally checked in. 