### PR TITLE
Remove default-factor-initialized focal length

### DIFF
--- a/gtsfm/common/image.py
+++ b/gtsfm/common/image.py
@@ -73,14 +73,10 @@ class Image(NamedTuple):
 
         return sensor_width_mm
 
-    def get_intrinsics_from_exif(self, default_focal_length_factor: float = 1.2) -> Optional[Cal3Bundler]:
+    def get_intrinsics_from_exif(self) -> Optional[Cal3Bundler]:
         """Constructs the camera intrinsics from exif tag.
 
         Equation: focal_px=max(w_px,h_px)∗focal_mm / ccdw_mm
-
-        Note that it returns a default value based on image dimensions if EXIF not found:
-
-        focal_px=max(w_px, h_px)*default_factor
 
         Ref:
         - https://www.awaresystems.be/imaging/tiff/tifftags/privateifd/exif.html
@@ -88,36 +84,23 @@ class Image(NamedTuple):
         - https://openmvg.readthedocs.io/en/latest/software/SfM/SfMInit_ImageListing/
         - https://photo.stackexchange.com/questions/40865/how-can-i-get-the-image-sensor-dimensions-in-mm-to-get-circle-of-confusion-from # noqa: E501
 
-        Args:
-            default_focal_length_factor: A heuristic value that scales image width or height in pixel units.
-            The default value of 1.2 matches the value used in COLMAP,
-            see `ImageReaderOptions.default_focal_length_factor` in
-            https://github.com/colmap/colmap/blob/dev/src/base/image_reader.h.
-
         Returns:
             intrinsics matrix (3x3).
         """
 
+        if self.exif_data is None or len(self.exif_data) <= 0:
+            return None
+
         img_w_px = self.width
         img_h_px = self.height
+        max_size = max(img_w_px, img_h_px)
 
         # Initialize principal point.
         center_x = img_w_px / 2
         center_y = img_h_px / 2
 
-        # Initialize focal length by `default_focal_length_factor * max(width, height)`.
-        max_size = max(img_w_px, img_h_px)
-        focal_length_px = default_focal_length_factor * max_size
-
-        # Read focal length prior from exif.
-        if self.exif_data is None or len(self.exif_data) <= 0:
-            return Cal3Bundler(
-                fx=float(focal_length_px),
-                k1=0.0,
-                k2=0.0,
-                u0=float(center_x),
-                v0=float(center_y),
-            )
+        # Initialize focal length as None.
+        focal_length_px = None
 
         # Read from `FocalLengthIn35mmFilm`.
         focal_length_35_mm = self.exif_data.get("FocalLengthIn35mmFilm")
@@ -127,13 +110,7 @@ class Image(NamedTuple):
             # Read from `FocalLength` mm.
             focal_length_mm = self.exif_data.get("FocalLength")
             if focal_length_mm is None or focal_length_mm <= 0:
-                return Cal3Bundler(
-                    fx=float(focal_length_px),
-                    k1=0.0,
-                    k2=0.0,
-                    u0=float(center_x),
-                    v0=float(center_y),
-                )
+                return None
 
             # Compute sensor width, either from database or from EXIF.
             sensor_width_mm = 0.0
@@ -147,8 +124,8 @@ class Image(NamedTuple):
             if sensor_width_mm > 0.0:
                 focal_length_px = focal_length_mm / sensor_width_mm * max_size
 
