### PR TITLE
Fix unit test failures in TA and process graph generator

### DIFF
--- a/gtsfm/averaging/translation/averaging_1dsfm.py
+++ b/gtsfm/averaging/translation/averaging_1dsfm.py
@@ -532,7 +532,7 @@ class TranslationAveraging1DSFM(TranslationAveragingBase):
             if tracks_2d is None:
                 raise ValueError("Tracks must be provided when they are to be used in translation averaging.")
             if intrinsics is None or len(intrinsics) != len(wRi_list):
-                raise ValueError("Number of intrinsics must match number of rotations when tracks are provided.")
+                raise ValueError("Number of intrinsics must match number of cameras when tracks are provided.")
             selected_tracks = self._select_tracks_for_averaging(tracks_2d, valid_cameras, intrinsics)
             w_i2Ui1_dict_tracks = self._get_landmark_directions(selected_tracks, intrinsics, wRi_list)
         else:

--- a/tests/ui/test_process_graph_generator.py
+++ b/tests/ui/test_process_graph_generator.py
@@ -44,8 +44,8 @@ class TestProcessGraphGenerator(unittest.TestCase):
 
         output_raw_dot = process_graph_generator._main_graph.to_string()
 
-        self.assertTrue("GTSFMProcess" not in output_raw_dot)
-        self.assertTrue("Fake" not in output_raw_dot)
+        self.assertNotIn("GTSFMProcess", output_raw_dot)
+        self.assertNotIn("Fake", output_raw_dot)
 
     def test_build_graph(self):
         """Check that the test nodes are in the graph and connected correctly.
@@ -58,16 +58,16 @@ class TestProcessGraphGenerator(unittest.TestCase):
         output_raw_dot = process_graph_generator._main_graph.to_string()
 
         # can't assert the full graph directly because the REGISTRY will have other classes
-        self.assertTrue("FakeImageLoader [" in output_raw_dot)
-        self.assertTrue('"Internal Data" [' in output_raw_dot)
-        self.assertTrue('FakeImageLoader -> "Internal Data"  [' in output_raw_dot)
-        self.assertTrue('"Raw Images" -> FakeImageLoader  [' in output_raw_dot)
-        self.assertTrue('FakeOutput -> "GTSFM Output"  [' in output_raw_dot)
-        self.assertTrue('"Internal Data" -> FakeOutput  [' in output_raw_dot)
-        self.assertTrue("subgraph cluster_ParentPlate" in output_raw_dot)
-        self.assertTrue("label=ParentPlate" in output_raw_dot)
-        self.assertTrue("FakeOutput [" in output_raw_dot)
-        self.assertTrue('"GTSFM Output" [' in output_raw_dot)
+        self.assertIn("FakeImageLoader [", output_raw_dot)
+        self.assertIn('"Internal Data" [', output_raw_dot)
+        self.assertIn('FakeImageLoader -> "Internal Data"', output_raw_dot)
+        self.assertIn('"Raw Images" -> FakeImageLoader', output_raw_dot)
+        self.assertIn('FakeOutput -> "GTSFM Output"', output_raw_dot)
+        self.assertIn('"Internal Data" -> FakeOutput', output_raw_dot)
+        self.assertIn("subgraph cluster_ParentPlate", output_raw_dot)
+        self.assertIn("label=ParentPlate", output_raw_dot)
+        self.assertIn("FakeOutput [", output_raw_dot)
+        self.assertIn('"GTSFM Output" [', output_raw_dot)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
TA unit tests were failing due to some recently added sanity checks. 

Process graph generator expects a certain formatting of output, while that does not seem to be the real intention of the test. The two-spacing output has changed to single spacing, likely due to some version changes in the dependencies. 