### PR TITLE
Cluster Centralized Logs

### DIFF
--- a/gtsfm/utils/logger.py
+++ b/gtsfm/utils/logger.py
@@ -3,6 +3,7 @@
 Authors: Ayush Baid, John Lambert.
 """
 import logging
+import logging.handlers
 import sys
 from logging import Logger
 
@@ -13,7 +14,9 @@ def get_logger() -> Logger:
     logger = logging.getLogger(logger_name)
     logger.setLevel(logging.INFO)
     if not logger.handlers:
-        handler = logging.StreamHandler(sys.stdout)
+        handler = logging.handlers.SocketHandler(
+            'wildcat.cc.gatech.edu', 5000)
+
         fmt = "[%(asctime)s %(levelname)s %(filename)s line %(lineno)d %(process)d] %(message)s"
         handler.setFormatter(logging.Formatter(fmt))
         logger.addHandler(handler)

--- a/gtsfm/utils/logservertest.py
+++ b/gtsfm/utils/logservertest.py
@@ -1,0 +1,83 @@
+import pickle
+import logging
+import logging.handlers
+import socketserver
+import struct
+
+
+class LogRecordStreamHandler(socketserver.StreamRequestHandler):
+    """Handler for a streaming logging request.
+
+    This basically logs the record using whatever logging policy is
+    configured locally.
+    """
+
+    def handle(self):
+        """
+        Handle multiple requests - each expected to be a 4-byte length,
+        followed by the LogRecord in pickle format. Logs the record
+        according to whatever policy is configured locally.
+        """
+        while 1:
+            chunk = self.connection.recv(4)
+            if len(chunk) < 4:
+                break
+            slen = struct.unpack(">L", chunk)[0]
+            chunk = self.connection.recv(slen)
+            while len(chunk) < slen:
+                chunk = chunk + self.connection.recv(slen - len(chunk))
+            obj = self.unPickle(chunk)
+            record = logging.makeLogRecord(obj)
+            self.handleLogRecord(record)
+
+    def unPickle(self, data):
+        return pickle.loads(data)
+
+    def handleLogRecord(self, record):
+        # if a name is specified, we use the named logger rather than the one
+        # implied by the record.
+        if self.server.logname is not None:
+            name = self.server.logname
+        else:
+            name = record.name
+        logger = logging.getLogger(name)
+        # N.B. EVERY record gets logged. This is because Logger.handle
+        # is normally called AFTER logger-level filtering. If you want
+        # to do filtering, do it at the client end to save wasting
+        # cycles and network bandwidth!
+        logger.handle(record)
+
+class LogRecordSocketReceiver(socketserver.ThreadingTCPServer):
+    """simple TCP socket-based logging receiver suitable for testing.
+    """
+
+    allow_reuse_address = 1
+
+    def __init__(self, host='wildcat.cc.gatech.edu',
+                 port=5000,
+                 handler=LogRecordStreamHandler):
+        socketserver.ThreadingTCPServer.__init__(self, (host, port), handler)
+        self.abort = 0
+        self.timeout = 1
+        self.logname = None
+
+    def serve_until_stopped(self):
+        import select
+        abort = 0
+        while not abort:
+            rd, wr, ex = select.select([self.socket.fileno()],
+                                       [], [],
+                                       self.timeout)
+            if rd:
+                self.handle_request()
+            abort = self.abort
+
+def main():
+    logging.basicConfig(
+        format="%(relativeCreated)5d %(name)-15s %(levelname)-8s %(message)s")
+    tcpserver = LogRecordSocketReceiver()
+    print("About to start TCP server...")
+    tcpserver.serve_until_stopped()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
GTSfM logs that use the Python logging module are not visible when running GTSfM on a cluster.

One solution to this problem is using the [SocketHandler](https://docs.python.org/3/library/logging.handlers.html#logging.handlers.SocketHandler) module of the Python logging library to send the logs from all machines to the scheduler machine. At the same time, we create a server (Python [SocketServer](https://docs.python.org/3/library/socketserver.html) module) on the scheduler machine to listen to this port and process the logs.

This is a draft PR to propose this change and get feedback.