### PR TITLE
Update download urls for palace-fine-arts-281 dataset

### DIFF
--- a/.github/scripts/download_single_benchmark.sh
+++ b/.github/scripts/download_single_benchmark.sh
@@ -50,9 +50,10 @@ function download_and_unzip_dataset_files {
     ZIP_FNAME=notre-dame-20.zip
 
   elif [ "$DATASET_NAME" == "palace-fine-arts-281" ]; then
-    # Description: TODO
-    WGET_URL1=http://vision.maths.lth.se/calledataset/fine_arts_palace/fine_arts_palace.zip
-    WGET_URL2=http://vision.maths.lth.se/calledataset/fine_arts_palace/data.mat
+    # Description: 281 images captured at the Palace of Fine Arts in San Francisco, CA. Images and pseudo-ground truth
+    # poses from Carl Olsson's page: https://www.maths.lth.se/matematiklth/personal/calle/dataset/dataset.html
+    WGET_URL1=https://github.com/johnwlambert/gtsfm-datasets-mirror/releases/download/palace-fine-arts-281/fine_arts_palace.zip
+    WGET_URL2=https://github.com/johnwlambert/gtsfm-datasets-mirror/releases/download/palace-fine-arts-281/data.mat
     ZIP_FNAME=fine_arts_palace.zip
 
   elif [ "$DATASET_NAME" == "2011205_rc3" ]; then


### PR DESCRIPTION
CI was previously failing due to expired certificates [[see here]](https://github.com/borglab/gtsfm/actions/runs/4823096074/jobs/8599985702):
```
Connecting to vision.maths.lth.se (vision.maths.lth.se)|130.235.3.77|:443... connected.
ERROR: cannot verify vision.maths.lth.se's certificate, issued by ‘CN=GEANT OV RSA CA 4,O=GEANT Vereniging,C=NL’:
  Issued certificate has expired.
To connect to vision.maths.lth.se insecurely, use `--no-check-certificate'.
Retry 10/10 exited 5, no more retries left.
http://vision.maths.lth.se/calledataset/fine_arts_palace/fine_arts_palace.zip
http://vision.maths.lth.se/calledataset/fine_arts_palace/data.mat
unzip:  cannot find or open fine_arts_palace.zip, fine_arts_palace.zip.zip or fine_arts_palace.zip.ZIP.
Retry 5/5 exited 9, no more retries left.
```

 Images and pseudo-ground truth poses from Carl Olsson's page at https://www.maths.lth.se/matematiklth/personal/calle/dataset/dataset.html

281 images captured at the Palace of Fine Arts in San Francisco, CA.

Sourced from the following URLs, which now have expired certificates:
http://vision.maths.lth.se/calledataset/fine_arts_palace/fine_arts_palace.zip
http://vision.maths.lth.se/calledataset/fine_arts_palace/data.mat