### PR TITLE
Add correspondence augmenter

### DIFF
--- a/gtsfm/configs/deep_front_end.yaml
+++ b/gtsfm/configs/deep_front_end.yaml
@@ -50,6 +50,31 @@ SceneOptimizer:
       _target_: gtsfm.two_view_estimator.InlierSupportProcessor
       min_num_inliers_est_model: 15
       min_inlier_ratio_est_model: 0.1
+  
+  correspondence_augmenter:
+    _target_: gtsfm.frontend.correspondence_augmenter.CorrespondenceAugmenter
+    correspondence_generator:
+      _target_: gtsfm.frontend.correspondence_generator.det_desc_correspondence_generator.DetDescCorrespondenceGenerator
+
+      detector_descriptor:
+        _target_: gtsfm.frontend.cacher.detector_descriptor_cacher.DetectorDescriptorCacher
+        detector_descriptor_obj:
+          _target_: gtsfm.frontend.detector_descriptor.sift.SIFTDetectorDescriptor
+          max_keypoints: 5000
+
+      matcher:
+        _target_: gtsfm.frontend.cacher.matcher_cacher.MatcherCacher
+        matcher_obj:
+          _target_: gtsfm.frontend.matcher.twoway_matcher.TwoWayMatcher
+          ratio_test_threshold: 0.8 
+    eval_threshold_px: 4 # in px
+    triangulation_options:
+      _target_: gtsfm.data_association.point3d_initializer.TriangulationOptions
+      mode:
+        _target_: gtsfm.data_association.point3d_initializer.TriangulationSamplingMode
+        value: NO_RANSAC
+
+
 
   multiview_optimizer:
     _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer

--- a/gtsfm/frontend/correspondence_augmenter.py
+++ b/gtsfm/frontend/correspondence_augmenter.py
@@ -137,10 +137,13 @@ class CorrespondenceAugmenter:
         results: Dict[Tuple[int, int], TWO_VIEW_OUTPUT] = {}
         for (i1, i2), two_view_output in two_view_outputs.items():
             new_corr_idxs = verified_corr_idxs_dict[(i1, i2)]
-            new_corr_idxs[:, 0] += keypoint_idx_offsets[i1]
-            new_corr_idxs[:, 1] += keypoint_idx_offsets[i2]
+            if len(new_corr_idxs) > 0:
+                new_corr_idxs[:, 0] += keypoint_idx_offsets[i1]
+                new_corr_idxs[:, 1] += keypoint_idx_offsets[i2]
 
-            augmented_v_corr_idxs = np.append(two_view_output[2], new_corr_idxs, axis=0)
+                augmented_v_corr_idxs = np.append(two_view_output[2], new_corr_idxs, axis=0)
+            else:
+                augmented_v_corr_idxs = two_view_output[2]
 
             two_view_reports = two_view_output[3]
             two_view_report_before_augmentation = two_view_reports[TWO_VIEW_REPORT_TAG.POST_ISP]

--- a/gtsfm/frontend/correspondence_augmenter.py
+++ b/gtsfm/frontend/correspondence_augmenter.py
@@ -83,6 +83,9 @@ class CorrespondenceAugmenter:
             triangulation_options: TriangulationOptions,
             ba_optimizer: BundleAdjustmentOptimizer,
         ) -> np.ndarray:
+            if i2Ri1 is None or i2Ui1 is None:
+                return np.array([], dtype=np.uint64)
+
             i2Ti1_prior = PosePrior(
                 value=Pose3(i2Ri1, i2Ui1.point3()),
                 covariance=RELATIVE_POSE_PRIOR_SIGMA,

--- a/gtsfm/frontend/correspondence_augmenter.py
+++ b/gtsfm/frontend/correspondence_augmenter.py
@@ -1,0 +1,173 @@
+"""Augment correspondences on two-view estimates.
+
+Authors: Ayush Baid
+"""
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+from dask.distributed import Client, Future
+from gtsam import Pose3, Rot3, Unit3
+
+import gtsfm.common.types as gtsfm_types
+import gtsfm.frontend.two_view_ba_utils as two_view_ba_utils
+from gtsfm.bundle.bundle_adjustment import BundleAdjustmentOptimizer
+from gtsfm.bundle.two_view_ba import TwoViewBundleAdjustment
+from gtsfm.common.keypoints import Keypoints
+from gtsfm.common.pose_prior import PosePrior, PosePriorType
+from gtsfm.data_association.point3d_initializer import TriangulationOptions
+from gtsfm.frontend.correspondence_generator.correspondence_generator_base import CorrespondenceGeneratorBase
+from gtsfm.two_view_estimator import TWO_VIEW_OUTPUT, TWO_VIEW_REPORT_TAG, generate_two_view_report_from_result
+
+RELATIVE_POSE_PRIOR_SIGMA = np.ones((6,)) * 3e-2
+
+
+class CorrespondenceAugmenter:
+    """Augment correspondences on two-view estimates."""
+
+    def __init__(
+        self,
+        correspondence_generator: CorrespondenceGeneratorBase,
+        eval_threshold_px: float,
+        triangulation_options: TriangulationOptions,
+        bundle_adjust_2view_maxiters: int = 10,
+        ba_reproj_error_thresholds: List[Optional[float]] = [3],
+    ) -> None:
+        self._correspondence_generator = correspondence_generator
+        self._corr_metric_dist_threshold = eval_threshold_px
+        self._triangulation_options = triangulation_options
+        self._ba_optimizer = TwoViewBundleAdjustment(
+            reproj_error_thresholds=ba_reproj_error_thresholds,
+            robust_measurement_noise=True,
+            max_iterations=bundle_adjust_2view_maxiters,
+        )
+
+    def _augment_keypoints(self, keypoints_original: Keypoints, keypoints_new: Keypoints) -> Tuple[Keypoints, int]:
+        if len(keypoints_original) == 0:
+            return keypoints_new, 0
+        if len(keypoints_new) == 0:
+            return keypoints_original, 0
+
+        num_original_keypoints = len(keypoints_original)
+
+        # Note(Ayush): we avoid augmenting scales and responses and they do not make sense across different detectors
+        return (
+            Keypoints(coordinates=np.append(keypoints_original.coordinates, keypoints_new.coordinates, axis=0)),
+            num_original_keypoints,
+        )
+
+    def augment_correspondences(
+        self,
+        client: Client,
+        images: List[Future],
+        keypoints_list: List[Keypoints],
+        camera_intrinsics: List[gtsfm_types.CALIBRATION_TYPE],
+        two_view_outputs: Dict[Tuple[int, int], TWO_VIEW_OUTPUT],
+        gt_cameras: List[Optional[gtsfm_types.CAMERA_TYPE]],
+        gt_scene_mesh: Optional[Any],
+    ) -> Tuple[List[Keypoints], Dict[Tuple[int, int], TWO_VIEW_OUTPUT]]:
+        (
+            keypoints_to_augment_list,
+            putative_corr_idxs_to_augment,
+        ) = self._correspondence_generator.generate_correspondences(
+            client=client, images=images, image_pairs=list(two_view_outputs.keys())
+        )
+
+        def verify_putative_correspondences(
+            keypoints_i1: Keypoints,
+            Keypoints_i2: Keypoints,
+            putative_corr_idxs: np.ndarray,
+            camera_intrinsics_i1: gtsfm_types.CALIBRATION_TYPE,
+            camera_intrinsics_i2: gtsfm_types.CALIBRATION_TYPE,
+            i2Ri1: Rot3,
+            i2Ui1: Unit3,
+            triangulation_options: TriangulationOptions,
+            ba_optimizer: BundleAdjustmentOptimizer,
+        ) -> np.ndarray:
+            i2Ti1_prior = PosePrior(
+                value=Pose3(i2Ri1, i2Ui1.point3()),
+                covariance=RELATIVE_POSE_PRIOR_SIGMA,
+                type=PosePriorType.SOFT_CONSTRAINT,
+            )
+
+            _, _, verified_corr_idxs = two_view_ba_utils.bundle_adjust(
+                keypoints_i1=keypoints_i1,
+                keypoints_i2=Keypoints_i2,
+                verified_corr_idxs=putative_corr_idxs,
+                camera_intrinsics_i1=camera_intrinsics_i1,
+                camera_intrinsics_i2=camera_intrinsics_i2,
+                i2Ri1_initial=i2Ri1,
+                i2Ui1_initial=i2Ui1,
+                i2Ti1_prior=i2Ti1_prior,
+                triangulation_options=triangulation_options,
+                ba_optimizer=ba_optimizer,
+            )
+
+            return verified_corr_idxs
+
+        verified_corr_idxs_futures = {
+            (i1, i2): client.submit(
+                verify_putative_correspondences,
+                keypoints_to_augment_list[i1],
+                keypoints_to_augment_list[i2],
+                putative_corr_idxs_to_augment[(i1, i2)],
+                camera_intrinsics[i1],
+                camera_intrinsics[i2],
+                two_view_output[0],
+                two_view_output[1],
+                self._triangulation_options,
+                self._ba_optimizer,
+            )
+            for (i1, i2), two_view_output in two_view_outputs.items()
+        }
+        verified_corr_idxs_dict = client.gather(verified_corr_idxs_futures)
+
+        augmented_keypoints_list: List[Keypoints] = []
+        keypoint_idx_offsets: List[int] = []
+        for keypoints_original, keypoints_new in zip(keypoints_list, keypoints_to_augment_list):
+            keypoints_augmented, offset = self._augment_keypoints(
+                keypoints_original=keypoints_original, keypoints_new=keypoints_new
+            )
+            augmented_keypoints_list.append(keypoints_augmented)
+            keypoint_idx_offsets.append(offset)
+
+        # Merge the corr_idxs
+        results: Dict[Tuple[int, int], TWO_VIEW_OUTPUT] = {}
+        for (i1, i2), two_view_output in two_view_outputs.items():
+            new_corr_idxs = verified_corr_idxs_dict[(i1, i2)]
+            new_corr_idxs[:, 0] += keypoint_idx_offsets[i1]
+            new_corr_idxs[:, 1] += keypoint_idx_offsets[i2]
+
+            augmented_v_corr_idxs = np.append(two_view_output[2], new_corr_idxs, axis=0)
+
+            two_view_reports = two_view_output[3]
+            two_view_report_before_augmentation = two_view_reports[TWO_VIEW_REPORT_TAG.POST_ISP]
+            num_putative_corrs_before_augmentation = (
+                int(
+                    two_view_report_before_augmentation.num_inliers_est_model
+                    / two_view_report_before_augmentation.inlier_ratio_est_model
+                )
+                if two_view_report_before_augmentation.inlier_ratio_est_model is not None
+                else 0
+            )
+            num_putative_corrs_post_augmentation = (
+                num_putative_corrs_before_augmentation + putative_corr_idxs_to_augment[(i1, i2)].shape[0]
+            )
+
+            two_view_report_post_augmentation = generate_two_view_report_from_result(
+                i2Ri1_computed=two_view_output[0],
+                i2Ui1_computed=two_view_output[1],
+                keypoints_i1=augmented_keypoints_list[i1],
+                keypoints_i2=augmented_keypoints_list[i2],
+                verified_corr_idxs=augmented_v_corr_idxs,
+                inlier_ratio_wrt_estimate=augmented_v_corr_idxs.shape[0] / num_putative_corrs_post_augmentation,
+                gt_camera_i1=gt_cameras[i1],
+                gt_camera_i2=gt_cameras[i2],
+                gt_scene_mesh=gt_scene_mesh,
+                corr_metric_dist_threshold=self._corr_metric_dist_threshold,
+            )
+
+            two_view_reports[TWO_VIEW_REPORT_TAG.CORRESPONDENCE_AUGMENTED] = two_view_report_post_augmentation
+
+            results[(i1, i2)] = (two_view_output[0], two_view_output[1], augmented_v_corr_idxs, two_view_reports)
+
+        return augmented_keypoints_list, results

--- a/gtsfm/frontend/two_view_ba_utils.py
+++ b/gtsfm/frontend/two_view_ba_utils.py
@@ -1,0 +1,131 @@
+"""Functions to run Bundle Adjustment on a pair of images.
+
+Authors: Ayush Baid, John Lambert.
+"""
+import timeit
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+from gtsam import Pose3, Rot3, SfmTrack, Unit3
+
+import gtsfm.common.types as gtsfm_types
+import gtsfm.utils.logger as logger_utils
+from gtsfm.bundle.bundle_adjustment import BundleAdjustmentOptimizer
+from gtsfm.common.gtsfm_data import GtsfmData
+from gtsfm.common.keypoints import Keypoints
+from gtsfm.common.pose_prior import PosePrior
+from gtsfm.common.sfm_track import SfmMeasurement, SfmTrack2d
+from gtsfm.data_association.point3d_initializer import Point3dInitializer, TriangulationOptions
+
+logger = logger_utils.get_logger()
+
+
+def triangulate_two_view_correspondences(
+    triangulation_options: TriangulationOptions,
+    cameras: Dict[int, gtsfm_types.CAMERA_TYPE],
+    keypoints_i1: Keypoints,
+    keypoints_i2: Keypoints,
+    corr_ind: np.ndarray,
+) -> Tuple[List[int], List[SfmTrack]]:
+    """Triangulate 2-view correspondences to form 3D tracks.
+
+    Args:
+        camera_i1: Camera for 1st view.
+        camera_i2: Camera for 2nd view.
+        keypoints_i1: Keypoints for 1st view.
+        keypoints_i2: Keypoints for 2nd view.
+        corr_ind: Indices of corresponding keypoints.
+
+    Returns:
+        Indices of successfully triangulated tracks.
+        Triangulated 3D points as tracks.
+    """
+    assert len(cameras) == 2
+    point3d_initializer = Point3dInitializer(cameras, triangulation_options)
+    triangulated_indices: List[int] = []
+    triangulated_tracks: List[SfmTrack] = []
+    for j, (idx1, idx2) in enumerate(corr_ind):
+        track2d = SfmTrack2d(
+            [SfmMeasurement(0, keypoints_i1.coordinates[idx1]), SfmMeasurement(1, keypoints_i2.coordinates[idx2])]
+        )
+        track, _, _ = point3d_initializer.triangulate(track2d)
+        if track is not None:
+            triangulated_indices.append(j)
+            triangulated_tracks.append(track)
+
+    return triangulated_indices, triangulated_tracks
+
+
+def bundle_adjust(
+    keypoints_i1: Keypoints,
+    keypoints_i2: Keypoints,
+    verified_corr_idxs: np.ndarray,
+    camera_intrinsics_i1: gtsfm_types.CALIBRATION_TYPE,
+    camera_intrinsics_i2: gtsfm_types.CALIBRATION_TYPE,
+    i2Ri1_initial: Optional[Rot3],
+    i2Ui1_initial: Optional[Unit3],
+    i2Ti1_prior: Optional[PosePrior],
+    triangulation_options: TriangulationOptions,
+    ba_optimizer: BundleAdjustmentOptimizer,
+) -> Tuple[Optional[Rot3], Optional[Unit3], np.ndarray]:
+    """Refine the relative pose using bundle adjustment on the 2-view scene.
+
+    Args:
+        keypoints_i1: Keypoints from image i1.
+        keypoints_i2: Keypoints from image i2.
+        verified_corr_idxs: Indices of verified correspondences between i1 and i2.
+        camera_intrinsics_i1: Intrinsics for i1.
+        camera_intrinsics_i2: Intrinsics for i2.
+        i2Ri1_initial: The relative rotation to be used as initial rotation between cameras.
+        i2Ui1_initial: The relative unit direction, to be used to initialize initial translation between cameras.
+        i2Ti1_prior: Prior on the relative pose for cameras (i1, i2).
+    Returns:
+        Optimized relative rotation i2Ri1.
+        Optimized unit translation i2Ui1.
+        Optimized verified_corr_idxs.
+    """
+    # Choose initial pose estimate for triangulation and BA (prior gets priority).
+    i2Ti1_initial = i2Ti1_prior.value if i2Ti1_prior is not None else None
+    if i2Ti1_initial is None and i2Ri1_initial is not None and i2Ui1_initial is not None:
+        i2Ti1_initial = Pose3(i2Ri1_initial, i2Ui1_initial.point3())
+    if i2Ti1_initial is None:
+        return None, None, verified_corr_idxs
+
+    # Set the i1 camera pose as the global coordinate system.
+    camera_class = gtsfm_types.get_camera_class_for_calibration(camera_intrinsics_i1)
+    cameras = {
+        0: camera_class(Pose3(), camera_intrinsics_i1),
+        1: camera_class(i2Ti1_initial.inverse(), camera_intrinsics_i2),
+    }
+
+    # Triangulate!
+    start_time = timeit.default_timer()
+    triangulated_indices, triangulated_tracks = triangulate_two_view_correspondences(
+        triangulation_options, cameras, keypoints_i1, keypoints_i2, verified_corr_idxs
+    )
+    logger.debug("Performed DA in %.6f seconds.", timeit.default_timer() - start_time)
+    logger.debug("Triangulated %d correspondences out of %d.", len(triangulated_tracks), len(verified_corr_idxs))
+
+    if len(triangulated_tracks) == 0:
+        return i2Ti1_initial.rotation(), Unit3(i2Ti1_initial.translation()), np.array([], dtype=np.uint32)
+
+    # Build BA inputs.
+    start_time = timeit.default_timer()
+    ba_input = GtsfmData(number_images=2, cameras=cameras, tracks=triangulated_tracks)
+    relative_pose_prior_for_ba = {(0, 1): i2Ti1_prior} if i2Ti1_prior is not None else {}
+
+    # Optimize!
+    _, ba_output, valid_mask = ba_optimizer.run_ba(
+        ba_input, absolute_pose_priors=[], relative_pose_priors=relative_pose_prior_for_ba, verbose=False
+    )
+
+    # Unpack results.
+    valid_corr_idxs = verified_corr_idxs[triangulated_indices][valid_mask]
+    wTi1, wTi2 = ba_output.get_camera_poses()  # extract the camera poses
+    if wTi1 is None or wTi2 is None:
+        logger.warning("2-view BA failed...")
+        return i2Ri1_initial, i2Ui1_initial, valid_corr_idxs
+    i2Ti1_optimized = wTi2.between(wTi1)
+    logger.debug("Performed 2-view BA in %.6f seconds.", timeit.default_timer() - start_time)
+
+    return i2Ti1_optimized.rotation(), Unit3(i2Ti1_optimized.translation()), valid_corr_idxs


### PR DESCRIPTION
Correspondence augmenter fits in between the two-view estimator and the multi-view estimator. It uses the pose estimates from the 2-view estimator and runs a different correspondence generator to augmend correspondences