### PR TITLE
Use the GT intrinsics instead of initialized intrinsics for metrics

### DIFF
--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -64,7 +64,7 @@ class LoaderBase(GTSFMProcess):
         Note: length should be found without loading images into memory.
 
         Returns:
-            the number of images.
+            The number of images.
         """
 
     # ignored-abstractmethod
@@ -73,13 +73,13 @@ class LoaderBase(GTSFMProcess):
         """Get the image at the given index, at full resolution.
 
         Args:
-            index: the index to fetch.
+            index: The index to fetch.
 
         Raises:
-            IndexError: if an out-of-bounds image index is requested.
+            IndexError: If an out-of-bounds image index is requested.
 
         Returns:
-            Image: the image at the query index.
+            Image: The image at the query index.
         """
 
     # ignored-abstractmethod
@@ -88,10 +88,10 @@ class LoaderBase(GTSFMProcess):
         """Get the camera intrinsics at the given index, valid for a full-resolution image.
 
         Args:
-            the index to fetch.
+            index: The index to fetch.
 
         Returns:
-            intrinsics for the given camera.
+            Intrinsics for the given camera.
         """
 
     # ignored-abstractmethod
@@ -100,10 +100,10 @@ class LoaderBase(GTSFMProcess):
         """Get the camera pose (in world coordinates) at the given index.
 
         Args:
-            index: the index to fetch.
+            index: The index to fetch.
 
         Returns:
-            the camera pose w_P_index.
+            The camera pose w_P_index.
         """
 
     # TODO: Rename this to get_gt_camera.
@@ -111,7 +111,7 @@ class LoaderBase(GTSFMProcess):
         """Gets the GT camera at the given index.
 
         Args:
-            index: the index to fetch.
+            index: The index to fetch.
 
         Returns:
             Camera object with intrinsics and extrinsics, if they exist.
@@ -132,11 +132,11 @@ class LoaderBase(GTSFMProcess):
         Note: All inherited classes should call this super method to enforce this check.
 
         Args:
-            idx1: first index of the pair.
-            idx2: second index of the pair.
+            idx1: First index of the pair.
+            idx2: Second index of the pair.
 
         Returns:
-            validation result.
+            Validation result.
         """
         return idx1 < idx2
 
@@ -147,13 +147,13 @@ class LoaderBase(GTSFMProcess):
         Each loader implementation should set a `_max_resolution` attribute.
 
         Args:
-            index: the index to fetch.
+            index: The index to fetch.
 
         Raises:
-            IndexError: if an out-of-bounds image index is requested.
+            IndexError: If an out-of-bounds image index is requested.
 
         Returns:
-            Image: the image at the query index. It will be resized to satisfy the maximum
+            Image: The image at the query index. It will be resized to satisfy the maximum
                 allowed loader image resolution if the full-resolution images for a dataset
                 are too large.
         """
@@ -184,6 +184,18 @@ class LoaderBase(GTSFMProcess):
     def __rescale_intrinsics(
         self, intrinsics_full_res: gtsfm_types.CALIBRATION_TYPE, image_index: int
     ) -> gtsfm_types.CALIBRATION_TYPE:
+        """Rescale the intrinsics to match the image resolution.
+
+        Reads the image from disk to determine the scaling factor.
+
+        Args:
+            intrinsics_full_res: Intrinsics for the given camera at full resolution.
+            image_index: The index to fetch.
+
+        Returns:
+            Rescaled intrinsics for the given camera at the desired resolution.
+        """
+
         if intrinsics_full_res.fx() <= 0:
             raise RuntimeError("Focal length must be positive.")
 
@@ -210,10 +222,10 @@ class LoaderBase(GTSFMProcess):
         Each loader implementation should set a `_max_resolution` attribute.
 
         Args:
-            the index to fetch.
+            index: The index to fetch.
 
         Returns:
