### PR TITLE
Add GTSFM command

### DIFF
--- a/gtsfm_run.sh
+++ b/gtsfm_run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#!/bin/sh
+
+function gtsfm() {
+  echo 'Running GTSfM with data from' $1
+  (trap 'kill 0' SIGINT; 
+  npm start --prefix rtf_vis_tool & 
+  python gtsfm/runner/run_scene_optimizer_olssonloader.py --dataset_root $1 --image_extension JPG --config_name sift_front_end.yaml --num_workers 4)
+}

--- a/rtf_vis_tool/package.json
+++ b/rtf_vis_tool/package.json
@@ -21,7 +21,7 @@
     "three": "0.125.0"
   },
   "scripts": {
-    "start": "react-app-rewired start",
+    "start": "GENERATE_SOURCEMAP=false react-app-rewired start",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
This PR creates a `gtsfm` command that users can utilize to run both the React JS frontend and the python backend. The command follows these steps:

1. Start the React server, and provide the user with a localhost link, move the job to the background.
2. Run the `gtsfm` backend using the data path provided by the user as a foreground job.
3. After finishing running the backend, bring the react server job to the foreground again.

To enable the command locally:
`source gtsfm_run.sh`
`gtsfm <datapath>` e.g. `gtsfm tests/data/set1_lund_door`