### PR TITLE
Loader delayed

### DIFF
--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -59,6 +59,8 @@ class LoaderBase(GTSFMProcess):
         """
         The number of images in the dataset.
 
+        Note: length should be found without loading images into memory.
+
         Returns:
             the number of images.
         """
@@ -274,6 +276,8 @@ class LoaderBase(GTSFMProcess):
     def get_all_intrinsics(self) -> List[Optional[gtsfm_types.CALIBRATION_TYPE]]:
         """Return all the camera intrinsics.
 
+        Note: use create_computation_graph_for_intrinsics when calling from runners.
+
         Returns:
             list of camera intrinsics.
         """
@@ -301,6 +305,8 @@ class LoaderBase(GTSFMProcess):
     def get_gt_cameras(self) -> List[Optional[gtsfm_types.CAMERA_TYPE]]:
         """Return all the cameras.
 
+        Note: use create_computation_graph_for_gt_cameras when calling from runners.
+
         Returns:
             List of ground truth cameras, if available.
         """
@@ -318,6 +324,8 @@ class LoaderBase(GTSFMProcess):
 
     def get_image_shapes(self) -> List[Tuple[int, int]]:
         """Return all the image shapes.
+
+        Note: use create_computation_graph_for_image_shapes when calling from runners.
 
         Returns:
             list of delayed tasks for image shapes.

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -271,12 +271,20 @@ class LoaderBase(GTSFMProcess):
         N = len(self)
         return [dask.delayed(self.get_image)(i) for i in range(N)]
 
-    # change name to create_computation_graph_for_intrinsics?
     def get_all_intrinsics(self) -> List[Optional[gtsfm_types.CALIBRATION_TYPE]]:
         """Return all the camera intrinsics.
 
         Returns:
             list of camera intrinsics.
+        """
+        N = len(self)
+        return [self.get_camera_intrinsics(i) for i in range(N)]
+
+    def create_computation_graph_for_intrinsics(self) -> List[Delayed]:
+        """Creates the computation graph for camera intrinsics.
+
+        Returns:
+            list of delayed tasks for camera intrinsics.
         """
         N = len(self)
         return [dask.delayed(self.get_camera_intrinsics)(i) for i in range(N)]
@@ -290,7 +298,6 @@ class LoaderBase(GTSFMProcess):
         N = len(self)
         return [self.get_camera_pose(i) for i in range(N)]
 
-    # change name to create_computation_graph_for_gt_cameras?
     def get_gt_cameras(self) -> List[Optional[gtsfm_types.CAMERA_TYPE]]:
         """Return all the cameras.
 
@@ -298,15 +305,27 @@ class LoaderBase(GTSFMProcess):
             List of ground truth cameras, if available.
         """
         N = len(self)
+        return [self.get_camera(i) for i in range(N)]
+
+    def create_computation_graph_for_gt_cameras(self) -> List[Delayed]:
+        """Return the computation graph for all cameras.
+
+        Returns:
+            list of delayed tasks for ground truth cameras
+        """
+        N = len(self)
         return [dask.delayed(self.get_camera)(i) for i in range(N)]
 
-    # change name to create_computation_graph_for_image_shapes?
     def get_image_shapes(self) -> List[Tuple[int, int]]:
         """Return all the image shapes.
 
         Returns:
             list of delayed tasks for image shapes.
         """
+        N = len(self)
+        return [self.get_image_shape(i) for i in range(N)]
+
+    def create_computation_graph_for_image_shapes(self) -> List[Delayed]:
         N = len(self)
         return [dask.delayed(self.get_image_shape)(i) for i in range(N)]
 

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -271,6 +271,7 @@ class LoaderBase(GTSFMProcess):
         N = len(self)
         return [dask.delayed(self.get_image)(i) for i in range(N)]
 
+    # change name to create_computation_graph_for_intrinsics?
     def get_all_intrinsics(self) -> List[Optional[gtsfm_types.CALIBRATION_TYPE]]:
         """Return all the camera intrinsics.
 