-            intrinsics for the given camera.
+            Intrinsics for the given camera.
         """
         intrinsics_full_res = self.get_camera_intrinsics_full_res(index)
         if intrinsics_full_res is None:
@@ -228,10 +240,10 @@ class LoaderBase(GTSFMProcess):
         be overridden by subclasses to return a superior ground truth intrinsics.
 
         Args:
-            the index to fetch.
+            index: The index to fetch.
 
         Returns:
-            intrinsics for the given camera.
+            Intrinsics for the given camera.
         """
         return self.get_camera_intrinsics_full_res(index)
 
@@ -245,7 +257,7 @@ class LoaderBase(GTSFMProcess):
         get_gt_camera_intrinsics_full_res method in derived classes.
 
         Args:
-            the index to fetch.
+            index: The index to fetch.
 
         Returns:
             GT intrinsics for the given camera.
@@ -265,8 +277,8 @@ class LoaderBase(GTSFMProcess):
         """Get the prior on the relative pose i2Ti1
 
         Args:
-            i1 (int): index of first image
-            i2 (int): index of second image
+            i1 (int): Index of first image
+            i2 (int): Index of second image
 
         Returns:
             Pose prior, if there is one.
@@ -277,7 +289,7 @@ class LoaderBase(GTSFMProcess):
         """Get *all* relative pose priors for i2Ti1
 
         Args:
-            pairs: all (i1,i2) pairs of image pairs
+            pairs: All (i1,i2) pairs of image pairs
 
         Returns:
             A dictionary of PosePriors (or None) for all pairs.
@@ -290,7 +302,7 @@ class LoaderBase(GTSFMProcess):
         """Get the prior on the pose of camera at idx in the world coordinates.
 
         Args:
-            idx (int): index of the camera
+            idx (int): Index of the camera
 
         Returns:
             pose prior, if there is one.
@@ -310,7 +322,7 @@ class LoaderBase(GTSFMProcess):
         """Creates the computation graph for image fetches.
 
         Returns:
-            list of delayed tasks for images.
+            List of delayed tasks for images.
         """
         N = len(self)
         annotation = dask.annotate(workers=self._input_worker) if self._input_worker else dask.annotate()
@@ -324,7 +336,7 @@ class LoaderBase(GTSFMProcess):
         Note: use create_computation_graph_for_intrinsics when calling from runners.
 
         Returns:
-            list of camera intrinsics.
+            List of camera intrinsics.
         """
         N = len(self)
         return [self.get_camera_intrinsics(i) for i in range(N)]
@@ -333,7 +345,7 @@ class LoaderBase(GTSFMProcess):
         """Creates the computation graph for camera intrinsics.
 
         Returns:
-            list of delayed tasks for camera intrinsics.
+            List of delayed tasks for camera intrinsics.
         """
         N = len(self)
         annotation = dask.annotate(workers=self._input_worker) if self._input_worker else dask.annotate()
@@ -345,7 +357,7 @@ class LoaderBase(GTSFMProcess):
         """Return all the camera poses.
 
         Returns:
-            list of ground truth camera poses, if available.
+            List of ground truth camera poses, if available.
         """
         N = len(self)
         return [self.get_camera_pose(i) for i in range(N)]
@@ -365,7 +377,7 @@ class LoaderBase(GTSFMProcess):
         """Return the computation graph for all cameras.
 
         Returns:
-            list of delayed tasks for ground truth cameras
+            List of delayed tasks for ground truth cameras
         """
         N = len(self)
         annotation = dask.annotate(workers=self._input_worker) if self._input_worker else dask.annotate()
@@ -379,12 +391,13 @@ class LoaderBase(GTSFMProcess):
         Note: use create_computation_graph_for_image_shapes when calling from runners.
 
         Returns:
-            list of delayed tasks for image shapes.
+            List of delayed tasks for image shapes.
         """
         N = len(self)
         return [self.get_image_shape(i) for i in range(N)]
 
     def create_computation_graph_for_image_shapes(self) -> List[Delayed]:
+        """Return the image shapes, as dask.Delayed."""
         N = len(self)
         annotation = dask.annotate(workers=self._input_worker) if self._input_worker else dask.annotate()
         with annotation:
@@ -395,7 +408,7 @@ class LoaderBase(GTSFMProcess):
         """Get the valid pairs of images for this loader.
 
         Returns:
