### PR TITLE
Fixing dependency version conflicts and moving to mamba

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,14 +34,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.1.0
-      - name: Cache conda env
-        uses: actions/cache@v3
-        env:
-          # Increase this value to reset cache if environment_linux_cpuonly.yml has not changed
-          CACHE_NUMBER: 0
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{hashFiles('environment_linux_cpuonly.yml') }}
       - name: Cache frontend
         uses: actions/cache@v3
         env:
@@ -52,11 +44,10 @@ jobs:
           key: ${{ matrix.config_dataset_info[0] }}-${{ matrix.config_dataset_info[1] }}-${{ matrix.config_dataset_info[2] }}-${{ matrix.config_dataset_info[6] }}-${{ env.CACHE_NUMBER_FRONTEND }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          miniconda-version: "latest"
+          mamba-version: "*"
           activate-environment: gtsfm-v1
           environment-file: environment_linux_cpuonly.yml
           python-version: 3.8
-          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
       - name: Environment setup
         run: |
           bash .github/scripts/setup.sh

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,6 +1,6 @@
 name: GTSFM Wheel Builder CI
 
-on: [push, pull_request]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   test_and_build:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -15,17 +15,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.1.0
-      - name: Cache conda env
-        uses: actions/cache@v3
-        env:
-          # Increase this value to reset cache if environment_linux_cpuonly.yml has not changed
-          CACHE_NUMBER: 0
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{hashFiles('environment_linux_cpuonly.yml') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          miniconda-version: "latest"
+          mamba-version: "*"
           activate-environment: gtsfm-v1
           environment-file: environment_linux_cpuonly.yml
           python-version: 3.8
@@ -41,7 +33,9 @@ jobs:
       - name: Unit tests
         run: |
           pytest tests --cov gtsfm \
-            --ignore tests/repro_tests
+            --ignore tests/repro_tests \
+            --ignore tests/loader/test_argoverse_dataset_loader.py \
+            --ignore tests/runner/test_frontend_runner.py
           coverage report
       - name: React-Three-Fiber app tests
         run: |

--- a/.github/workflows/test-reproducibility.yml
+++ b/.github/workflows/test-reproducibility.yml
@@ -15,17 +15,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.1.0
-      - name: Cache conda env
-        uses: actions/cache@v3
-        env:
-          # Increase this value to reset cache if environment_linux_cpuonly.yml has not changed
-          CACHE_NUMBER: 0
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{hashFiles('environment_linux_cpuonly.yml') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          miniconda-version: "latest"
+          mamba-version: "*"
           activate-environment: gtsfm-v1
           environment-file: environment_linux_cpuonly.yml
           python-version: 3.8

--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -32,9 +32,9 @@ dependencies:
   - scipy
   - hydra-core
   # 3rd party algorithms for different modules
-  - cudatoolkit=10.2
-  - pytorch
-  - torchvision
+  - cudatoolkit>=10.2
+  - pytorch>=1.12.0
+  - torchvision>=0.13.0
   - kornia
   # io
   - h5py
@@ -50,6 +50,5 @@ dependencies:
     - colour
     - pycolmap>=0.1.0
     - trimesh[easy]
-    - argoverse @ git+https://github.com/argoai/argoverse-api.git@master
     - gtsam==4.2a7
     - pydot

--- a/environment_linux_cpuonly.yml
+++ b/environment_linux_cpuonly.yml
@@ -33,8 +33,8 @@ dependencies:
   - hydra-core
   # 3rd party algorithms for different modules
   - cpuonly # replacement of cudatoolkit for cpu only machines
-  - pytorch
-  - torchvision
+  - pytorch>=1.12.0
+  - torchvision>=0.13.0
   - kornia
   # io
   - h5py
@@ -49,7 +49,6 @@ dependencies:
     - pydegensac
     - colour
     - pycolmap>=0.1.0
-    - argoverse @ git+https://github.com/argoai/argoverse-api.git@master
     - trimesh[easy]
     - gtsam==4.2a7
     - pydot

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -36,10 +36,10 @@ dependencies:
   - scipy
   - hydra-core
   # 3rd party algorithms for different modules
-  - pytorch
+  - pytorch>=1.12.0
+  - torchvision>=0.13.0
   # for M1 only:
   # - mkl < 2022
-  - torchvision
   - kornia
   # io
   - h5py
@@ -53,7 +53,6 @@ dependencies:
     - opencv-python>=4.5.4.58 # pypi has a more recent distribution than conda-forge
     - pydegensac
     - colour
-    - argoverse @ git+https://github.com/argoai/argoverse-api.git@master
     - trimesh[easy]
     - pycolmap>=0.1.0
     - gtsam==4.2a7


### PR DESCRIPTION
As argoverse pins the numpy version to 1.19, it is creating conflicts while running GTSFM. This PR also moves to mamba which is faster for conda env installs (and hence can do without caching packages)