### PR TITLE
Bump up shonan optimality threshold param

### DIFF
--- a/gtsfm/averaging/rotation/shonan.py
+++ b/gtsfm/averaging/rotation/shonan.py
@@ -33,6 +33,9 @@ logger = logger_utils.get_logger()
 
 _DEFAULT_TWO_VIEW_ROTATION_SIGMA = 1.0
 
+# The threshold for the smallest eigenvalue check in GTSAM. Defaults to -1e-4 in GTSAM.
+_OPTIMALITY_THRESHOLD = -1e-5
+
 
 class ShonanRotationAveraging(RotationAveragingBase):
     """Performs Shonan rotation averaging."""
@@ -60,6 +63,7 @@ class ShonanRotationAveraging(RotationAveragingBase):
         shonan_params = ShonanAveragingParameters3(lm_params)
         shonan_params.setUseHuber(False)
         shonan_params.setCertifyOptimality(True)
+        shonan_params.setOptimalityThreshold(_OPTIMALITY_THRESHOLD)
         return shonan_params
 
     def __measurements_from_2view_relative_rotations(


### PR DESCRIPTION
This commit passes in the optimality treshold explicitly from GTSFM: a value of `-1e-5` compared to `-1e-4` default value.
I tried using 0 and `1e-5` (value used in paper for large datasets) but even the unit tests are taking up a lot of time with higher thresholds.