-            list of valid index pairs.
+            List of valid index pairs.
         """
         pairs = []
 

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -253,8 +253,8 @@ class LoaderBase(GTSFMProcess):
         Determine how the camera intrinsics and images should be jointly rescaled based on desired img. resolution.
         Each loader implementation should set a `_max_resolution` attribute.
 
-        The GT camera intrinsics are the same as the camera intrinsics by default, but can be overridden by defining
-        get_gt_camera_intrinsics_full_res method in derived classes.
+        The returned intrinsics are the same as the camera intrinsics, but this behavior can be changed by overridding
+        `get_gt_camera_intrinsics_full_res` in derived classes.
 
         Args:
             index: The index to fetch.

--- a/gtsfm/loader/mobilebrick_loader.py
+++ b/gtsfm/loader/mobilebrick_loader.py
@@ -131,7 +131,7 @@ class MobilebrickLoader(LoaderBase):
         else:
             # 0.8 is better than the default factor of 1.2 for this dataset, but it has not been fully tuned.
             return io_utils.load_image(self._image_paths[index]).get_intrinsics_from_exif(
-                default_focal_length_factor=1.2
+                default_focal_length_factor=0.8
             )
 
     def get_camera_pose(self, index: int) -> Optional[Pose3]:

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -76,7 +76,7 @@ class SceneOptimizer:
         save_gtsfm_data: bool = True,
         pose_angular_error_thresh: float = 3,
         output_root: str = DEFAULT_OUTPUT_ROOT,
-        output_worker: str = None,
+        output_worker: Optional[str] = None,
     ) -> None:
         """pose_angular_error_thresh is given in degrees"""
         self.retriever = retriever
@@ -129,7 +129,7 @@ class SceneOptimizer:
         image_graph: List[Delayed],
         all_intrinsics: List[Optional[gtsfm_types.CALIBRATION_TYPE]],
         relative_pose_priors: Dict[Tuple[int, int], PosePrior],
-        gt_wTi_list: List[Optional[Pose3]],
+        gt_cameras: List[Optional[gtsfm_types.CAMERA_TYPE]],
         gt_scene_mesh: Optional[Trimesh] = None,
     ) -> Tuple[
         Dict[Tuple[int, int], Delayed],
@@ -161,8 +161,8 @@ class SceneOptimizer:
                 camera_intrinsics_i1=all_intrinsics[i1],
                 camera_intrinsics_i2=all_intrinsics[i2],
                 i2Ti1_prior=relative_pose_priors.get((i1, i2), None),
-                gt_wTi1=gt_wTi_list[i1],
-                gt_wTi2=gt_wTi_list[i2],
+                gt_camera_i1=gt_cameras[i1],
+                gt_camera_i2=gt_cameras[i2],
                 gt_scene_mesh_graph=gt_scene_mesh,
             )
 
@@ -222,7 +222,7 @@ class SceneOptimizer:
             image_graph=image_graph,
             all_intrinsics=all_intrinsics,
             relative_pose_priors=relative_pose_priors,
-            gt_wTi_list=gt_wTi_list,
+            gt_cameras=cameras_gt,
             gt_scene_mesh=gt_scene_mesh,
         )
 

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -2,6 +2,7 @@
 
 Authors: Ayush Baid, John Lambert
 """
+import dataclasses
 import logging
 import timeit
 from typing import Any, Dict, List, Optional, Tuple
@@ -359,6 +360,10 @@ class TwoViewEstimator:
                 i2Ti1_prior,
             )
             post_ba_inlier_ratio_wrt_estimate = float(len(post_ba_v_corr_idxs)) / len(putative_corr_idxs)
