### PR TITLE
allow configurable local cluster port

### DIFF
--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -276,6 +276,7 @@ class GtsfmRunnerBase:
             local_cluster_kwargs = {
                 "n_workers": self.parsed_args.num_workers,
                 "threads_per_worker": self.parsed_args.threads_per_worker,
+                "dashboard_address": self.parsed_args.dashboard_port
             }
             if self.parsed_args.worker_memory_limit is not None:
                 local_cluster_kwargs["memory_limit"] = self.parsed_args.worker_memory_limit


### PR DESCRIPTION
no-op, as already defaults to 8787 (https://distributed.dask.org/en/stable/api.html#distributed.LocalCluster)