### PR TITLE
save with absolute path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,7 +153,7 @@ data/
 *.DS_Store
 
 # Data dumped by GTSFM directory
-debugging/
+debug/
 plots/
 results/
 result_metrics/

--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,7 @@ data/
 *.DS_Store
 
 # Data dumped by GTSFM directory
+debugging/
 plots/
 results/
 result_metrics/

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -27,6 +27,7 @@ from gtsfm.data_association.dsf_tracks_estimator import DsfTracksEstimator
 
 DEFAULT_OUTPUT_ROOT = Path(__file__).resolve().parent.parent
 
+
 class MultiViewOptimizer:
     def __init__(
         self,
@@ -98,7 +99,13 @@ class MultiViewOptimizer:
                 viewgraph_two_view_reports_graph,
                 viewgraph_estimation_metrics,
             ) = self.view_graph_estimator.create_computation_graph(
-                i2Ri1_graph, i2Ui1_graph, all_intrinsics, v_corr_idxs_graph, keypoints_graph, two_view_reports_dict, self._plot_cycle_consist_path
+                i2Ri1_graph,
+                i2Ui1_graph,
+                all_intrinsics,
+                v_corr_idxs_graph,
+                keypoints_graph,
+                two_view_reports_dict,
+                self._plot_cycle_consist_path
             )
         else:
             viewgraph_i2Ri1_graph = dask.delayed(i2Ri1_graph)

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -43,16 +43,13 @@ class MultiViewOptimizer:
         self.data_association_module = data_association_module
         self.ba_optimizer = bundle_adjustment_module
         self._run_view_graph_estimator: bool = self.view_graph_estimator is not None
-        self._create_debugging_directories()
+        self._create_debug_directories()
 
-    def _create_debugging_directories(self) -> None:
+    def _create_debug_directories(self) -> None:
         """Create output directories for GTSFM result debugging."""
 
-        self._debug_output_dir = DEFAULT_OUTPUT_ROOT / "debugging"
-        self._plot_cycle_consist_path = self._debug_output_dir / "cycle_consistency" / "plots"
-        
+        self._debug_output_dir = DEFAULT_OUTPUT_ROOT / "debug"
         os.makedirs(self._debug_output_dir, exist_ok=True)
-        os.makedirs(self._plot_cycle_consist_path, exist_ok=True)
 
     def create_computation_graph(
         self,
@@ -105,7 +102,7 @@ class MultiViewOptimizer:
                 v_corr_idxs_graph,
                 keypoints_graph,
                 two_view_reports_dict,
-                self._plot_cycle_consist_path
+                self._debug_output_dir,
             )
         else:
             viewgraph_i2Ri1_graph = dask.delayed(i2Ri1_graph)

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -6,8 +6,8 @@ from typing import Dict, List, Optional, Tuple
 
 import dask
 import numpy as np
-from dask.delayed import Delayed
 import os
+from dask.delayed import Delayed
 from pathlib import Path
 from gtsam import Pose3
 

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -249,6 +249,7 @@ class SceneOptimizer:
             two_view_reports_dict[POST_ISP_REPORT_TAG],
             cameras_gt,
             gt_wTi_list,
+            self.output_root,
         )
         if view_graph_two_view_reports is not None:
             two_view_reports_dict[VIEWGRAPH_REPORT_TAG] = view_graph_two_view_reports

--- a/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
+++ b/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
@@ -93,6 +93,7 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
             corr_idxs_i1i2: Dict from (i1, i2) to indices of verified correspondences from i1 to i2 (unused).
             keypoints: keypoints for each images (unused).
             two_view_reports: Dict from (i1, i2) to the TwoViewEstimationReport of the edge.
+            output_dir: Path to directory where outputs for debugging will be saved.
 
         Returns:
             Edges of the view-graph, which are the subset of the image pairs in the input args.

--- a/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
+++ b/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
@@ -5,6 +5,7 @@ Authors: John Lambert, Ayush Baid, Akshay Krishnan
 import os
 from collections import defaultdict
 from enum import Enum
+from pathlib import Path
 from typing import Dict, List, Set, Tuple
 
 import matplotlib.pyplot as plt
@@ -25,6 +26,7 @@ ERROR_THRESHOLD = 7.0
 
 # threshold for evaluation w.r.t. GT
 MAX_INLIER_MEASUREMENT_ERROR_DEG = 5.0
