### PR TITLE
Increase memory limit for SSH cluster

### DIFF
--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -214,6 +214,7 @@ class GtsfmRunnerBase:
                     worker_options={
                         "n_workers": self.parsed_args.num_workers,
                         "nthreads": self.parsed_args.threads_per_worker,
+                        "memory_limit": "8GB",
                     },
                 )
                 connected = True


### PR DESCRIPTION
Fixes crashes due to workers running out of memory in auto mode