### PR TITLE
SSHCluster Runner

### DIFF
--- a/gtsfm/configs/cluster.yaml
+++ b/gtsfm/configs/cluster.yaml
@@ -1,3 +1,5 @@
+# replace by names of host machines, first worker is used for I/O
+
 workers:
   - host1.cc.gatech.edu
   - host2.cc.gatech.edu

--- a/gtsfm/configs/cluster.yaml
+++ b/gtsfm/configs/cluster.yaml
@@ -1,0 +1,4 @@
+workers:
+  - host1.cc.gatech.edu
+  - host2.cc.gatech.edu
+  - host3.cc.gatech.edu

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -138,7 +138,7 @@ class GtsfmRunnerBase:
             type=str,
             default=None,
             nargs="+",
-            help="list of worker ip addresses for the cluster"
+            help="list of worker ip addresses for the cluster, first worker is used as scheduler and should contain the dataset",
         )
         parser.add_argument(
             "--dashboard_address",

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -284,7 +284,7 @@ class GtsfmRunnerBase:
         with performance_report(filename="scene-optimizer-dask-report.html"):
             sfm_result = client.compute(delayed_sfm_result).result()
             future_io = client.compute(delayed_io)
-            io = [io_task.result() for io_task in future_io]
+            (*io, ) = [io_task.result() for io_task in future_io]
 
         assert isinstance(sfm_result, GtsfmData)
 

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -283,8 +283,8 @@ class GtsfmRunnerBase:
 
         with performance_report(filename="scene-optimizer-dask-report.html"):
             sfm_result = client.compute(delayed_sfm_result).result()
-            io_future = client.compute(delayed_io)
-            io = [io_task.result() for io_task in io_future]
+            future_io = client.compute(delayed_io)
+            io = [io_task.result() for io_task in future_io]
 
         assert isinstance(sfm_result, GtsfmData)
 

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -228,7 +228,10 @@ class GtsfmRunnerBase:
             cluster = SSHCluster(
                 [scheduler] + workers,
                 scheduler_options={"dashboard_address": self.parsed_args.dashboard_address},
-                worker_options={"n_workers": self.parsed_args.num_workers},
+                worker_options={
+                    "n_workers": self.parsed_args.num_workers,
+                    "nthreads": self.parsed_args.threads_per_worker
+                },
             )
             client = Client(cluster)
             self.loader._input_worker = list(client.scheduler_info()["workers"].keys())[0]

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -135,10 +135,16 @@ class GtsfmRunnerBase:
         )
         parser.add_argument(
             "--cluster_workers",
-            default=None,
             type=str,
+            default=None,
             nargs="+",
             help="list of worker ip addresses for the cluster"
+        )
+        parser.add_argument(
+            "--dashboard_address",
+            type=str,
+            default=":8787",
+            help="dask dashboard port number",
         )
         return parser
 
@@ -221,11 +227,11 @@ class GtsfmRunnerBase:
             scheduler = workers[0]
             cluster = SSHCluster(
                 [scheduler] + workers,
-                scheduler_options={"port": 0, "dashboard_address": ":8795"},
-                worker_options={"n_workers": self.parsed_args.num_workers}, # num workers per machine
+                scheduler_options={"dashboard_address": self.parsed_args.dashboard_address},
+                worker_options={"n_workers": self.parsed_args.num_workers},
             )
             client = Client(cluster)
-            self.loader._input_worker = list(client.scheduler_info()['workers'].keys())[0]
+            self.loader._input_worker = list(client.scheduler_info()["workers"].keys())[0]
         else:
             cluster = LocalCluster(
                 n_workers=self.parsed_args.num_workers, threads_per_worker=self.parsed_args.threads_per_worker

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -245,7 +245,7 @@ class GtsfmRunnerBase:
         process_graph_generator.save_graph()
 
         pairs_graph = self.retriever.create_computation_graph(self.loader)
-        with Client(cluster), performance_report(filename="retriever-dask-report.html"):
+        with performance_report(filename="retriever-dask-report.html"):
             image_pair_indices = pairs_graph.compute()
 
         (
@@ -257,7 +257,7 @@ class GtsfmRunnerBase:
             image_pair_indices=image_pair_indices,
         )
 
-        with Client(cluster), performance_report(filename="correspondence-generator-dask-report.html"):
+        with performance_report(filename="correspondence-generator-dask-report.html"):
             keypoints_list, putative_corr_idxs_dict = dask.compute(delayed_keypoints, delayed_putative_corr_idxs_dict)
 
         delayed_sfm_result, delayed_io = self.scene_optimizer.create_computation_graph(
@@ -275,7 +275,7 @@ class GtsfmRunnerBase:
             matching_regime=ImageMatchingRegime(self.parsed_args.matching_regime),
         )
 
-        with Client(cluster), performance_report(filename="scene-optimizer-dask-report.html"):
+        with performance_report(filename="scene-optimizer-dask-report.html"):
             sfm_result, *io = dask.compute(delayed_sfm_result, *delayed_io)
 
         assert isinstance(sfm_result, GtsfmData)

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -224,7 +224,8 @@ class GtsfmRunnerBase:
         # create dask cluster
         if self.parsed_args.run_cluster:
             workers = OmegaConf.load(
-                os.path.join(self.parsed_args.output_root, "gtsfm", "configs", self.parsed_args.cluster_config_name))["workers"]
+                os.path.join(
+                    self.parsed_args.output_root, "gtsfm", "configs", self.parsed_args.cluster_config_name))["workers"]
             scheduler = workers[0]
             cluster = SSHCluster(
                 [scheduler] + workers,
@@ -235,6 +236,7 @@ class GtsfmRunnerBase:
                 },
             )
             client = Client(cluster)