@@ -278,7 +279,7 @@ class LoaderBase(GTSFMProcess):
             list of camera intrinsics.
         """
         N = len(self)
-        return [self.get_camera_intrinsics(i) for i in range(N)]
+        return [dask.delayed(self.get_camera_intrinsics)(i) for i in range(N)]
 
     def get_gt_poses(self) -> List[Optional[Pose3]]:
         """Return all the camera poses.
@@ -289,6 +290,7 @@ class LoaderBase(GTSFMProcess):
         N = len(self)
         return [self.get_camera_pose(i) for i in range(N)]
 
+    # change name to create_computation_graph_for_gt_cameras?
     def get_gt_cameras(self) -> List[Optional[gtsfm_types.CAMERA_TYPE]]:
         """Return all the cameras.
 
@@ -296,8 +298,9 @@ class LoaderBase(GTSFMProcess):
             List of ground truth cameras, if available.
         """
         N = len(self)
-        return [self.get_camera(i) for i in range(N)]
+        return [dask.delayed(self.get_camera)(i) for i in range(N)]
 
+    # change name to create_computation_graph_for_image_shapes?
     def get_image_shapes(self) -> List[Tuple[int, int]]:
         """Return all the image shapes.
 
@@ -305,7 +308,7 @@ class LoaderBase(GTSFMProcess):
             list of delayed tasks for image shapes.
         """
         N = len(self)
-        return [self.get_image_shape(i) for i in range(N)]
+        return [dask.delayed(self.get_image_shape)(i) for i in range(N)]
 
     def get_valid_pairs(self) -> List[Tuple[int, int]]:
         """Get the valid pairs of images for this loader.

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -284,7 +284,7 @@ class LoaderBase(GTSFMProcess):
         N = len(self)
         return [self.get_camera_intrinsics(i) for i in range(N)]
 
-    def create_computation_graph_for_intrinsics(self) -> List[Delayed]:
+    def __create_computation_graph_for_intrinsics(self) -> List[Delayed]:
         """Creates the computation graph for camera intrinsics.
 
         Returns:
@@ -313,7 +313,7 @@ class LoaderBase(GTSFMProcess):
         N = len(self)
         return [self.get_camera(i) for i in range(N)]
 
-    def create_computation_graph_for_gt_cameras(self) -> List[Delayed]:
+    def __create_computation_graph_for_gt_cameras(self) -> List[Delayed]:
         """Return the computation graph for all cameras.
 
         Returns:
@@ -333,7 +333,7 @@ class LoaderBase(GTSFMProcess):
         N = len(self)
         return [self.get_image_shape(i) for i in range(N)]
 
-    def create_computation_graph_for_image_shapes(self) -> List[Delayed]:
+    def __create_computation_graph_for_image_shapes(self) -> List[Delayed]:
         N = len(self)
         return [dask.delayed(self.get_image_shape)(i) for i in range(N)]
 

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -273,7 +273,7 @@ class LoaderBase(GTSFMProcess):
         N = len(self)
         return [dask.delayed(self.get_image)(i) for i in range(N)]
 
-    def get_all_intrinsics(self) -> List[Optional[gtsfm_types.CALIBRATION_TYPE]]:
+    def __get_all_intrinsics(self) -> List[Optional[gtsfm_types.CALIBRATION_TYPE]]:
         """Return all the camera intrinsics.
 
         Note: use create_computation_graph_for_intrinsics when calling from runners.
@@ -284,7 +284,7 @@ class LoaderBase(GTSFMProcess):
         N = len(self)
         return [self.get_camera_intrinsics(i) for i in range(N)]
 
