### PR TITLE
generalize self-hosted runner to other machines, change data location

### DIFF
--- a/.github/scripts/execute_single_benchmark_self_hosted.sh
+++ b/.github/scripts/execute_single_benchmark_self_hosted.sh
@@ -3,7 +3,7 @@
 # Datasets are stored in ~/sfm_datasets in order to reduce runtimes by not 
 # redownloading each (very large) dataset every CI run. Any new datasets must be
 # downloaded and stored in ~/sfm_datasets before running this action.
-DATASET_PREFIX=/home/tdriver6/sfm_datasets
+DATASET_PREFIX=/usr/local/gtsfm-data
 
 DATASET_NAME=$1
 CONFIG_NAME=$2

--- a/.github/scripts/execute_single_benchmark_self_hosted.sh
+++ b/.github/scripts/execute_single_benchmark_self_hosted.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Datasets are stored in ~/sfm_datasets in order to reduce runtimes by not 
+# Datasets are stored in /usr/local/gtsfm-data in order to reduce runtimes by not 
 # redownloading each (very large) dataset every CI run. Any new datasets must be
-# downloaded and stored in ~/sfm_datasets before running this action.
+# downloaded and stored in /usr/local/gtsfm-data before running this action.
 DATASET_PREFIX=/usr/local/gtsfm-data
 
 DATASET_NAME=$1

--- a/.github/workflows/benchmark-self-hosted.yml
+++ b/.github/workflows/benchmark-self-hosted.yml
@@ -1,4 +1,4 @@
-name: Benchmark GTSFM on select datasets on the wildcat machine
+name: Benchmark GTSFM on select datasets using our self-hosted instances
 
 ################################################################################
 # Please only run this action after making sure that the shorter benchmarks
@@ -58,10 +58,10 @@ jobs:
           ./download_model_weights.sh
       - name: Prepare dataset
         run: |
-          echo "Datasets are stored in /home/tdriver6/sfm_datasets in order to" 
+          echo "Datasets are stored in /usr/local/gtsfm-data in order to" 
           echo "reduce runtimes by not redownloading each (very large) dataset"
           echo "every CI run. Any new datasets must be downloaded and stored in"
-          echo "/home/tdriver6/sfm_datasets before running this action."
+          echo "/usr/local/gtsfm-data before running this action."
       - name: Run GTSfM
         run: |
           DATASET_NAME=${{ matrix.config_dataset_info[1] }}
@@ -74,7 +74,7 @@ jobs:
           pwd
           micromamba activate gtsfm-v1
           micromamba list
-          bash .github/scripts/execute_single_benchmark_wildcat.sh \
+          bash .github/scripts/execute_single_benchmark_self_hosted.sh \
             $DATASET_NAME \
             $CONFIG_NAME \
             $MAX_FRAME_LOOKAHEAD \


### PR DESCRIPTION
updates data location to a common /usr/local/gtsfm-data which all users can access. 
also changed the instance from wildcat to eagle, but this does not matter, we can potentially run on any machine. 