### PR TITLE
JS Alert Only Once

### DIFF
--- a/rtf_vis_tool/src/Components/AllFrustums.js
+++ b/rtf_vis_tool/src/Components/AllFrustums.js
@@ -13,6 +13,7 @@ var Quaternion = require('quaternion');
 // Local Imports.
 var SE3 = require('./frustum_classes/se3');
 var ViewFrustum = require('./frustum_classes/view_frustum');
+let alerted = false;
 
 function AllFrustums(props) {
     /* 
@@ -63,10 +64,10 @@ function AllFrustums(props) {
         // remove any dummy lines from images.txt that contain the string "TODO", until gtsfm.utils.io.write_images is
         // updated
         ex_cameraList = ex_cameraList.filter(line => line !== "TODO"); 
-
-        if (in_cameraList.length !== ex_cameraList.length) {
+        
+        if (!alerted && in_cameraList.length !== ex_cameraList.length) {
             alert('Camera count mismatch between images.txt and cameras.txt');
-            return;
+            alerted = true;
         }
 
         var finalFrustumsJSX = [];


### PR DESCRIPTION
This PR makes JS alerts show up only once instead of constantly popping on the screen. This will allow the users to still see the visualization (even though there might be a count mismatch between images.txt and cameras.txt, about which they will get notified with an alert when they open the page for the first time).