-    def __create_computation_graph_for_intrinsics(self) -> List[Delayed]:
+    def create_computation_graph_for_intrinsics(self) -> List[Delayed]:
         """Creates the computation graph for camera intrinsics.
 
         Returns:
@@ -302,7 +302,7 @@ class LoaderBase(GTSFMProcess):
         N = len(self)
         return [self.get_camera_pose(i) for i in range(N)]
 
-    def get_gt_cameras(self) -> List[Optional[gtsfm_types.CAMERA_TYPE]]:
+    def __get_gt_cameras(self) -> List[Optional[gtsfm_types.CAMERA_TYPE]]:
         """Return all the cameras.
 
         Note: use create_computation_graph_for_gt_cameras when calling from runners.
@@ -313,7 +313,7 @@ class LoaderBase(GTSFMProcess):
         N = len(self)
         return [self.get_camera(i) for i in range(N)]
 
-    def __create_computation_graph_for_gt_cameras(self) -> List[Delayed]:
+    def create_computation_graph_for_gt_cameras(self) -> List[Delayed]:
         """Return the computation graph for all cameras.
 
         Returns:
@@ -322,7 +322,7 @@ class LoaderBase(GTSFMProcess):
         N = len(self)
         return [dask.delayed(self.get_camera)(i) for i in range(N)]
 
-    def get_image_shapes(self) -> List[Tuple[int, int]]:
+    def __get_image_shapes(self) -> List[Tuple[int, int]]:
         """Return all the image shapes.
 
         Note: use create_computation_graph_for_image_shapes when calling from runners.
@@ -333,7 +333,7 @@ class LoaderBase(GTSFMProcess):
         N = len(self)
         return [self.get_image_shape(i) for i in range(N)]
 
-    def __create_computation_graph_for_image_shapes(self) -> List[Delayed]:
+    def create_computation_graph_for_image_shapes(self) -> List[Delayed]:
         N = len(self)
         return [dask.delayed(self.get_image_shape)(i) for i in range(N)]
 