+DEFAULT_OUTPUT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
 class EdgeErrorAggregationCriterion(str, Enum):
@@ -186,14 +188,16 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
         plt.ylabel("Rotation error w.r.t GT")
         plt.axis("equal")
         plt.legend(loc="lower right")
-        plt.savefig(os.path.join("plots", f"gt_err_vs_{self._edge_error_aggregation_criterion}_agg_error.jpg"), dpi=400)
+        plt.savefig(os.path.join(
+            DEFAULT_OUTPUT_ROOT, "plots", f"gt_err_vs_{self._edge_error_aggregation_criterion}_agg_error.jpg"), dpi=400)
         plt.close("all")
 
         plt.scatter(cycle_errors, max_gt_error_in_cycle)
         plt.xlabel("Cycle error")
         plt.ylabel("Avg. Rot3 error over cycle triplet")
         plt.axis("equal")
-        plt.savefig(os.path.join("plots", "cycle_error_vs_GT_rot_error.jpg"), dpi=400)
+        plt.savefig(os.path.join(
+            DEFAULT_OUTPUT_ROOT, "plots", "cycle_error_vs_GT_rot_error.jpg"), dpi=400)
         plt.close("all")
 
     def __aggregate_errors_for_edge(self, edge_errors: List[float]) -> float:

--- a/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
+++ b/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
@@ -6,7 +6,7 @@ import os
 from collections import defaultdict
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -82,7 +82,7 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
         corr_idxs_i1i2: Dict[Tuple[int, int], np.ndarray],
         keypoints: List[Keypoints],
         two_view_reports: Dict[Tuple[int, int], TwoViewEstimationReport],
-        output_dir: Path,
+        output_dir: Optional[Path] = None,
     ) -> Set[Tuple[int, int]]:
         """Estimates the view graph using the rotation consistency constraint in a cycle of 3 edges.
 
@@ -133,8 +133,9 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
             pair_indices: self.__aggregate_errors_for_edge(errors) for pair_indices, errors in per_edge_errors.items()
         }
         valid_edges = {edge for edge, error in per_edge_aggregate_error.items() if error < self._error_threshold}
-        self.__save_plots(
-            valid_edges, cycle_errors, max_gt_error_in_cycle, per_edge_aggregate_error, two_view_reports, output_dir)
+        if output_dir:
+            self.__save_plots(
+                valid_edges, cycle_errors, max_gt_error_in_cycle, per_edge_aggregate_error, two_view_reports, output_dir)
 
         logger.info("Found %d consistent rel. rotations from %d original edges.", len(valid_edges), len(input_edges))
 

--- a/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
+++ b/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
@@ -135,7 +135,12 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
         valid_edges = {edge for edge, error in per_edge_aggregate_error.items() if error < self._error_threshold}
         if output_dir:
             self.__save_plots(
-                valid_edges, cycle_errors, max_gt_error_in_cycle, per_edge_aggregate_error, two_view_reports, output_dir)
+                valid_edges,
+                cycle_errors,
+                max_gt_error_in_cycle,
+                per_edge_aggregate_error,
+                two_view_reports,
+                output_dir)
 
         logger.info("Found %d consistent rel. rotations from %d original edges.", len(valid_edges), len(input_edges))
 

--- a/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
+++ b/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
@@ -26,7 +26,6 @@ ERROR_THRESHOLD = 7.0
 
 # threshold for evaluation w.r.t. GT
 MAX_INLIER_MEASUREMENT_ERROR_DEG = 5.0
-DEFAULT_OUTPUT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
 class EdgeErrorAggregationCriterion(str, Enum):

--- a/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
+++ b/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
@@ -83,7 +83,7 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
         corr_idxs_i1i2: Dict[Tuple[int, int], np.ndarray],
         keypoints: List[Keypoints],
         two_view_reports: Dict[Tuple[int, int], TwoViewEstimationReport],
-        debug_output_dir: str,
+        output_dir: str,
     ) -> Set[Tuple[int, int]]:
         """Estimates the view graph using the rotation consistency constraint in a cycle of 3 edges.
 