-        if focal_length_px <= 0:
-            raise ValueError("Focal length must be positive value.")
+        if focal_length_px is None or focal_length_px <= 0.0:
+            return None
 
         return Cal3Bundler(
             fx=float(focal_length_px),
@@ -156,6 +133,36 @@ class Image(NamedTuple):
             k2=0.0,
             u0=float(center_x),
             v0=float(center_y),
+        )
+
+    def get_intrinsics(self, default_focal_length_factor: float = 1.2) -> Optional[Cal3Bundler]:
+        """Constructs the camera intrinsics.
+
+        Note that it returns a default value based on image dimensions if EXIF not found.
+        Equation: focal_px=max(w_px, h_px)*default_factor
+
+        Args:
+            default_focal_length_factor: A heuristic value that scales image width or height in pixel units.
+            The default value of 1.2 matches the value used in COLMAP,
+            see `ImageReaderOptions.default_focal_length_factor` in
+            https://github.com/colmap/colmap/blob/dev/src/base/image_reader.h.
+
+        """
+
+        # Construct intrinsics from exif tag.
+        intrinsics = self.get_intrinsics_from_exif()
+        if intrinsics is not None:
+            return intrinsics
+
+        # Initialize focal length by `default_focal_length_factor * max(width, height)`.
+        focal_length_px = default_focal_length_factor * max(self.width, self.height)
+
+        return Cal3Bundler(
+            fx=float(focal_length_px),
+            k1=0.0,
+            k2=0.0,
+            u0=float(self.width / 2),
+            v0=float(self.height / 2),
         )
 
     def extract_patch(self, center_x: float, center_y: float, patch_size: int) -> "Image":

--- a/gtsfm/common/image.py
+++ b/gtsfm/common/image.py
@@ -156,6 +156,8 @@ class Image(NamedTuple):
 
         # Initialize focal length by `default_focal_length_factor * max(width, height)`.
         focal_length_px = default_focal_length_factor * max(self.width, self.height)
