### PR TITLE
Save pose AUC plots by default to pose_auc/* folder.

### DIFF
--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -141,9 +141,8 @@ class MultiViewOptimizer:
             relative_pose_priors,
             images,
         )
-
         ba_result_graph, ba_metrics_graph = self.ba_optimizer.create_computation_graph(
-            ba_input_graph, absolute_pose_priors, relative_pose_priors, cameras_gt
+            ba_input_graph, absolute_pose_priors, relative_pose_priors, cameras_gt, save_dir=output_root
         )
 
         multiview_optimizer_metrics_graph = [

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -227,7 +227,7 @@ class GtsfmRunnerBase:
         """Run the SceneOptimizer."""
         start_time = time.time()
 
-        # create dask cluster
+        # Create dask cluster.
         if self.parsed_args.cluster_config:
             cluster = self.setup_ssh_cluster_with_retries()
             client = Client(cluster)
@@ -241,7 +241,7 @@ class GtsfmRunnerBase:
             )
             client = Client(cluster)
 
-        # create process graph
+        # Create process graph.
         process_graph_generator = ProcessGraphGenerator()
         if isinstance(self.scene_optimizer.correspondence_generator, ImageCorrespondenceGenerator):
             process_graph_generator.is_image_correspondence = True

--- a/gtsfm/utils/metrics.py
+++ b/gtsfm/utils/metrics.py
@@ -308,6 +308,7 @@ def compute_pose_auc_metric(
     rotation_angular_errors: Sequence[float],
     translation_angular_errors: Sequence[float],
     thresholds_deg: Tuple[float] = (1, 2.5, 5, 10, 20),
+    save_dir: Optional[str] = None,
 ) -> List[GtsfmMetric]:
     """Computes "Pose AUC" metric from rotation & translation angular errors.
 
@@ -328,7 +329,7 @@ def compute_pose_auc_metric(
         raise ValueError("# of rotation and translation angular errors must match.")
 
     pose_errors = np.maximum(rotation_angular_errors, translation_angular_errors)
-    aucs = pose_auc(pose_errors, thresholds_deg)
+    aucs = pose_auc(pose_errors, thresholds_deg, save_dir=save_dir)
     metrics = []
     for threshold, auc in zip(thresholds_deg, aucs):
         metrics.append(GtsfmMetric(f"pose_auc_@{threshold}_deg", auc))
@@ -338,6 +339,7 @@ def compute_pose_auc_metric(
 def compute_ba_pose_metrics(
     gt_wTi_list: List[Pose3],
     ba_output: GtsfmData,
+    save_dir: Optional[str] = None,
 ) -> GtsfmMetricsGroup:
     """Compute pose errors w.r.t. GT for the bundle adjustment result.
 
@@ -364,7 +366,7 @@ def compute_ba_pose_metrics(
 
     rotation_angular_errors = metrics[0]._data
     translation_angular_errors = metrics[3]._data
-    metrics.extend(compute_pose_auc_metric(rotation_angular_errors, translation_angular_errors))
+    metrics.extend(compute_pose_auc_metric(rotation_angular_errors, translation_angular_errors, save_dir=save_dir))
 
     return GtsfmMetricsGroup(name="ba_pose_error_metrics", metrics=metrics)
 
@@ -502,7 +504,9 @@ def get_measurement_angle_errors(
     return errors
 
 
-def pose_auc(errors: np.ndarray, thresholds: Sequence[float], save_plot: bool = True) -> Sequence[float]:
+def pose_auc(
+    errors: np.ndarray, thresholds: Sequence[float], save_plot: bool = True, save_dir: Optional[str] = None
+) -> Sequence[float]:
     """Computes area under the Recall (y) vs. Pose Error (x) curve, the pose AUC.
 
     If recall is defined as TP / # actual positives, then every camera is a TP if one can register it.
@@ -510,6 +514,8 @@ def pose_auc(errors: np.ndarray, thresholds: Sequence[float], save_plot: bool = 
     Args:
         errors: Array of shape (n,) representing angular errors.
         thresholds: Angular error thresholds.
+        save_plot: Whether to save an AUC plot.
+        save_dir: Directory where AUC plots should be saved.
 
     Returns:
         List of AUC values, one per threshold.
@@ -526,13 +532,15 @@ def pose_auc(errors: np.ndarray, thresholds: Sequence[float], save_plot: bool = 
         r = np.r_[recall[:last_index], recall[last_index - 1]]
         e = np.r_[errors[:last_index], t]
         if save_plot:
+            if save_dir is None:
+                raise ValueError("If `save_plot` is True, then `save_dir` must be provided.")
             plt.scatter(e, r, 20, color="k", marker=".")
             plt.plot(e, r, color="r")
             plt.ylabel("Recall")
             plt.xlabel("Pose Error (deg.)")
             uuid = datetime.datetime.utcnow().strftime("%Y_%m_%d_%H_%M_%S_%f")
-            Path("pose_auc").mkdir(parents=True, exist_ok=True)
-            save_fpath = Path("pose_auc", f"{uuid}_recall_vs_pose_error_curve_auc_{t}_deg_threshold.jpg")
+            Path(save_dir, "pose_auc").mkdir(parents=True, exist_ok=True)
+            save_fpath = Path(save_dir, "pose_auc", f"{uuid}_recall_vs_pose_error_curve_auc_{t}_deg_threshold.jpg")
             plt.savefig(save_fpath)
             plt.close("all")
 

--- a/gtsfm/utils/metrics.py
+++ b/gtsfm/utils/metrics.py
@@ -502,7 +502,7 @@ def get_measurement_angle_errors(
     return errors
 
 
-def pose_auc(errors: np.ndarray, thresholds: Sequence[float], save_plot: bool = False) -> Sequence[float]:
+def pose_auc(errors: np.ndarray, thresholds: Sequence[float], save_plot: bool = True) -> Sequence[float]:
     """Computes area under the Recall (y) vs. Pose Error (x) curve, the pose AUC.
 
     If recall is defined as TP / # actual positives, then every camera is a TP if one can register it.
@@ -531,7 +531,8 @@ def pose_auc(errors: np.ndarray, thresholds: Sequence[float], save_plot: bool = 
             plt.ylabel("Recall")
             plt.xlabel("Pose Error (deg.)")
             uuid = datetime.datetime.utcnow().strftime("%Y_%m_%d_%H_%M_%S_%f")
-            save_fpath = f"{uuid}_recall_vs_pose_error_curve_auc.jpg"
+            Path("pose_auc").mkdir(parents=True, exist_ok=True)
+            save_fpath = Path("pose_auc", f"{uuid}_recall_vs_pose_error_curve_auc_{t}_deg_threshold.jpg")
             plt.savefig(save_fpath)
             plt.close("all")
 

--- a/gtsfm/utils/metrics.py
+++ b/gtsfm/utils/metrics.py
@@ -539,8 +539,10 @@ def pose_auc(
             plt.ylabel("Recall")
             plt.xlabel("Pose Error (deg.)")
             uuid = datetime.datetime.utcnow().strftime("%Y_%m_%d_%H_%M_%S_%f")
-            Path(save_dir, "pose_auc").mkdir(parents=True, exist_ok=True)
-            save_fpath = Path(save_dir, "pose_auc", f"{uuid}_recall_vs_pose_error_curve_auc_{t}_deg_threshold.jpg")
+            Path(save_dir, "plots", "pose_auc").mkdir(parents=True, exist_ok=True)
+            save_fpath = Path(
+                save_dir, "plots", "pose_auc", f"{uuid}_recall_vs_pose_error_curve_auc_{t}_deg_threshold.jpg"
+            )
             plt.savefig(save_fpath)
             plt.close("all")
 

--- a/tests/utils/test_metric_utils.py
+++ b/tests/utils/test_metric_utils.py
@@ -222,7 +222,7 @@ def test_pose_auc1() -> None:
     errors = np.ones(5) * 5.0
     thresholds = [5, 10, 20]
 
-    aucs = metric_utils.pose_auc(errors, thresholds)
+    aucs = metric_utils.pose_auc(errors, thresholds, save_plot=False)
 
     # Sum triangles and rectangles.
     # AUC @ 5 deg thresh: 0. (no cameras under this threshold).
@@ -237,7 +237,7 @@ def test_pose_auc_all_zero_errors_perfect_auc() -> None:
     errors = np.zeros(5)
 
     thresholds = [5, 10, 20]
-    aucs = metric_utils.pose_auc(errors, thresholds)
+    aucs = metric_utils.pose_auc(errors, thresholds, save_plot=False)
     expected_aucs = [1.0, 1.0, 1.0]
     assert np.allclose(aucs, expected_aucs)
 
@@ -245,7 +245,7 @@ def test_pose_auc_all_zero_errors_perfect_auc() -> None:
 def test_pose_auc_all_errors_exceed_threshold_zero_auc() -> None:
     errors = np.ones(5) * 25.0
     thresholds = [5, 10, 20]
-    aucs = metric_utils.pose_auc(errors, thresholds)
+    aucs = metric_utils.pose_auc(errors, thresholds, save_plot=False)
     expected_aucs = [0.0, 0.0, 0.0]
     assert np.allclose(aucs, expected_aucs)
 
@@ -290,7 +290,7 @@ def test_pose_auc_works_for_nan_error() -> None:
         ]
     )
 
-    aucs = metric_utils.pose_auc(pose_errors, thresholds)
+    aucs = metric_utils.pose_auc(pose_errors, thresholds, save_plot=False)
 
     # Note recall is roughly (27 / 32) since exclude 5 errors above 1 deg -> (1.422, 1.676, 2.935, 6.655,   nan)
     # If we drew triangle up to recall point, we would get 0.84 * 0.5 -> 0.42, but more


### PR DESCRIPTION
Door-12 file named as `2023_08_04_02_39_53_236300_recall_vs_pose_error_curve_auc_1_deg_threshold.jpg`.
![2023_08_04_02_39_53_236300_recall_vs_pose_error_curve_auc_1_deg_threshold](https://github.com/borglab/gtsfm/assets/16724970/6ce262dc-b011-4c7a-8775-92c029ccb39d)