@@ -133,7 +133,8 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
             pair_indices: self.__aggregate_errors_for_edge(errors) for pair_indices, errors in per_edge_errors.items()
         }
         valid_edges = {edge for edge, error in per_edge_aggregate_error.items() if error < self._error_threshold}
-        self.__save_plots(valid_edges, cycle_errors, max_gt_error_in_cycle, per_edge_aggregate_error, two_view_reports, debug_output_dir)
+        self.__save_plots(
+            valid_edges, cycle_errors, max_gt_error_in_cycle, per_edge_aggregate_error, two_view_reports, output_dir)
 
         logger.info("Found %d consistent rel. rotations from %d original edges.", len(valid_edges), len(input_edges))
 
@@ -146,7 +147,7 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
         max_gt_error_in_cycle: List[float],
         per_edge_aggregate_error: Dict[Tuple[int, int], float],
         two_view_reports_dict: Dict[Tuple[int, int], TwoViewEstimationReport],
-        debug_output_dir: Path,
+        output_dir: Path,
     ) -> None:
         """Saves plots of aggregate error vs GT error for each edge, and cyclic error vs max GT error for each cycle.
 
@@ -156,7 +157,7 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
             max_gt_error_in_cycle: Maximum GT rotation error in the cycle, for all cycles.
             per_edge_aggregate_error: Dict from edge index pair to aggregate cyclic error of the edge.
             two_view_reports_dict: Dict from edge index pair to the TwoViewEstimationReport of the edge.
-            debug_output_dir: Path to directory where outputs for debugging will be saved.
+            output_dir: Path to directory where outputs for debugging will be saved.
         """
         # aggregate info over per edge_errors
         inlier_errors_aggregate = []
@@ -191,14 +192,15 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
         plt.ylabel("Rotation error w.r.t GT")
         plt.axis("equal")
         plt.legend(loc="lower right")
-        plt.savefig(os.path.join(debug_output_dir, f"gt_err_vs_{self._edge_error_aggregation_criterion}_agg_error.jpg"), dpi=400)
+        plt.savefig(
+            os.path.join(output_dir, f"gt_err_vs_{self._edge_error_aggregation_criterion}_agg_error.jpg"), dpi=400)
         plt.close("all")
 
         plt.scatter(cycle_errors, max_gt_error_in_cycle)
         plt.xlabel("Cycle error")
         plt.ylabel("Avg. Rot3 error over cycle triplet")
         plt.axis("equal")
-        plt.savefig(os.path.join(debug_output_dir, "cycle_error_vs_GT_rot_error.jpg"), dpi=400)
+        plt.savefig(os.path.join(output_dir, "cycle_error_vs_GT_rot_error.jpg"), dpi=400)
         plt.close("all")
 
     def __aggregate_errors_for_edge(self, edge_errors: List[float]) -> float:

--- a/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
+++ b/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
@@ -82,7 +82,7 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
         corr_idxs_i1i2: Dict[Tuple[int, int], np.ndarray],
         keypoints: List[Keypoints],
         two_view_reports: Dict[Tuple[int, int], TwoViewEstimationReport],
-        output_dir: str,
+        output_dir: Path,
     ) -> Set[Tuple[int, int]]:
         """Estimates the view graph using the rotation consistency constraint in a cycle of 3 edges.
 

--- a/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
+++ b/gtsfm/view_graph_estimator/cycle_consistent_rotation_estimator.py
@@ -83,6 +83,7 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
         corr_idxs_i1i2: Dict[Tuple[int, int], np.ndarray],
         keypoints: List[Keypoints],
         two_view_reports: Dict[Tuple[int, int], TwoViewEstimationReport],
+        debug_output_dir: str,
     ) -> Set[Tuple[int, int]]:
         """Estimates the view graph using the rotation consistency constraint in a cycle of 3 edges.
 
@@ -132,7 +133,7 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
             pair_indices: self.__aggregate_errors_for_edge(errors) for pair_indices, errors in per_edge_errors.items()
         }
         valid_edges = {edge for edge, error in per_edge_aggregate_error.items() if error < self._error_threshold}
-        self.__save_plots(valid_edges, cycle_errors, max_gt_error_in_cycle, per_edge_aggregate_error, two_view_reports)
+        self.__save_plots(valid_edges, cycle_errors, max_gt_error_in_cycle, per_edge_aggregate_error, two_view_reports, debug_output_dir)
 
         logger.info("Found %d consistent rel. rotations from %d original edges.", len(valid_edges), len(input_edges))
 
