### PR TITLE
Move open3d to from pip to config dependency and remove duplicate pycolmap dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ To run GTSfM, first, we need to create a conda environment with the required dep
 On **Linux**, with CUDA support, run:
 
 ```bash
-conda env create -f environment_linux.yml
-conda activate gtsfm-v1 # you may need "source activate gtsfm-v1" depending upon your bash and conda set-up
+mamba env create -f environment_linux.yml
+mamba activate gtsfm-v1 # you may need "source activate gtsfm-v1" depending upon your bash and conda set-up
 ```
 
 On **macOS**, there is no CUDA support, so run:

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -49,14 +49,13 @@ dependencies:
   - tabulate
   - simplejson
   - pycolmap
+  - open3d
   # testing
   - parameterized
   - pip:
-      - open3d
       - opencv-python>=4.5.4.58 # pypi has a more recent distribution than conda-forge
       - pydegensac
       - colour
       - trimesh[easy]
-      - pycolmap>=0.1.0
       - gtsam==4.2
       - pydot


### PR DESCRIPTION
The existing config failed for me because of open3d. Using the conda install worked better for me on my mac (M2 silicon)