### PR TITLE
Add COLMAP `PINHOLE` to Cal3Bundler conversion

### DIFF
--- a/gtsfm/utils/io.py
+++ b/gtsfm/utils/io.py
@@ -266,7 +266,8 @@ def read_cameras_txt(fpath: str) -> Optional[List[Cal3Bundler]]:
             # https://github.com/colmap/colmap/blob/master/src/base/camera_models.h#L198
             _, _, img_w, img_h, fx, fy, u0, v0 = cam_params[:8]
             img_w, img_h, fx, fy, u0, v0 = int(img_w), int(img_h), float(fx), float(fy), float(u0), float(v0)
-            # Convert COLMAP's PINHOLE to GTSAM's Cal3Bundler (add two radial distortion coefficients of value zero).
+            # Convert COLMAP's PINHOLE to GTSAM's Cal3Bundler by adding two radial distortion coefficients of
+            # value zero, and by discarding fy (using only fx).
             # TODO(gchenfc, kfu02): Return `Cal3_S2` instead of `Cal3Bundler`.
             k1, k2 = 0, 0
             calibrations.append(Cal3Bundler(fx, k1, k2, u0, v0))

--- a/gtsfm/utils/io.py
+++ b/gtsfm/utils/io.py
@@ -261,6 +261,15 @@ def read_cameras_txt(fpath: str) -> Optional[List[Cal3Bundler]]:
                 float(k2),
             )
             calibrations.append(Cal3Bundler(fx, k1, k2, u0, v0))
+        elif model == "PINHOLE":
+            # See COLMAP's `PINHOLE` documentation:
+            # https://github.com/colmap/colmap/blob/master/src/base/camera_models.h#L198
+            _, _, img_w, img_h, fx, fy, u0, v0 = cam_params[:8]
+            img_w, img_h, fx, fy, u0, v0 = int(img_w), int(img_h), float(fx), float(fy), float(u0), float(v0)
+            # Convert COLMAP's PINHOLE to GTSAM's Cal3Bundler (add two radial distortion coefficients of value zero).
+            # TODO(gchenfc, kfu02): Return `Cal3_S2` instead of `Cal3Bundler`.
+            k1, k2 = 0, 0
+            calibrations.append(Cal3Bundler(fx, k1, k2, u0, v0))
 
     assert len(calibrations) == num_cams
     return calibrations

--- a/gtsfm/utils/io.py
+++ b/gtsfm/utils/io.py
@@ -240,8 +240,8 @@ def read_cameras_txt(fpath: str) -> Optional[List[Cal3Bundler]]:
         cam_params = line.split()
         # Note that u0 is px, and v0 is py
         model = cam_params[1]
-        # Currently only handles SIMPLE RADIAL and RADIAL camera models
-        assert model in ["SIMPLE_RADIAL", "RADIAL"]
+        # Currently only handles SIMPLE RADIAL, RADIAL, and PINHOLE camera models from COLMAP.
+        assert model in ["SIMPLE_RADIAL", "RADIAL", "PINHOLE"]
         if model == "SIMPLE_RADIAL":
             _, _, img_w, img_h, fx, u0, v0, k1 = cam_params[:8]
             img_w, img_h, fx, u0, v0, k1 = int(img_w), int(img_h), float(fx), float(u0), float(v0), float(k1)


### PR DESCRIPTION
Fixes broken CI because one dataset GT file uses COLMAP's `PINHOLE` camera model, instead of already supported `RADIAL` and `SIMPLE_RADIAL`.