@@ -145,6 +146,7 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
         max_gt_error_in_cycle: List[float],
         per_edge_aggregate_error: Dict[Tuple[int, int], float],
         two_view_reports_dict: Dict[Tuple[int, int], TwoViewEstimationReport],
+        debug_output_dir: Path,
     ) -> None:
         """Saves plots of aggregate error vs GT error for each edge, and cyclic error vs max GT error for each cycle.
 
@@ -154,6 +156,7 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
             max_gt_error_in_cycle: Maximum GT rotation error in the cycle, for all cycles.
             per_edge_aggregate_error: Dict from edge index pair to aggregate cyclic error of the edge.
             two_view_reports_dict: Dict from edge index pair to the TwoViewEstimationReport of the edge.
+            debug_output_dir: Path to directory where outputs for debugging will be saved.
         """
         # aggregate info over per edge_errors
         inlier_errors_aggregate = []
@@ -188,16 +191,14 @@ class CycleConsistentRotationViewGraphEstimator(ViewGraphEstimatorBase):
         plt.ylabel("Rotation error w.r.t GT")
         plt.axis("equal")
         plt.legend(loc="lower right")
-        plt.savefig(os.path.join(
-            DEFAULT_OUTPUT_ROOT, "plots", f"gt_err_vs_{self._edge_error_aggregation_criterion}_agg_error.jpg"), dpi=400)
+        plt.savefig(os.path.join(debug_output_dir, f"gt_err_vs_{self._edge_error_aggregation_criterion}_agg_error.jpg"), dpi=400)
         plt.close("all")
 
         plt.scatter(cycle_errors, max_gt_error_in_cycle)
         plt.xlabel("Cycle error")
         plt.ylabel("Avg. Rot3 error over cycle triplet")
         plt.axis("equal")
-        plt.savefig(os.path.join(
-            DEFAULT_OUTPUT_ROOT, "plots", "cycle_error_vs_GT_rot_error.jpg"), dpi=400)
+        plt.savefig(os.path.join(debug_output_dir, "cycle_error_vs_GT_rot_error.jpg"), dpi=400)
         plt.close("all")
 
     def __aggregate_errors_for_edge(self, edge_errors: List[float]) -> float:

--- a/gtsfm/view_graph_estimator/view_graph_estimator_base.py
+++ b/gtsfm/view_graph_estimator/view_graph_estimator_base.py
@@ -255,7 +255,7 @@ class ViewGraphEstimatorBase(GTSFMProcess):
         corr_idxs_i1i2: Dict[Tuple[int, int], Delayed],
         keypoints: List[Delayed],
         two_view_reports: Optional[Dict[Tuple[int, int], TwoViewEstimationReport]],
-        debug_output_dir: Path,
+        debug_output_dir: Optional[Path] = None,
     ) -> Tuple[Delayed, Delayed, Delayed, Delayed, Delayed]:
         """Create the computation graph for ViewGraph estimation and metric evaluation.
 
@@ -280,8 +280,9 @@ class ViewGraphEstimatorBase(GTSFMProcess):
         """
 
         # create debug directory for cycle_consistency