+        if focal_length_px <= 0.0:
+            raise ValueError("Focal length must be positive value.")
 
         return Cal3Bundler(
             fx=float(focal_length_px),

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -4,6 +4,7 @@ Authors: Frank Dellaert and Ayush Baid
 """
 
 import abc
+import glob
 import logging
 from typing import Dict, List, Optional, Tuple
 
@@ -13,6 +14,7 @@ from gtsam import Cal3Bundler, Pose3
 
 import gtsfm.common.types as gtsfm_types
 import gtsfm.utils.images as img_utils
+import gtsfm.utils.io as io_utils
 from gtsfm.common.image import Image
 from gtsfm.common.pose_prior import PosePrior
 from gtsfm.ui.gtsfm_process import GTSFMProcess, UiMetadata
@@ -418,3 +420,24 @@ class LoaderBase(GTSFMProcess):
                     pairs.append((idx1, idx2))
 
         return pairs
+
+    def get_images_with_exif(self, search_path: str) -> Tuple[List[str], int]:
+        """Return images with exif.
+        Args:
+            search_path: image sequence search path.
+        Returns:
+            Tuple[
+                List of image with exif paths.
+                The number of all the images.
+            ]
+        """
+        all_image_paths = glob.glob(search_path)
+        num_all_imgs = len(all_image_paths)
+        exif_image_paths = []
+        for single_img_path in all_image_paths:
+            # Drop images without exif.
+            if io_utils.load_image(single_img_path).get_intrinsics_from_exif() is None:
+                continue
+            exif_image_paths.append(single_img_path)
+
+        return (exif_image_paths, num_all_imgs)

--- a/gtsfm/loader/mobilebrick_loader.py
+++ b/gtsfm/loader/mobilebrick_loader.py
@@ -130,9 +130,7 @@ class MobilebrickLoader(LoaderBase):
             return self._gt_intrinsics[index]
         else:
             # 0.8 is better than the default factor of 1.2 for this dataset, but it has not been fully tuned.
-            return io_utils.load_image(self._image_paths[index]).get_intrinsics_from_exif(
-                default_focal_length_factor=0.8
-            )
+            return io_utils.load_image(self._image_paths[index]).get_intrinsics(default_focal_length_factor=0.8)
 
     def get_camera_pose(self, index: int) -> Optional[Pose3]:
         """Get the camera pose (in world coordinates) at the given index.

--- a/gtsfm/loader/one_d_sfm_loader.py
+++ b/gtsfm/loader/one_d_sfm_loader.py
@@ -17,9 +17,6 @@ from gtsfm.loader.loader_base import LoaderBase
 
 logger = logger_utils.get_logger()
 
-# Focal length is initialized to 1.2 * largest dimension of image if EXIF data is not available.
-NO_EXIF_DEFAULT_FOCAL_LENGTH_FACTOR = 1.2
-
 
 class OneDSFMLoader(LoaderBase):
     """Loader for datasets used in 1DSFM and Colmap papers.
@@ -41,7 +38,7 @@ class OneDSFMLoader(LoaderBase):
         folder: str,
         image_extension: str = "jpg",
         max_resolution: int = 640,
-        enable_no_exif: bool = False,
+        default_focal_length_factor: float = 0.0,
     ) -> None:
         """Initializes to load from a specified folder on disk.
 
@@ -52,15 +49,16 @@ class OneDSFMLoader(LoaderBase):
                 the smaller of the height/width of the image. e.g. for 1080p (1920 x 1080),
                 max_resolution would be 1080. If the image resolution max(height, width) is
                 greater than the max_resolution, it will be downsampled to match the max_resolution.
-            enable_no_exif: flag to whether to read images without exif.
+            default_focal_length_factor: focal length is initialized to default_focal_length_factor * largest dimension
+            of image if EXIF data is not available. Non-positive value means exif required.
         """
         super().__init__(max_resolution=max_resolution)
-        self._enable_no_exif = enable_no_exif
+        self._default_focal_length_factor = default_focal_length_factor
 
         # Fetch all the file names in /images folder.
         search_path = os.path.join(folder, "images", f"*.{image_extension}")
 
-        if not self._enable_no_exif:
+        if self._default_focal_length_factor > 0.0:
             self._image_paths = glob.glob(search_path)
         else:
             (self._image_paths, num_all_imgs) = self.get_images_with_exif(search_path)
@@ -69,27 +67,6 @@ class OneDSFMLoader(LoaderBase):
         self._num_imgs = len(self._image_paths)
         if self._num_imgs == 0:
             raise RuntimeError(f"Loader could not find any images with the specified file extension in {search_path}")
-
-    def get_images_with_exif(self, search_path: str) -> Tuple[List[str], int]:
-        """Return images with exif.
-        Args:
-            search_path: image sequence search path.
-        Returns:
-            Tuple[
-                List of image with exif paths.
-                The number of all the images.
-            ]
-        """
-        all_image_paths = glob.glob(search_path)
-        num_all_imgs = len(all_image_paths)
-        exif_image_paths = []
-        for single_img_path in all_image_paths:
-            # Drop images without exif.
-            if io_utils.load_image(single_img_path).get_intrinsics_from_exif() is None:
-                continue
-            exif_image_paths.append(single_img_path)
-
-        return (exif_image_paths, num_all_imgs)
 
     def image_filenames(self) -> List[str]:
         """Return the file names corresponding to each image index."""
@@ -128,16 +105,10 @@ class OneDSFMLoader(LoaderBase):
         Returns:
             Intrinsics for the given camera.
         """
-        # Get intrinsics from exif.
-        # TODO(yanwei) It is probably fine to only use the second method, as
-        # the images have been filtered before in consturctor.
-        if not self._enable_no_exif:
-            intrinsics = io_utils.load_image(self._image_paths[index]).get_intrinsics_from_exif()
-        else:
-            intrinsics = io_utils.load_image(self._image_paths[index]).get_intrinsics(
-                default_focal_length_factor=NO_EXIF_DEFAULT_FOCAL_LENGTH_FACTOR
-            )
-        return intrinsics
+        # Get intrinsics.
+        return io_utils.load_image(self._image_paths[index]).get_intrinsics(
+            default_focal_length_factor=self._default_focal_length_factor
+        )
 
     def get_camera_pose(self, index: int) -> Optional[Pose3]:
         """Get the camera pose (in world coordinates) at the given index.

--- a/gtsfm/loader/one_d_sfm_loader.py
+++ b/gtsfm/loader/one_d_sfm_loader.py
@@ -6,7 +6,7 @@ Authors: Yanwei Du
 import glob
 import os
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from gtsam import Cal3Bundler, Pose3
 
@@ -38,7 +38,8 @@ class OneDSFMLoader(LoaderBase):
         folder: str,
         image_extension: str = "jpg",
         max_resolution: int = 640,
-        default_focal_length_factor: float = 0.0,
+        enable_no_exif: bool = False,
+        default_focal_length_factor: float = 1.2,
     ) -> None:
         """Initializes to load from a specified folder on disk.
 
@@ -49,8 +50,10 @@ class OneDSFMLoader(LoaderBase):
                 the smaller of the height/width of the image. e.g. for 1080p (1920 x 1080),
                 max_resolution would be 1080. If the image resolution max(height, width) is
                 greater than the max_resolution, it will be downsampled to match the max_resolution.
+            enable_no_exif: flag to whether to read images without exif.
             default_focal_length_factor: focal length is initialized to default_focal_length_factor * largest dimension
-            of image if EXIF data is not available. Non-positive value means exif required.
+            of image if exif data is not available. The value has not been tuned for performance, 1.2 would be a
+            good start.
         """
         super().__init__(max_resolution=max_resolution)
         self._default_focal_length_factor = default_focal_length_factor
@@ -58,7 +61,7 @@ class OneDSFMLoader(LoaderBase):
         # Fetch all the file names in /images folder.
         search_path = os.path.join(folder, "images", f"*.{image_extension}")
 
-        if self._default_focal_length_factor > 0.0:
+        if enable_no_exif:
             self._image_paths = glob.glob(search_path)
         else:
             (self._image_paths, num_all_imgs) = self.get_images_with_exif(search_path)

--- a/gtsfm/loader/one_d_sfm_loader.py
+++ b/gtsfm/loader/one_d_sfm_loader.py
@@ -6,7 +6,7 @@ Authors: Yanwei Du
 import glob
 import os
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from gtsam import Cal3Bundler, Pose3
 
@@ -41,6 +41,7 @@ class OneDSFMLoader(LoaderBase):
         folder: str,
         image_extension: str = "jpg",
         max_resolution: int = 640,
+        enable_no_exif: bool = False,
     ) -> None:
         """Initializes to load from a specified folder on disk.
 
@@ -51,17 +52,44 @@ class OneDSFMLoader(LoaderBase):
                 the smaller of the height/width of the image. e.g. for 1080p (1920 x 1080),
                 max_resolution would be 1080. If the image resolution max(height, width) is
                 greater than the max_resolution, it will be downsampled to match the max_resolution.
+            enable_no_exif: flag to whether to read images without exif.
         """
         super().__init__(max_resolution=max_resolution)
+        self._enable_no_exif = enable_no_exif
 
         # Fetch all the file names in /images folder.
         search_path = os.path.join(folder, "images", f"*.{image_extension}")
 
-        self._image_paths = glob.glob(search_path)
-        self._num_imgs = len(self._image_paths)
+        if not self._enable_no_exif:
+            self._image_paths = glob.glob(search_path)
+        else:
+            (self._image_paths, num_all_imgs) = self.get_images_with_exif(search_path)
+            logger.info("Read %d images with exif out of %d in total.", len(self._image_paths), num_all_imgs)
 
+        self._num_imgs = len(self._image_paths)
         if self._num_imgs == 0:
             raise RuntimeError(f"Loader could not find any images with the specified file extension in {search_path}")
+
+    def get_images_with_exif(self, search_path: str) -> Tuple[List[str], int]:
+        """Return images with exif.
+        Args:
+            search_path: image sequence search path.
+        Returns:
+            Tuple[
+                List of image with exif paths.
+                The number of all the images.
+            ]
+        """
+        all_image_paths = glob.glob(search_path)
+        num_all_imgs = len(all_image_paths)
+        exif_image_paths = []
+        for single_img_path in all_image_paths:
+            # Drop images without exif.
+            if io_utils.load_image(single_img_path).get_intrinsics_from_exif() is None:
+                continue
+            exif_image_paths.append(single_img_path)
+
+        return (exif_image_paths, num_all_imgs)
 
     def image_filenames(self) -> List[str]:
         """Return the file names corresponding to each image index."""
@@ -101,9 +129,14 @@ class OneDSFMLoader(LoaderBase):
             Intrinsics for the given camera.
         """
         # Get intrinsics from exif.
-        intrinsics = io_utils.load_image(self._image_paths[index]).get_intrinsics_from_exif(
-            default_focal_length_factor=NO_EXIF_DEFAULT_FOCAL_LENGTH_FACTOR
-        )
+        # TODO(yanwei) It is probably fine to only use the second method, as
+        # the images have been filtered before in consturctor.
+        if not self._enable_no_exif:
+            intrinsics = io_utils.load_image(self._image_paths[index]).get_intrinsics_from_exif()
+        else:
+            intrinsics = io_utils.load_image(self._image_paths[index]).get_intrinsics(
+                default_focal_length_factor=NO_EXIF_DEFAULT_FOCAL_LENGTH_FACTOR
+            )
         return intrinsics
 
     def get_camera_pose(self, index: int) -> Optional[Pose3]:

--- a/gtsfm/runner/run_scene_optimizer_1dsfm.py
+++ b/gtsfm/runner/run_scene_optimizer_1dsfm.py
@@ -22,14 +22,14 @@ class GtsfmRunnerOneDSFMLoader(GtsfmRunnerBase):
         parser = super(GtsfmRunnerOneDSFMLoader, self).construct_argparser()
         parser.add_argument("--dataset_root", type=str, default="", help="")
         parser.add_argument("--image_extension", type=str, default="jpg", help="")
-        parser.add_argument("--enable_no_exif", type=bool, default=False, help="")
+        parser.add_argument("--default_focal_length_factor", type=float, default=0.0, help="")
         return parser
 
     def construct_loader(self) -> LoaderBase:
         loader = OneDSFMLoader(
             folder=self.parsed_args.dataset_root,
             image_extension=self.parsed_args.image_extension,
-            enable_no_exif=self.parsed_args.enable_no_exif,
+            default_focal_length_factor=self.parsed_args.default_focal_length_factor,
         )
         return loader
 

--- a/gtsfm/runner/run_scene_optimizer_1dsfm.py
+++ b/gtsfm/runner/run_scene_optimizer_1dsfm.py
@@ -22,12 +22,14 @@ class GtsfmRunnerOneDSFMLoader(GtsfmRunnerBase):
         parser = super(GtsfmRunnerOneDSFMLoader, self).construct_argparser()
         parser.add_argument("--dataset_root", type=str, default="", help="")
         parser.add_argument("--image_extension", type=str, default="jpg", help="")
+        parser.add_argument("--enable_no_exif", type=bool, default=False, help="")
         return parser
 
     def construct_loader(self) -> LoaderBase:
         loader = OneDSFMLoader(
             folder=self.parsed_args.dataset_root,
             image_extension=self.parsed_args.image_extension,
+            enable_no_exif=self.parsed_args.enable_no_exif,
         )
         return loader
 

--- a/gtsfm/runner/run_scene_optimizer_1dsfm.py
+++ b/gtsfm/runner/run_scene_optimizer_1dsfm.py
@@ -22,7 +22,7 @@ class GtsfmRunnerOneDSFMLoader(GtsfmRunnerBase):
         parser = super(GtsfmRunnerOneDSFMLoader, self).construct_argparser()
         parser.add_argument("--dataset_root", type=str, default="", help="")
         parser.add_argument("--image_extension", type=str, default="jpg", help="")
-        parser.add_argument("--enable_no_exif", type=bool, default=False, help="")
+        parser.add_argument("--enable_no_exif", action="store_true", help="")
         parser.add_argument("--default_focal_length_factor", type=float, default=1.2, help="")
         return parser
 

--- a/gtsfm/runner/run_scene_optimizer_1dsfm.py
+++ b/gtsfm/runner/run_scene_optimizer_1dsfm.py
@@ -22,13 +22,15 @@ class GtsfmRunnerOneDSFMLoader(GtsfmRunnerBase):
         parser = super(GtsfmRunnerOneDSFMLoader, self).construct_argparser()
         parser.add_argument("--dataset_root", type=str, default="", help="")
         parser.add_argument("--image_extension", type=str, default="jpg", help="")
-        parser.add_argument("--default_focal_length_factor", type=float, default=0.0, help="")
+        parser.add_argument("--enable_no_exif", type=bool, default=False, help="")
+        parser.add_argument("--default_focal_length_factor", type=float, default=1.2, help="")
         return parser
 
     def construct_loader(self) -> LoaderBase:
         loader = OneDSFMLoader(
             folder=self.parsed_args.dataset_root,
             image_extension=self.parsed_args.image_extension,
+            enable_no_exif=self.parsed_args.enable_no_exif,
             default_focal_length_factor=self.parsed_args.default_focal_length_factor,
         )
         return loader

--- a/tests/common/test_image.py
+++ b/tests/common/test_image.py
@@ -17,22 +17,19 @@ DEFAULT_FOCAL_LENGTH_FACTOR = 1.2
 class TestImage(unittest.TestCase):
     """Unit tests for the image class."""
 
-    def test_get_intrinsics_no_exif(self):
+    def test_get_intrinsics_from_exif_no_exif(self):
         """Tests the intrinsics generation from exif."""
 
         im_h = 100
         im_w = 120
         exif_data = None
         image = Image(np.random.randint(low=0, high=255, size=(im_h, im_w, 3)), exif_data)
-        computed_intrinsics = image.get_intrinsics(default_focal_length_factor=DEFAULT_FOCAL_LENGTH_FACTOR)
+        computed_intrinsics = image.get_intrinsics_from_exif()
 
-        expected_focal_length = DEFAULT_FOCAL_LENGTH_FACTOR * max(im_h, im_w)
-        expected_intrinsics = Cal3Bundler(fx=expected_focal_length, k1=0.0, k2=0.0, u0=60.0, v0=50.0)
+        # None is expected because exif data is None.
+        self.assertTrue(computed_intrinsics is None)
 
-        # Focal length default value is expected because exif data is None.
-        self.assertTrue(expected_intrinsics.equals(computed_intrinsics, 1e-3))
-
-    def test_get_intrinsics_no_tags(self):
+    def test_get_intrinsics_from_exif_no_tags(self):
         """Tests the intrinsics generation from exif."""
 
         im_h = 100
@@ -41,13 +38,10 @@ class TestImage(unittest.TestCase):
             "DummyName": "DummyValue",
         }
         image = Image(np.random.randint(low=0, high=255, size=(im_h, im_w, 3)), exif_data)