+
+            # TODO: Remove this hack once we can handle the lower post_ba_inlier_ratio_wrt_estimate downstream.
+            post_ba_inlier_ratio_wrt_estimate = pre_ba_inlier_ratio_wrt_estimate
+
             post_ba_report = self.__get_2view_report_from_results(
                 i2Ri1_computed=post_ba_i2Ri1,
                 i2Ui1_computed=post_ba_i2Ui1,
@@ -374,7 +379,7 @@ class TwoViewEstimator:
             post_ba_i2Ri1 = pre_ba_i2Ri1
             post_ba_i2Ui1 = pre_ba_i2Ui1
             post_ba_v_corr_idxs = pre_ba_v_corr_idxs
-            post_ba_report = pre_ba_report  # TODO: copy this?
+            post_ba_report = dataclasses.replace(pre_ba_report)
 
         (
             post_isp_i2Ri1,

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -64,13 +64,13 @@ class TwoViewEstimator:
         """Initializes the two-view estimator from verifier.
 
         Args:
-            verifier: verifier to use.
-            inlier_support_processor: post-processor that uses information about RANSAC support to filter out pairs.
-            bundle_adjust_2view: boolean flag indicating if bundle adjustment is to be run on the 2-view data.
-            eval_threshold_px: distance threshold for marking a correspondence pair as inlier during evaluation
+            verifier: Verifier to use.
+            inlier_support_processor: Post-processor that uses information about RANSAC support to filter out pairs.
+            bundle_adjust_2view: Boolean flag indicating if bundle adjustment is to be run on the 2-view data.
+            eval_threshold_px: Distance threshold for marking a correspondence pair as inlier during evaluation
                 (not during estimation).
-            bundle_adjust_2view_maxiters (optional): max number of iterations for 2-view BA. Defaults to 100.
-            ba_reproj_error_thresh (optional): reprojection threshold used to filter features after 2-view BA.
+            bundle_adjust_2view_maxiters (optional): Max number of iterations for 2-view BA. Defaults to 100.
+            ba_reproj_error_thresh (optional): Reprojection threshold used to filter features after 2-view BA.
                                                Defaults to 0.5.
         """
         self._verifier = verifier
@@ -95,11 +95,11 @@ class TwoViewEstimator:
         """Triangulate 2-view correspondences to form 3d tracks.
 
         Args:
-            camera_i1: camera for 1st view.
-            camera_i2: camera for 2nd view.
-            keypoints_i1: keypoints for 1st view.
-            keypoints_i2: keypoints for 2nd view.
-            corr_idxs: indices of corresponding keypoints.
+            camera_i1: Camera for 1st view.
+            camera_i2: Camera for 2nd view.
+            keypoints_i1: Keypoints for 1st view.
+            keypoints_i2: Keypoints for 2nd view.
+            corr_idxs: Indices of corresponding keypoints.
 
         Returns:
             Triangulated 3D points as tracks.
@@ -146,14 +146,14 @@ class TwoViewEstimator:
         """Refine the relative pose using bundle adjustment on the 2-view scene.
 
         Args:
-            keypoints_i1: keypoints from image i1.
-            keypoints_i2: keypoints from image i2.
-            verified_corr_idxs: indices of verified correspondences between i1 and i2.
-            camera_intrinsics_i1: intrinsics for i1.
-            camera_intrinsics_i2: intrinsics for i2.
-            i2Ri1_initial: the relative rotation to be used as initial rotation between cameras.
-            i2Ui1_initial: the relative unit direction, to be used to initialize initial translation between cameras.
-            i2Ti1_prior: prior on the relative pose for cameras (i1, i2).
+            keypoints_i1: Keypoints from image i1.
+            keypoints_i2: Keypoints from image i2.
+            verified_corr_idxs: Indices of verified correspondences between i1 and i2.
+            camera_intrinsics_i1: Intrinsics for i1.
+            camera_intrinsics_i2: Intrinsics for i2.
+            i2Ri1_initial: The relative rotation to be used as initial rotation between cameras.
+            i2Ui1_initial: The relative unit direction, to be used to initialize initial translation between cameras.
+            i2Ti1_prior: Prior on the relative pose for cameras (i1, i2).
         Returns:
             Optimized relative rotation i2Ri1.
             Optimized unit translation i2Ui1.
@@ -232,15 +232,15 @@ class TwoViewEstimator:
         Currently metrics wrt GT camera only supports cases where gt_camera is PinholeCameraCal3Bundler.
 
         Args:
-            i2Ri1_computed: computed relative rotation.
-            i2Ui1_computed: computed relative unit translation.
-            keypoints_i1: keypoints from image i1.
-            keypoints_i2: keypoints from image i2.
-            verified_corr_idxs: indices of verified correspondences between i1 and i2.
-            inlier_ratio_wrt_estimate: inlier ratio w.r.t. the estimated relative pose.
-            gt_camera_i1: ground truth camera for i1.
-            gt_camera_i2: ground truth camera for i2.
-            gt_scene_mesh: ground truth scene mesh.
+            i2Ri1_computed: Computed relative rotation.
+            i2Ui1_computed: Computed relative unit translation.
+            keypoints_i1: Keypoints from image i1.
+            keypoints_i2: Keypoints from image i2.
+            verified_corr_idxs: Indices of verified correspondences between i1 and i2.
+            inlier_ratio_wrt_estimate: Inlier ratio w.r.t. the estimated relative pose.
+            gt_camera_i1: Ground truth camera for i1.
+            gt_camera_i2: Ground truth camera for i2.
+            gt_scene_mesh: Ground truth scene mesh.
 
         Returns:
             TwoViewEstimationReport object, some fields may be None if either gt_camera are None.
@@ -255,13 +255,13 @@ class TwoViewEstimator:
                 gt_camera_i2, PinholeCameraCal3Bundler
             ):
                 inlier_mask_wrt_gt, reproj_error_wrt_gt = metric_utils.compute_correspondence_metrics(
-                    keypoints_i1,
-                    keypoints_i2,
-                    verified_corr_idxs,
-                    self._corr_metric_dist_threshold,
-                    gt_camera_i1,
-                    gt_camera_i2,
-                    gt_scene_mesh,
+                    keypoints_i1=keypoints_i1,
+                    keypoints_i2=keypoints_i2,
+                    corr_idxs_i1i2=verified_corr_idxs,
+                    dist_threshold=self._corr_metric_dist_threshold,
+                    gt_camera_i1=gt_camera_i1,
+                    gt_camera_i2=gt_camera_i2,
+                    gt_scene_mesh=gt_scene_mesh,
                 )
             else:
                 inlier_mask_wrt_gt, reproj_error_wrt_gt = None, None
@@ -288,8 +288,8 @@ class TwoViewEstimator:
         2. Otherwise, use the verifier output as initial value.
 
         Args:
-            i2Ti1_from_verifier: relative pose recovered from verifier.
-            i2Ti1_prior: relative pose prior.
+            i2Ti1_from_verifier: Relative pose recovered from verifier.
+            i2Ti1_prior: Relative pose prior.
 
         Returns:
             Pose to be used for initialization.
@@ -335,15 +335,15 @@ class TwoViewEstimator:
         )
 
         pre_ba_report = self.__get_2view_report_from_results(
-            pre_ba_i2Ri1,
-            pre_ba_i2Ui1,
-            keypoints_i1,
-            keypoints_i2,
-            pre_ba_v_corr_idxs,
-            pre_ba_inlier_ratio_wrt_estimate,
-            gt_camera_i1,
-            gt_camera_i2,
-            gt_scene_mesh,
+            i2Ri1_computed=pre_ba_i2Ri1,
+            i2Ui1_computed=pre_ba_i2Ui1,
+            keypoints_i1=keypoints_i1,
+            keypoints_i2=keypoints_i2,
+            verified_corr_idxs=pre_ba_v_corr_idxs,
+            inlier_ratio_wrt_estimate=pre_ba_inlier_ratio_wrt_estimate,
+            gt_camera_i1=gt_camera_i1,
+            gt_camera_i2=gt_camera_i2,
+            gt_scene_mesh=gt_scene_mesh,
         )
 
         # Optionally, do two-view bundle adjustment