-        self._plot_cycle_consist_path = debug_output_dir / "cycle_consistency"
-        os.makedirs(self._plot_cycle_consist_path, exist_ok=True)
+        if debug_output_dir:
+            self._plot_cycle_consist_path = debug_output_dir / "cycle_consistency"
+            os.makedirs(self._plot_cycle_consist_path, exist_ok=True)
 
         # Remove all invalid edges in the input dicts.
         valid_edges = dask.delayed(self._get_valid_input_edges)(

--- a/gtsfm/view_graph_estimator/view_graph_estimator_base.py
+++ b/gtsfm/view_graph_estimator/view_graph_estimator_base.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
 import dask
+import os
 import numpy as np
 from dask.delayed import Delayed
 from gtsam import Cal3Bundler, Rot3, Unit3
@@ -277,6 +278,11 @@ class ViewGraphEstimatorBase(GTSFMProcess):
             - Dict of two_view_reports in the view graph
             - GtsfmMetricsGroup with the view graph estimation metrics
         """
+
+        # create debug directory for cycle_consistency
+        self._plot_cycle_consist_path = debug_output_dir / "cycle_consistency"
+        os.makedirs(self._plot_cycle_consist_path, exist_ok=True)
+
         # Remove all invalid edges in the input dicts.
         valid_edges = dask.delayed(self._get_valid_input_edges)(
             i2Ri1_dict=i2Ri1_dict,
@@ -300,7 +306,7 @@ class ViewGraphEstimatorBase(GTSFMProcess):
             corr_idxs_i1i2=corr_idxs_i1i2_valid,
             keypoints=keypoints,
             two_view_reports=two_view_reports_valid,
-            output_dir=debug_output_dir,
+            output_dir=self._plot_cycle_consist_path,
         )
 
         # Remove all edges that are not in the view graph.

--- a/gtsfm/view_graph_estimator/view_graph_estimator_base.py
+++ b/gtsfm/view_graph_estimator/view_graph_estimator_base.py
@@ -280,9 +280,10 @@ class ViewGraphEstimatorBase(GTSFMProcess):
         """
 
         # create debug directory for cycle_consistency
+        plot_cycle_consist_path = None
         if debug_output_dir:
-            self._plot_cycle_consist_path = debug_output_dir / "cycle_consistency"
-            os.makedirs(self._plot_cycle_consist_path, exist_ok=True)
+            plot_cycle_consist_path = debug_output_dir / "cycle_consistency"
+            os.makedirs(plot_cycle_consist_path, exist_ok=True)
 
         # Remove all invalid edges in the input dicts.
         valid_edges = dask.delayed(self._get_valid_input_edges)(
@@ -307,7 +308,7 @@ class ViewGraphEstimatorBase(GTSFMProcess):
             corr_idxs_i1i2=corr_idxs_i1i2_valid,
             keypoints=keypoints,
             two_view_reports=two_view_reports_valid,
-            output_dir=self._plot_cycle_consist_path,
+            output_dir=plot_cycle_consist_path,
         )
 
         # Remove all edges that are not in the view graph.

--- a/gtsfm/view_graph_estimator/view_graph_estimator_base.py
+++ b/gtsfm/view_graph_estimator/view_graph_estimator_base.py
@@ -254,6 +254,7 @@ class ViewGraphEstimatorBase(GTSFMProcess):
         corr_idxs_i1i2: Dict[Tuple[int, int], Delayed],
         keypoints: List[Delayed],
         two_view_reports: Optional[Dict[Tuple[int, int], TwoViewEstimationReport]],
+        debug_output_dir: Path,
     ) -> Tuple[Delayed, Delayed, Delayed, Delayed, Delayed]:
         """Create the computation graph for ViewGraph estimation and metric evaluation.
 
@@ -266,6 +267,7 @@ class ViewGraphEstimatorBase(GTSFMProcess):
                 wrapped as Delayed.
             keypoints: keypoints for each image, wrapped as Delayed.
             two_view_reports: Dict from (i1, i2) to TwoViewEstimationReport that contains metrics, wrapped as Delayed.
+            debug_output_dir: Path to directory where outputs for debugging will be saved.
 
         Returns:
             Tuple of the following 5 elements, all wrapped as Delayed:
@@ -298,6 +300,7 @@ class ViewGraphEstimatorBase(GTSFMProcess):
             corr_idxs_i1i2=corr_idxs_i1i2_valid,
             keypoints=keypoints,
             two_view_reports=two_view_reports_valid,
+            debug_output_dir=debug_output_dir,
         )
 
         # Remove all edges that are not in the view graph.

--- a/gtsfm/view_graph_estimator/view_graph_estimator_base.py
+++ b/gtsfm/view_graph_estimator/view_graph_estimator_base.py
@@ -300,7 +300,7 @@ class ViewGraphEstimatorBase(GTSFMProcess):
             corr_idxs_i1i2=corr_idxs_i1i2_valid,
             keypoints=keypoints,
             two_view_reports=two_view_reports_valid,
-            debug_output_dir=debug_output_dir,
+            output_dir=debug_output_dir,
         )
 
         # Remove all edges that are not in the view graph.


### PR DESCRIPTION
For successful runs on the cluster, we need our paths to be absolute, so the machine doing the output can understand the location of the file. This PR changes the relative path to an absolute path.