+            # getting first worker's IP address and port to do IO
             io_worker = list(client.scheduler_info()["workers"].keys())[0]
             self.loader._input_worker = io_worker
             self.scene_optimizer._output_worker = io_worker

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -224,13 +224,13 @@ class GtsfmRunnerBase:
                 scheduler_options={"port": 0, "dashboard_address": ":8795"},
                 worker_options={"n_workers": self.parsed_args.num_workers}, # num workers per machine
             )
-            self.loader._input_worker = scheduler
+            client = Client(cluster)
+            self.loader._input_worker = list(client.scheduler_info()['workers'].keys())[0]
         else:
             cluster = LocalCluster(
                 n_workers=self.parsed_args.num_workers, threads_per_worker=self.parsed_args.threads_per_worker
             )
-
-        client = Client(cluster)
+            client = Client(cluster)
 
         # create process graph
         process_graph_generator = ProcessGraphGenerator()

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -141,7 +141,7 @@ class GtsfmRunnerBase:
             help="list of worker ip addresses for the cluster, first worker is used as scheduler and should contain the dataset",
         )
         parser.add_argument(
-            "--dashboard_address",
+            "--dashboard_port",
             type=str,
             default=":8787",
             help="dask dashboard port number",
@@ -227,7 +227,7 @@ class GtsfmRunnerBase:
             scheduler = workers[0]
             cluster = SSHCluster(
                 [scheduler] + workers,
-                scheduler_options={"dashboard_address": self.parsed_args.dashboard_address},
+                scheduler_options={"dashboard_address": self.parsed_args.dashboard_port},
                 worker_options={
                     "n_workers": self.parsed_args.num_workers,
                     "nthreads": self.parsed_args.threads_per_worker

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -134,7 +134,7 @@ class GtsfmRunnerBase:
             help="whether to run gtsfm on a cluster"
         )
         parser.add_argument(
-            "--cluster_config_name",
+            "--cluster_config",
             type=str,
             default="cluster.yaml",
             help="config listing IP worker addresses for the cluster,"
@@ -225,7 +225,7 @@ class GtsfmRunnerBase:
         if self.parsed_args.run_cluster:
             workers = OmegaConf.load(
                 os.path.join(
-                    self.parsed_args.output_root, "gtsfm", "configs", self.parsed_args.cluster_config_name))["workers"]
+                    self.parsed_args.output_root, "gtsfm", "configs", self.parsed_args.cluster_config))["workers"]
             scheduler = workers[0]
             cluster = SSHCluster(
                 [scheduler] + workers,

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -138,7 +138,8 @@ class GtsfmRunnerBase:
             type=str,
             default=None,
             nargs="+",
-            help="list of worker ip addresses for the cluster, first worker is used as scheduler and should contain the dataset",
+            help="list of worker ip addresses for the cluster," 
+            " first worker is used as scheduler and should contain the dataset",
         )
         parser.add_argument(
             "--dashboard_port",

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -128,15 +128,9 @@ class GtsfmRunnerBase:
             help="tmp directory for dask workers, uses dask's default (/tmp) if not set",
         )
         parser.add_argument(
-            "--run_cluster",
-            action="store_true",
-            default=False,
-            help="whether to run gtsfm on a cluster"
-        )
-        parser.add_argument(
             "--cluster_config",
             type=str,
-            default="cluster.yaml",
+            default=None,
             help="config listing IP worker addresses for the cluster,"
             " first worker is used as scheduler and should contain the dataset",
         )
@@ -222,7 +216,7 @@ class GtsfmRunnerBase:
         start_time = time.time()
 
         # create dask cluster
-        if self.parsed_args.run_cluster:
+        if self.parsed_args.cluster_config:
             workers = OmegaConf.load(
                 os.path.join(
                     self.parsed_args.output_root, "gtsfm", "configs", self.parsed_args.cluster_config))["workers"]


### PR DESCRIPTION
In this PR we are introducing an option to run gtsfm on a cluster using [SSHCluster](https://docs.dask.org/en/stable/deploying-ssh.html#dask.distributed.SSHCluster) class from dask. Command line takes the IP addresses of the workers as arguments. My current implementation assumes that the first worker (indexed at 0 in the list) will be responsible for the data input.