--- a/gtsfm/runner/frontend_runner.py
+++ b/gtsfm/runner/frontend_runner.py
@@ -41,13 +41,11 @@ def run_frontend(
     image_pair_indices = loader.get_valid_pairs()
     camera_intrinsics_graph = loader.create_computation_graph_for_intrinsics()
     image_shapes_graph = loader.create_computation_graph_for_image_shapes()
-    
-    [image_shapes] = dask.compute(image_shapes_graph)
-    [camera_intrinsics] = dask.compute(camera_intrinsics_graph)
 
+    # TODO(stepanyanhayk) change function signature to only accept delayed objects
     (delayed_keypoints, delayed_putative_corr_idxs_dict,) = correspondence_generator.create_computation_graph(
         delayed_images=loader.create_computation_graph_for_images(),
-        image_shapes=image_shapes,
+        image_shapes=image_shapes_graph,
         image_pair_indices=image_pair_indices,
     )
 
@@ -64,10 +62,10 @@ def run_frontend(
             keypoints_i1_graph=keypoints_list[i1],
             keypoints_i2_graph=keypoints_list[i2],
             putative_corr_idxs_graph=putative_corr_idxs_dict[i1, i2],
-            camera_intrinsics_i1=camera_intrinsics[i1],
-            camera_intrinsics_i2=camera_intrinsics[i2],
-            im_shape_i1=image_shapes[i1],
-            im_shape_i2=image_shapes[i2],
+            camera_intrinsics_i1=camera_intrinsics_graph[i1],
+            camera_intrinsics_i2=camera_intrinsics_graph[i2],
+            im_shape_i1=image_shapes_graph[i1],
+            im_shape_i2=image_shapes_graph[i2],
         )
 
         # Store results.

--- a/gtsfm/runner/frontend_runner.py
+++ b/gtsfm/runner/frontend_runner.py
@@ -39,12 +39,15 @@ def run_frontend(
         v_corr_idxs_dict: verified correspondence indices for each image pair.
     """
     image_pair_indices = loader.get_valid_pairs()
-    camera_intrinsics = loader.get_all_intrinsics()
-    image_shapes = loader.get_image_shapes()
+    camera_intrinsics_graph = loader.create_computation_graph_for_intrinsics()
+    image_shapes_graph = loader.create_computation_graph_for_image_shapes()
+    
+    [image_shapes] = dask.compute(image_shapes_graph)
+    [camera_intrinsics] = dask.compute(camera_intrinsics_graph)
 
     (delayed_keypoints, delayed_putative_corr_idxs_dict,) = correspondence_generator.create_computation_graph(
         delayed_images=loader.create_computation_graph_for_images(),
-        image_shapes=loader.get_image_shapes(),
+        image_shapes=image_shapes,
         image_pair_indices=image_pair_indices,
     )
 

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -222,7 +222,7 @@ class GtsfmRunnerBase:
             delayed_putative_corr_idxs_dict,
         ) = self.scene_optimizer.correspondence_generator.create_computation_graph(
             delayed_images=self.loader.create_computation_graph_for_images(),
-            image_shapes=self.loader.get_image_shapes(),
+            image_shapes=self.loader.create_computation_graph_for_image_shapes(),
             image_pair_indices=image_pair_indices,
         )
 
@@ -235,11 +235,11 @@ class GtsfmRunnerBase:
             num_images=len(self.loader),
             image_pair_indices=image_pair_indices,
             image_graph=self.loader.create_computation_graph_for_images(),
-            all_intrinsics=self.loader.get_all_intrinsics(),
-            image_shapes=self.loader.get_image_shapes(),
+            all_intrinsics=self.loader.create_computation_graph_for_intrinsics(),
+            image_shapes=self.loader.create_computation_graph_for_image_shapes(),
             relative_pose_priors=self.loader.get_relative_pose_priors(image_pair_indices),
             absolute_pose_priors=self.loader.get_absolute_pose_priors(),
-            cameras_gt=self.loader.get_gt_cameras(),
+            cameras_gt=self.loader.create_computation_graph_for_gt_cameras(),
             gt_wTi_list=self.loader.get_gt_poses(),
             matching_regime=ImageMatchingRegime(self.parsed_args.matching_regime),
         )

--- a/gtsfm/runner/run_scene_optimizer_argoverse.py
+++ b/gtsfm/runner/run_scene_optimizer_argoverse.py
@@ -34,9 +34,9 @@ def run_scene_optimizer(args: argparse.Namespace) -> None:
             num_images=len(loader),
             image_pair_indices=loader.get_valid_pairs(),
             image_graph=loader.create_computation_graph_for_images(),
-            all_intrinsics=loader.get_all_intrinsics(),
-            image_shapes=loader.get_image_shapes(),
-            cameras_gt=loader.get_gt_cameras(),
+            all_intrinsics=loader.get_computation_graph_for_intrinsics(),
+            image_shapes=loader.create_computation_graph_for_image_shapes(),
+            cameras_gt=loader.create_computation_graph_for_gt_cameras(),
         )
 
         # create dask client

--- a/gtsfm/runner/run_scene_optimizer_astrovision.py
+++ b/gtsfm/runner/run_scene_optimizer_astrovision.py
@@ -68,7 +68,7 @@ class GtsfmRunnerAstrovisionLoader(GtsfmRunnerBase):
                 delayed_putative_corr_idxs_dict,
             ) = self.scene_optimizer.correspondence_generator.create_computation_graph(
                 delayed_images=self.loader.create_computation_graph_for_images(),
-                image_shapes=self.loader.get_image_shapes(),
+                image_shapes=self.loader.create_computation_graph_for_image_shapes(),
                 image_pair_indices=image_pair_indices,
             )
             keypoints_list, putative_corr_idxs_dict = dask.compute(delayed_keypoints, delayed_putative_corr_idxs_dict)
@@ -84,10 +84,10 @@ class GtsfmRunnerAstrovisionLoader(GtsfmRunnerBase):
                 image_pair_indices=image_pair_indices,
                 image_graph=self.loader.create_computation_graph_for_images(),
                 all_intrinsics=self.loader.get_all_intrinsics(),
-                image_shapes=self.loader.get_image_shapes(),
+                image_shapes=self.loader.create_computation_graph_for_image_shapes(),
                 relative_pose_priors=self.loader.get_relative_pose_priors(image_pair_indices),
                 absolute_pose_priors=self.loader.get_absolute_pose_priors(),
-                cameras_gt=self.loader.get_gt_cameras(),
+                cameras_gt=self.loader.create_computation_graph_for_gt_cameras(),
                 gt_wTi_list=self.loader.get_gt_poses(),
                 matching_regime=ImageMatchingRegime(self.parsed_args.matching_regime),
                 gt_scene_mesh=gt_scene_trimesh_future,

--- a/gtsfm/runner/run_scene_optimizer_astrovision.py
+++ b/gtsfm/runner/run_scene_optimizer_astrovision.py
@@ -83,7 +83,7 @@ class GtsfmRunnerAstrovisionLoader(GtsfmRunnerBase):
                 num_images=len(self.loader),
                 image_pair_indices=image_pair_indices,
                 image_graph=self.loader.create_computation_graph_for_images(),
-                all_intrinsics=self.loader.get_all_intrinsics(),
+                all_intrinsics=self.loader.create_computation_graph_for_intrinsics(),
                 image_shapes=self.loader.create_computation_graph_for_image_shapes(),
                 relative_pose_priors=self.loader.get_relative_pose_priors(image_pair_indices),
                 absolute_pose_priors=self.loader.get_absolute_pose_priors(),

--- a/tests/loader/test_olsson_loader.py
+++ b/tests/loader/test_olsson_loader.py
@@ -130,7 +130,8 @@ class TestFolderLoader(unittest.TestCase):
     def test_get_all_intrinsics(self) -> None:
         """Tests the graph for all intrinsics."""
 
-        all_intrinsics = self.loader.get_all_intrinsics()
+        all_intrinsics_graph = self.loader.create_computation_graph_for_intrinsics()
+        [all_intrinsics] = dask.compute(all_intrinsics_graph)
 
         # check the length of the graph
         self.assertEqual(12, len(all_intrinsics))

--- a/tests/test_scene_optimizer.py
+++ b/tests/test_scene_optimizer.py
@@ -54,7 +54,7 @@ class TestSceneOptimizer(unittest.TestCase):
                 delayed_putative_corr_idxs_dict,
             ) = scene_optimizer.correspondence_generator.create_computation_graph(
                 delayed_images=self.loader.create_computation_graph_for_images(),
-                image_shapes=self.loader.get_image_shapes(),
+                image_shapes=self.loader.create_computation_graph_for_image_shapes(),
                 image_pair_indices=image_pair_indices,
             )
 
@@ -70,11 +70,11 @@ class TestSceneOptimizer(unittest.TestCase):
                 num_images=len(self.loader),
                 image_pair_indices=image_pair_indices,
                 image_graph=self.loader.create_computation_graph_for_images(),
-                all_intrinsics=self.loader.get_all_intrinsics(),
-                image_shapes=self.loader.get_image_shapes(),
+                all_intrinsics=self.loader.create_computation_graph_for_intrinsics(),
+                image_shapes=self.loader.create_computation_graph_for_image_shapes(),
                 absolute_pose_priors=self.loader.get_absolute_pose_priors(),
                 relative_pose_priors=self.loader.get_relative_pose_priors(image_pair_indices),
-                cameras_gt=self.loader.get_gt_cameras(),
+                cameras_gt=self.loader.create_computation_graph_for_gt_cameras(),
                 gt_wTi_list=self.loader.get_gt_poses(),
                 matching_regime=ImageMatchingRegime(matching_regime),
             )


### PR DESCRIPTION
In our efforts to run gtsfm on a cluster, we need to specify a worker/machine that would do the IO and share the data with other machines. To do this we need all our input to be delayed (so we can use dask to specify which worker should do the computation of the delayed task). This PR disallows all the direct access from `LoaderBase` to the images by creating dask computation graphs for the input.