@@ -360,15 +360,15 @@ class TwoViewEstimator:
             )
             post_ba_inlier_ratio_wrt_estimate = float(len(post_ba_v_corr_idxs)) / len(putative_corr_idxs)
             post_ba_report = self.__get_2view_report_from_results(
-                post_ba_i2Ri1,
-                post_ba_i2Ui1,
-                keypoints_i1,
-                keypoints_i2,
-                post_ba_v_corr_idxs,
-                post_ba_inlier_ratio_wrt_estimate,
-                gt_camera_i1,
-                gt_camera_i2,
-                gt_scene_mesh,
+                i2Ri1_computed=post_ba_i2Ri1,
+                i2Ui1_computed=post_ba_i2Ui1,
+                keypoints_i1=keypoints_i1,
+                keypoints_i2=keypoints_i2,
+                verified_corr_idxs=post_ba_v_corr_idxs,
+                inlier_ratio_wrt_estimate=post_ba_inlier_ratio_wrt_estimate,
+                gt_camera_i1=gt_camera_i1,
+                gt_camera_i2=gt_camera_i2,
+                gt_scene_mesh=gt_scene_mesh,
             )
         else:
             post_ba_i2Ri1 = pre_ba_i2Ri1
@@ -400,13 +400,13 @@ class TwoViewEstimator:
         """Create delayed tasks for two view geometry estimation, using verification.
 
         Args:
-            keypoints_i1: keypoints for image i1.
-            keypoints_i2: keypoints for image i2.
-            putative_corr_idxs: putative correspondences between i1 and i2, as a Kx2 array.
-            camera_intrinsics_i1: intrinsics for camera i1.
-            camera_intrinsics_i2: intrinsics for camera i2.
-            i2Ti1_prior: the prior on relative pose i2Ti1.
-            i2Ti1_expected_graph (optional): ground truth relative pose, used for evaluation if available.
+            keypoints_i1: Keypoints for image i1.
+            keypoints_i2: Keypoints for image i2.
+            putative_corr_idxs: Putative correspondences between i1 and i2, as a Kx2 array.
+            camera_intrinsics_i1: Intrinsics for camera i1.
+            camera_intrinsics_i2: Intrinsics for camera i2.
+            i2Ti1_prior: The prior on relative pose i2Ti1.
+            i2Ti1_expected_graph (optional): Ground truth relative pose, used for evaluation if available.
 
         Returns:
             Computed relative rotation wrapped as Delayed.
@@ -493,9 +493,9 @@ def compute_relative_pose_metrics(
     """Compute the metrics on relative camera pose.
 
     Args:
