### PR TITLE
Remove the lettuce dataset from the CI

### DIFF
--- a/.github/scripts/download_single_benchmark.sh
+++ b/.github/scripts/download_single_benchmark.sh
@@ -124,6 +124,7 @@ function download_and_unzip_dataset_files {
   elif [ "$DATASET_NAME" == "2011205_rc3" ]; then
     unzip -qq 2011205_rc3.zip
     tar -xvf cache_rc3_deep.tar.gz
+  fi
 }
 
 # Retry in case of corrupted file ("End-of-central-directory signature not found")

--- a/.github/scripts/download_single_benchmark.sh
+++ b/.github/scripts/download_single_benchmark.sh
@@ -61,11 +61,6 @@ function download_and_unzip_dataset_files {
     WGET_URL1=https://www.dropbox.com/s/q02mgq1unbw068t/2011205_rc3.zip
     WGET_URL2=https://github.com/johnwlambert/gtsfm-cache/releases/download/2011205_rc3_deep_front_end_cache/cache_rc3_deep.tar.gz
     ZIP_FNAME=2011205_rc3.zip
-
-  elif [ "$DATASET_NAME" == "lettuce-18" ]; then
-    # Description: images captured from BORG lab hydroponics experiments
-    export GDRIVE_FILEID='12HW6a7moTXP9H66HiGZCsdRKdEWl8gWC'
-    ZIP_FNAME=lettuce-18.zip
   fi
 
   # Download the data.
@@ -129,10 +124,6 @@ function download_and_unzip_dataset_files {
   elif [ "$DATASET_NAME" == "2011205_rc3" ]; then
     unzip -qq 2011205_rc3.zip
     tar -xvf cache_rc3_deep.tar.gz
-
-  elif [ "$DATASET_NAME" == "lettuce-18" ]; then
-    unzip -qq lettuce-18.zip
-  fi
 }
 
 # Retry in case of corrupted file ("End-of-central-directory signature not found")

--- a/.github/scripts/execute_single_benchmark.sh
+++ b/.github/scripts/execute_single_benchmark.sh
@@ -27,9 +27,6 @@ elif [ "$DATASET_NAME" == "skydio-501" ]; then
 elif [ "$DATASET_NAME" == "notre-dame-20" ]; then
   IMAGES_DIR=notre-dame-20/images
   COLMAP_FILES_DIRPATH=notre-dame-20/notre-dame-20-colmap
-elif [ "$DATASET_NAME" == "lettuce-18" ]; then
-  IMAGES_DIR="lettuce-18/images"
-  COLMAP_FILES_DIRPATH="lettuce-18/colmap_files"
 fi
 
 echo "Config: ${CONFIG_NAME}, Loader: ${LOADER_NAME}"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,8 +24,6 @@ jobs:
             [deep_front_end,           notre-dame-20,         20,  jpg,  gdrive,     colmap-loader,  760, false],
             [sift_front_end_astronet,  2011205_rc3,           65,  png,  wget,       astronet,       1024, true],
             [deep_front_end_astronet,  2011205_rc3,           65,  png,  wget,       astronet,       1024, true],
-            [sift_front_end,           lettuce-18,            12,  jpg,  gdrive,     colmap-loader,  760, false],
-            [deep_front_end,           lettuce-18,            12,  jpg,  gdrive,     colmap-loader,  760, false],
           ]
     defaults:
       run:


### PR DESCRIPTION
It has been failing because it used the wrong camera parameters. It can be removed from the CI now since we don't have a maintainer for it. 