-        computed_intrinsics = image.get_intrinsics(default_focal_length_factor=DEFAULT_FOCAL_LENGTH_FACTOR)
+        computed_intrinsics = image.get_intrinsics_from_exif()
 
-        expected_focal_length = DEFAULT_FOCAL_LENGTH_FACTOR * max(im_h, im_w)
-        expected_intrinsics = Cal3Bundler(fx=expected_focal_length, k1=0.0, k2=0.0, u0=60.0, v0=50.0)
-
-        # Focal length default value is expected because no tags of interest exist.
-        self.assertTrue(expected_intrinsics.equals(computed_intrinsics, 1e-3))
+        # None is expected because no tags of interest exist.
+        self.assertTrue(computed_intrinsics is None)
 
     def test_get_intrinsics_from_exif_focal_length_in_35mm_film(self):
         """Tests the intrinsics generation from exif.
@@ -68,7 +62,7 @@ class TestImage(unittest.TestCase):
             "FocalPlaneResolutionUnit": 2,
         }
         image = Image(np.random.randint(low=0, high=255, size=(im_h, im_w, 3)), exif_data)
-        computed_intrinsics = image.get_intrinsics(default_focal_length_factor=DEFAULT_FOCAL_LENGTH_FACTOR)
+        computed_intrinsics = image.get_intrinsics_from_exif()
 
         expected_intrinsics = Cal3Bundler(fx=480, k1=0.0, k2=0.0, u0=60.0, v0=50.0)
 
@@ -91,7 +85,7 @@ class TestImage(unittest.TestCase):
             "FocalPlaneResolutionUnit": 2,
         }
         image = Image(np.random.randint(low=0, high=255, size=(im_h, im_w, 3)), exif_data)
-        computed_intrinsics = image.get_intrinsics(default_focal_length_factor=DEFAULT_FOCAL_LENGTH_FACTOR)
+        computed_intrinsics = image.get_intrinsics_from_exif()
 
         expected_intrinsics = Cal3Bundler(fx=600, k1=0.0, k2=0.0, u0=60.0, v0=50.0)
 
@@ -110,7 +104,41 @@ class TestImage(unittest.TestCase):
             "FocalPlaneResolutionUnit": 2,
         }
         image = Image(np.random.randint(low=0, high=255, size=(im_h, im_w, 3)), exif_data)
+        computed_intrinsics = image.get_intrinsics_from_exif()
+
+        expected_intrinsics = Cal3Bundler(fx=590.551, k1=0.0, k2=0.0, u0=60.0, v0=50.0)
+
+        # Focal length computed from `ExifImageWidth` is expected.
+        self.assertTrue(expected_intrinsics.equals(computed_intrinsics, 1e-3))
+
+    def test_get_intrinsics_no_exif(self):
+        """Tests the intrinsics generation."""
+
+        im_h = 100
+        im_w = 120
+        exif_data = None
+        image = Image(np.random.randint(low=0, high=255, size=(im_h, im_w, 3)), exif_data)
         computed_intrinsics = image.get_intrinsics(default_focal_length_factor=DEFAULT_FOCAL_LENGTH_FACTOR)
+
+        expected_focal_length = DEFAULT_FOCAL_LENGTH_FACTOR * max(im_h, im_w)
+        expected_intrinsics = Cal3Bundler(fx=expected_focal_length, k1=0.0, k2=0.0, u0=60.0, v0=50.0)
+
+        # Focal length default value is expected because exif data is None.
+        self.assertTrue(expected_intrinsics.equals(computed_intrinsics, 1e-3))
+
+    def test_get_intrinsics_from_exif(self):
+        """Tests the intrinsics generation."""
+
+        im_h = 100
+        im_w = 120
+        exif_data = {
+            "FocalLength": 25,
+            "ExifImageWidth": 200,
+            "FocalPlaneXResolution": 1000,
+            "FocalPlaneResolutionUnit": 2,
+        }
+        image = Image(np.random.randint(low=0, high=255, size=(im_h, im_w, 3)), exif_data)
+        computed_intrinsics = image.get_intrinsics_from_exif()
 
         expected_intrinsics = Cal3Bundler(fx=590.551, k1=0.0, k2=0.0, u0=60.0, v0=50.0)
 

--- a/tests/common/test_image.py
+++ b/tests/common/test_image.py
@@ -17,14 +17,14 @@ DEFAULT_FOCAL_LENGTH_FACTOR = 1.2
 class TestImage(unittest.TestCase):
     """Unit tests for the image class."""
 
-    def test_get_intrinsics_from_exif_no_exif(self):
+    def test_get_intrinsics_no_exif(self):
         """Tests the intrinsics generation from exif."""
 
         im_h = 100
         im_w = 120
         exif_data = None
         image = Image(np.random.randint(low=0, high=255, size=(im_h, im_w, 3)), exif_data)
-        computed_intrinsics = image.get_intrinsics_from_exif(default_focal_length_factor=DEFAULT_FOCAL_LENGTH_FACTOR)
+        computed_intrinsics = image.get_intrinsics(default_focal_length_factor=DEFAULT_FOCAL_LENGTH_FACTOR)
 
         expected_focal_length = DEFAULT_FOCAL_LENGTH_FACTOR * max(im_h, im_w)
         expected_intrinsics = Cal3Bundler(fx=expected_focal_length, k1=0.0, k2=0.0, u0=60.0, v0=50.0)
@@ -32,7 +32,7 @@ class TestImage(unittest.TestCase):
         # Focal length default value is expected because exif data is None.
         self.assertTrue(expected_intrinsics.equals(computed_intrinsics, 1e-3))
 
-    def test_get_intrinsics_from_exif_no_tags(self):
+    def test_get_intrinsics_no_tags(self):
         """Tests the intrinsics generation from exif."""
 
         im_h = 100
@@ -41,7 +41,7 @@ class TestImage(unittest.TestCase):
             "DummyName": "DummyValue",
         }
         image = Image(np.random.randint(low=0, high=255, size=(im_h, im_w, 3)), exif_data)
-        computed_intrinsics = image.get_intrinsics_from_exif(default_focal_length_factor=DEFAULT_FOCAL_LENGTH_FACTOR)
+        computed_intrinsics = image.get_intrinsics(default_focal_length_factor=DEFAULT_FOCAL_LENGTH_FACTOR)
 
         expected_focal_length = DEFAULT_FOCAL_LENGTH_FACTOR * max(im_h, im_w)
         expected_intrinsics = Cal3Bundler(fx=expected_focal_length, k1=0.0, k2=0.0, u0=60.0, v0=50.0)
@@ -68,7 +68,7 @@ class TestImage(unittest.TestCase):
             "FocalPlaneResolutionUnit": 2,
         }
         image = Image(np.random.randint(low=0, high=255, size=(im_h, im_w, 3)), exif_data)
-        computed_intrinsics = image.get_intrinsics_from_exif(default_focal_length_factor=DEFAULT_FOCAL_LENGTH_FACTOR)
+        computed_intrinsics = image.get_intrinsics(default_focal_length_factor=DEFAULT_FOCAL_LENGTH_FACTOR)
 
         expected_intrinsics = Cal3Bundler(fx=480, k1=0.0, k2=0.0, u0=60.0, v0=50.0)
 
@@ -91,7 +91,7 @@ class TestImage(unittest.TestCase):
             "FocalPlaneResolutionUnit": 2,
         }
         image = Image(np.random.randint(low=0, high=255, size=(im_h, im_w, 3)), exif_data)
-        computed_intrinsics = image.get_intrinsics_from_exif(default_focal_length_factor=DEFAULT_FOCAL_LENGTH_FACTOR)
+        computed_intrinsics = image.get_intrinsics(default_focal_length_factor=DEFAULT_FOCAL_LENGTH_FACTOR)
 
         expected_intrinsics = Cal3Bundler(fx=600, k1=0.0, k2=0.0, u0=60.0, v0=50.0)
 
@@ -110,7 +110,7 @@ class TestImage(unittest.TestCase):
             "FocalPlaneResolutionUnit": 2,
         }
         image = Image(np.random.randint(low=0, high=255, size=(im_h, im_w, 3)), exif_data)
-        computed_intrinsics = image.get_intrinsics_from_exif(default_focal_length_factor=DEFAULT_FOCAL_LENGTH_FACTOR)
+        computed_intrinsics = image.get_intrinsics(default_focal_length_factor=DEFAULT_FOCAL_LENGTH_FACTOR)
 
         expected_intrinsics = Cal3Bundler(fx=590.551, k1=0.0, k2=0.0, u0=60.0, v0=50.0)
 


### PR DESCRIPTION
#### Fix 
Remove default-factor-initialized focal length value.

#### How
- Remove the default focal length value from the original API `get_intrinsics_from_exif()`.
- Move it to a new API `get_intrinsics()`. (A better method name is needed.)
- OneDSFM loader default only reads images with exif.