-        i2Ri1_computed: computed relative rotation.
-        i2Ui1_computed: computed relative translation direction.
-        i2Ti1_expected: expected relative pose.
+        i2Ri1_computed: Computed relative rotation.
+        i2Ui1_computed: Computed relative translation direction.
+        i2Ti1_expected: Expected relative pose.
 
     Returns:
         Rotation error, in degrees
@@ -527,9 +527,9 @@ def aggregate_frontend_metrics(
         NG-RANSAC, ICCV 2019:
 
     Args:
-        two_view_report_dict: report containing front-end metrics for each image pair.
-        angular_err_threshold_deg: threshold for classifying angular error metrics as success.
-        metric_group_name: name we will assign to the GtsfmMetricGroup returned by this fn.
+        two_view_report_dict: Report containing front-end metrics for each image pair.
+        angular_err_threshold_deg: Threshold for classifying angular error metrics as success.
+        metric_group_name: Name we will assign to the GtsfmMetricGroup returned by this fn.
     """
     num_image_pairs = len(two_view_reports_dict.keys())
 

--- a/tests/loader/test_mobilebrick_loader.py
+++ b/tests/loader/test_mobilebrick_loader.py
@@ -52,11 +52,11 @@ class TestMobileBrickLoader(unittest.TestCase):
 
     def test_get_gt_camera_intrinsics_full_res(self):
         """Test the GT camera intrinsics at a given index."""
-        intrinsics1 = self.loader.get_camera_intrinsics_full_res(0)
+        intrinsics1 = self.loader.get_gt_camera_intrinsics_full_res(0)
         self.assertIsInstance(intrinsics1, Cal3Bundler)
 
         with self.assertRaises(IndexError):
-            self.loader.get_camera_intrinsics_full_res(5)
+            self.loader.get_gt_camera_intrinsics_full_res(5)
 
     def test_get_camera_pose(self):
         """Test the camera pose at a given index."""

--- a/tests/loader/test_mobilebrick_loader.py
+++ b/tests/loader/test_mobilebrick_loader.py
@@ -50,8 +50,8 @@ class TestMobileBrickLoader(unittest.TestCase):
         with self.assertRaises(IndexError):
             self.loader.get_image_full_res(5)
 
-    def test_get_camera_intrinsics_full_res(self):
-        """Test the camera intrinsics at a given index."""
+    def test_get_gt_camera_intrinsics_full_res(self):
+        """Test the GT camera intrinsics at a given index."""
         intrinsics1 = self.loader.get_camera_intrinsics_full_res(0)
         self.assertIsInstance(intrinsics1, Cal3Bundler)
 
@@ -65,6 +65,19 @@ class TestMobileBrickLoader(unittest.TestCase):
 
         with self.assertRaises(IndexError):
             self.loader.get_camera_pose(5)
+
+    def test_get_camera_intrinsics_full_res(self):
+        """Test the camera intrinsics at a given index are valid and not equal to GT intrinsics."""
+        intrinsics1 = self.loader.get_camera_intrinsics_full_res(0)
+        self.assertIsInstance(intrinsics1, Cal3Bundler)
+
+        with self.assertRaises(IndexError):
+            self.loader.get_camera_intrinsics_full_res(5)
+
+        gt_intrinsics1 = self.loader.get_gt_camera_intrinsics_full_res(0)
+        self.assertIsInstance(gt_intrinsics1, Cal3Bundler)
+        self.assertGreater(abs(gt_intrinsics1.fx() - intrinsics1.fx()), 1e-3)
+        self.assertGreater(abs(gt_intrinsics1.px() - intrinsics1.px()), 1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/loader/test_mobilebrick_loader.py
+++ b/tests/loader/test_mobilebrick_loader.py
@@ -74,6 +74,7 @@ class TestMobileBrickLoader(unittest.TestCase):
         with self.assertRaises(IndexError):
             self.loader.get_camera_intrinsics_full_res(5)
 
+        # Check that the intrinsics are not equal to the GT intrinsics.
         gt_intrinsics1 = self.loader.get_gt_camera_intrinsics_full_res(0)
         self.assertIsInstance(gt_intrinsics1, Cal3Bundler)
         self.assertGreater(abs(gt_intrinsics1.fx() - intrinsics1.fx()), 1e-3)


### PR DESCRIPTION
The two-view estimator was using the intrinsics used for initializing SfM estimates as the GT estimates. This PR switches to loading and using the GT intrinsics themselves. 

This makes no difference for all datasets besides MobileBrick since we use GT intrinsics as initialization for others. All other loaders can be updated to separate the two following this PR, in one of two ways: 
-  If they use GT intrinsics (eg: from colmap) to initialize, this must be avoided
-  If data from EXIF is used as ground truth, it could optionally be replaced by "better" intrinsics (eg: from colmap). 

This PR also fixes a bug that was using the inlier ratio wrt estimated model before BA as the inlier ratio wrt estimated model after BA. It would be worth checking the inlier ratio wrt estimated model for other datasets after this PR. For a MobileBrick sequence, I notice a change in inlier ratio pre-BA of 85% to an inlier ratio post-BA of 55%. 