### PR TITLE
graph partitioning update + local test with failed pytest

### DIFF
--- a/gtsfm/graph_partitioner/graph_partitioner_base.py
+++ b/gtsfm/graph_partitioner/graph_partitioner_base.py
@@ -4,7 +4,6 @@ Authors: Zongyue Liu
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, List, Tuple, Any
 
 import numpy as np
 
@@ -18,7 +17,7 @@ logger = logger_utils.get_logger()
 class GraphPartitionerBase(GTSFMProcess):
     """Base class for all graph partitioners in GTSFM.
 
-    Graph partitioners take a set of image pairs (or a similarity matrix) and 
+    Graph partitioners take a set of image pairs and 
     divide them into subgraphs to be processed independently.
     """
 
@@ -47,13 +46,11 @@ class GraphPartitionerBase(GTSFMProcess):
 
     @abstractmethod
     def partition_image_pairs(
-        self, image_pairs: List[Tuple[int, int]]
-    ) -> List[List[Tuple[int, int]]]:
+        self, image_pairs: list[tuple[int, int]],) -> list[list[tuple[int, int]]]:
         """Partition a set of image pairs into subgraphs.
         
         Args:
-            image_pairs: List of image pairs (i,j) where i < j.
-            
+            image_pairs: List of image pairs (i,j) where i < j.          
         Returns:
             List of subgraphs, where each subgraph is a list of image pairs.
         """

--- a/gtsfm/graph_partitioner/graph_partitioner_base.py
+++ b/gtsfm/graph_partitioner/graph_partitioner_base.py
@@ -3,9 +3,9 @@
 Authors: Zongyue Liu
 """
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 
-import numpy as np
+
 
 import gtsfm.utils.logger as logger_utils
 from gtsfm.ui.gtsfm_process import GTSFMProcess
@@ -46,7 +46,8 @@ class GraphPartitionerBase(GTSFMProcess):
 
     @abstractmethod
     def partition_image_pairs(
-        self, image_pairs: list[tuple[int, int]],) -> list[list[tuple[int, int]]]:
+            self, image_pairs: list[tuple[int, int]],
+    ) -> list[list[tuple[int, int]]]:
         """Partition a set of image pairs into subgraphs.
         
         Args:
@@ -55,3 +56,6 @@ class GraphPartitionerBase(GTSFMProcess):
             List of subgraphs, where each subgraph is a list of image pairs.
         """
         pass
+
+
+

--- a/gtsfm/graph_partitioner/graph_partitioner_base.py
+++ b/gtsfm/graph_partitioner/graph_partitioner_base.py
@@ -1,0 +1,60 @@
+"""Base class for graph partitioners in GTSFM.
+
+Authors: Zongyue Liu
+"""
+
+from abc import ABC, abstractmethod
+from typing import Dict, List, Tuple, Any
+
+import numpy as np
+
+import gtsfm.utils.logger as logger_utils
+from gtsfm.ui.gtsfm_process import GTSFMProcess
+from gtsfm.ui.gtsfm_process import UiMetadata
+
+logger = logger_utils.get_logger()
+
+
+class GraphPartitionerBase(GTSFMProcess):
+    """Base class for all graph partitioners in GTSFM.
+
+    Graph partitioners take a set of image pairs (or a similarity matrix) and 
+    divide them into subgraphs to be processed independently.
+    """
+
+    def __init__(self, process_name: str = "GraphPartitioner"):
+        """Initialize the base graph partitioner.
+        
+        Args:
+            process_name: Name of the process, used for logging.
+        """
+        super().__init__()
+        self.process_name = process_name
+
+    @classmethod
+    def get_ui_metadata(cls) -> UiMetadata:
+        """Return metadata for UI display.
+        
+        Returns:
+            UiMetadata object containing UI metadata for this process.
+        """
+        return UiMetadata(
+            display_name="Graph Partitioner",
+            input_products=("Image Pairs",),
+            output_products=("Subgraphs",),
+            parent_plate="Preprocessing"
+        )
+
+    @abstractmethod
+    def partition_image_pairs(
+        self, image_pairs: List[Tuple[int, int]]
+    ) -> List[List[Tuple[int, int]]]:
+        """Partition a set of image pairs into subgraphs.
+        
+        Args:
+            image_pairs: List of image pairs (i,j) where i < j.
+            
+        Returns:
+            List of subgraphs, where each subgraph is a list of image pairs.
+        """
+        pass

--- a/gtsfm/graph_partitioner/single_partition.py
+++ b/gtsfm/graph_partitioner/single_partition.py
@@ -3,8 +3,8 @@
 Authors: Zongyue Liu
 """
 
-from typing import Dict, List, Tuple
-import numpy as np
+
+
 
 import gtsfm.utils.logger as logger_utils
 from gtsfm.graph_partitioner.graph_partitioner_base import GraphPartitionerBase
@@ -36,3 +36,4 @@ class SinglePartition(GraphPartitionerBase):
         """
         logger.info(f"SinglePartition: returning all {len(image_pairs)} pairs as a single partition")
         return [image_pairs]
+    

--- a/gtsfm/graph_partitioner/single_partition.py
+++ b/gtsfm/graph_partitioner/single_partition.py
@@ -1,0 +1,44 @@
+"""Implementation of a graph partitioner that returns a single partition.
+
+Authors: Zongyue Liu
+"""
+
+from typing import Dict, List, Tuple
+import numpy as np
+
+import gtsfm.utils.logger as logger_utils
+from gtsfm.graph_partitioner.graph_partitioner_base import GraphPartitionerBase
+
+logger = logger_utils.get_logger()
+
+
+class SinglePartition(GraphPartitionerBase):
+    """Graph partitioner that returns all edges as a single partition.
+    
+    This implementation doesn't actually partition the graph but serves as 
+    a baseline implementation that maintains the original workflow.
+    """
+    
+    def __init__(self, threshold: float = 0.0):
+        """Initialize the partitioner.
+        
+        Args:
+            threshold: Minimum similarity threshold to consider an edge valid.
+                      Edges with similarity below this value are excluded.
+        """
+        super().__init__(process_name="SinglePartition")
+        self.threshold = threshold
+        
+    def partition_image_pairs(
+        self, image_pairs: List[Tuple[int, int]]
+    ) -> List[List[Tuple[int, int]]]:
+        """Return all image pairs as a single partition.
+        
+        Args:
+            image_pairs: List of image pairs (i,j) where i < j.
+                               
+        Returns:
+            A list containing a single subgraph with all valid edges.
+        """
+        logger.info(f"SinglePartition: returning all {len(image_pairs)} pairs as a single partition")
+        return [image_pairs]

--- a/gtsfm/graph_partitioner/single_partition.py
+++ b/gtsfm/graph_partitioner/single_partition.py
@@ -19,19 +19,13 @@ class SinglePartition(GraphPartitionerBase):
     a baseline implementation that maintains the original workflow.
     """
     
-    def __init__(self, threshold: float = 0.0):
-        """Initialize the partitioner.
-        
-        Args:
-            threshold: Minimum similarity threshold to consider an edge valid.
-                      Edges with similarity below this value are excluded.
-        """
+    def __init__(self):
+        """Initialize the partitioner."""
         super().__init__(process_name="SinglePartition")
-        self.threshold = threshold
         
     def partition_image_pairs(
-        self, image_pairs: List[Tuple[int, int]]
-    ) -> List[List[Tuple[int, int]]]:
+        self, image_pairs: list[tuple[int, int]]
+    ) -> list[list[tuple[int, int]]]:
         """Return all image pairs as a single partition.
         
         Args:

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -285,12 +285,12 @@ class GtsfmRunnerBase:
         """Run the SceneOptimizer."""
         start_time = time.time()
 
-        # 如果没有提供分区器，根据命令行参数创建一个
+        # Create graph partitioner if not provided
         if graph_partitioner is None:
             if self.parsed_args.graph_partitioner == "single":
                 from gtsfm.graph_partitioner.single_partition import SinglePartition
                 graph_partitioner = SinglePartition()
-            # 添加其他分区器类型的处理...
+
 
         # Create dask cluster.
         if self.parsed_args.cluster_config:

--- a/gtsfm/runner/gtsfm_runner_base.py
+++ b/gtsfm/runner/gtsfm_runner_base.py
@@ -358,7 +358,13 @@ class GtsfmRunnerBase:
             )
             two_view_estimation_duration_sec = time.time() - two_view_estimation_start_time
 
-        i2Ri1_dict, i2Ui1_dict, v_corr_idxs_dict, pre_ba_two_view_reports_dict, post_isp_two_view_reports_dict = unzip_two_view_results(
+        (
+            i2Ri1_dict,
+            i2Ui1_dict,
+            v_corr_idxs_dict,
+            pre_ba_two_view_reports_dict,
+            post_isp_two_view_reports_dict
+        ) = unzip_two_view_results(
             two_view_results_dict
         )
 
@@ -405,16 +411,27 @@ class GtsfmRunnerBase:
         all_delayed_mvo_metrics_groups = []
 
         for idx, subgraph_result_dict in enumerate(subgraph_two_view_results):
-            logger.info(f"Creating computation graph for subgraph {idx+1}/{len(subgraph_two_view_results)} with {len(subgraph_result_dict)} image pairs")
-            
+            logger.info(
+                f"Creating computation graph for subgraph {idx+1}/{len(subgraph_two_view_results)} "
+                f"with {len(subgraph_result_dict)} image pairs"
+            )
             # Unzip the two-view results for this subgraph
-            subgraph_i2Ri1_dict, subgraph_i2Ui1_dict, subgraph_v_corr_idxs_dict, _, subgraph_post_isp_reports = unzip_two_view_results(
+            (
+                subgraph_i2Ri1_dict,
+                subgraph_i2Ui1_dict,
+                subgraph_v_corr_idxs_dict,
+                _,
+                subgraph_post_isp_reports
+            ) = unzip_two_view_results(
                 subgraph_result_dict
             )
-            
             # Create computation graph for this subgraph
             if len(subgraph_i2Ri1_dict) > 0:  # Only process non-empty subgraphs
-                delayed_sfm_result, delayed_io, delayed_mvo_metrics_groups = self.scene_optimizer.create_computation_graph(
+                (
+                    delayed_sfm_result,
+                    delayed_io,
+                    delayed_mvo_metrics_groups
+                ) = self.scene_optimizer.create_computation_graph(
                     keypoints_list=keypoints_list,
                     i2Ri1_dict=subgraph_i2Ri1_dict,
                     i2Ui1_dict=subgraph_i2Ui1_dict,
@@ -423,7 +440,9 @@ class GtsfmRunnerBase:
                     num_images=len(self.loader),
                     images=self.loader.create_computation_graph_for_images(),
                     camera_intrinsics=intrinsics,
-                    relative_pose_priors=self.loader.get_relative_pose_priors(list(subgraph_i2Ri1_dict.keys())),
+                    relative_pose_priors=self.loader.get_relative_pose_priors(
+                        list(subgraph_i2Ri1_dict.keys())
+                    ),
                     absolute_pose_priors=self.loader.get_absolute_pose_priors(),
                     cameras_gt=self.loader.get_gt_cameras(),
                     gt_wTi_list=self.loader.get_gt_poses(),
@@ -515,3 +534,5 @@ def save_metrics_reports(metrics_group_list: List[GtsfmMetricsGroup], metrics_pa
     metrics_report.generate_metrics_report_html(
         metrics_group_list, os.path.join(metrics_path, "gtsfm_metrics_report.html"), None
     )
+
+

--- a/gtsfm/utils/subgraph_utils.py
+++ b/gtsfm/utils/subgraph_utils.py
@@ -5,7 +5,7 @@ Authors: Zongyue Liu
 
 from typing import Dict, List, Tuple, Any
 
-import numpy as np
+
 
 
 def group_results_by_subgraph(

--- a/gtsfm/utils/subgraph_utils.py
+++ b/gtsfm/utils/subgraph_utils.py
@@ -1,0 +1,35 @@
+"""Utility functions for handling subgraphs in GTSFM.
+
+Authors: Zongyue Liu
+"""
+
+from typing import Dict, List, Tuple, Any
+
+import numpy as np
+
+
+def group_results_by_subgraph(
+    results: Dict[Tuple[int, int], Any],
+    subgraphs: List[List[Tuple[int, int]]],
+) -> List[Dict[Tuple[int, int], Any]]:
+    """Group results by subgraph.
+    
+    Args:
+        results: Dictionary mapping image pairs to their results.
+        subgraphs: List of subgraphs, where each subgraph is a list of image pairs.
+        
+    Returns:
+        List of dictionaries, where each dictionary contains the results for a subgraph.
+    """
+    subgraph_results = []
+    
+    for subgraph_pairs in subgraphs:
+        # Create a dictionary containing only the results for this subgraph
+        subgraph_result = {
+            pair: results[pair] 
+            for pair in subgraph_pairs 
+            if pair in results
+        }
+        subgraph_results.append(subgraph_result)
+    
+    return subgraph_results

--- a/tests/test_graph_partitioner.py
+++ b/tests/test_graph_partitioner.py
@@ -31,24 +31,6 @@ class TestGraphPartitioning(unittest.TestCase):
         # Check that the partition contains all the original pairs
         self.assertEqual(set(partitioned_pairs[0]), set(image_pairs))
 
-    def test_single_partition_with_threshold(self):
-        """Test that SinglePartition respects the threshold parameter."""
-        # Create a SinglePartition with a threshold
-        partitioner = SinglePartition(threshold=0.5)
-        
-        # Create some dummy image pairs
-        image_pairs = [(0, 1), (0, 2), (1, 2), (2, 3), (3, 4)]
-        
-        # Get partitioned result
-        partitioned_pairs = partitioner.partition_image_pairs(image_pairs)
-        
-        # For SinglePartition, the threshold shouldn't affect the result - all pairs should be included
-        self.assertEqual(len(partitioned_pairs), 1)
-        self.assertEqual(set(partitioned_pairs[0]), set(image_pairs))
-        
-        # Verify that it follows the interface defined in the base class
-        self.assertTrue(hasattr(partitioner, 'partition_image_pairs'))
-        self.assertEqual(partitioner.process_name, "SinglePartition")
 
 
 if __name__ == "__main__":

--- a/tests/test_graph_partitioner.py
+++ b/tests/test_graph_partitioner.py
@@ -4,9 +4,7 @@ Authors: Zongyue Liu
 """
 
 import unittest
-from typing import List, Tuple
 
-import numpy as np
 
 from gtsfm.graph_partitioner.single_partition import SinglePartition
 

--- a/tests/test_graph_partitioner.py
+++ b/tests/test_graph_partitioner.py
@@ -1,0 +1,55 @@
+"""Unit tests for graph partitioning functionality.
+
+Authors: Zongyue Liu
+"""
+
+import unittest
+from typing import List, Tuple
+
+import numpy as np
+
+from gtsfm.graph_partitioner.single_partition import SinglePartition
+
+
+class TestGraphPartitioning(unittest.TestCase):
+    """Tests for graph partitioning functionality."""
+
+    def test_single_partition(self):
+        """Test that SinglePartition correctly returns all pairs as one partition."""
+        # Create some dummy image pairs
+        image_pairs = [(0, 1), (0, 2), (1, 2), (2, 3), (3, 4)]
+        
+        # Create a SinglePartition instance
+        partitioner = SinglePartition()
+        
+        # Get partitioned result
+        partitioned_pairs = partitioner.partition_image_pairs(image_pairs)
+        
+        # Check that we get exactly one partition
+        self.assertEqual(len(partitioned_pairs), 1)
+        
+        # Check that the partition contains all the original pairs
+        self.assertEqual(set(partitioned_pairs[0]), set(image_pairs))
+
+    def test_single_partition_with_threshold(self):
+        """Test that SinglePartition respects the threshold parameter."""
+        # Create a SinglePartition with a threshold
+        partitioner = SinglePartition(threshold=0.5)
+        
+        # Create some dummy image pairs
+        image_pairs = [(0, 1), (0, 2), (1, 2), (2, 3), (3, 4)]
+        
+        # Get partitioned result
+        partitioned_pairs = partitioner.partition_image_pairs(image_pairs)
+        
+        # For SinglePartition, the threshold shouldn't affect the result - all pairs should be included
+        self.assertEqual(len(partitioned_pairs), 1)
+        self.assertEqual(set(partitioned_pairs[0]), set(image_pairs))
+        
+        # Verify that it follows the interface defined in the base class
+        self.assertTrue(hasattr(partitioner, 'partition_image_pairs'))
+        self.assertEqual(partitioner.process_name, "SinglePartition")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Add Graph Partitioning Functionality for SfM Pipeline

This PR introduces a graph partitioning system to GTSFM that allows the SfM pipeline to process large datasets more efficiently by dividing the image graph into manageable subgraphs.

## Changes

- Added `GraphPartitionerBase` abstract class that defines the interface for all graph partitioners
- Implemented `SinglePartition` as a baseline partitioner that keeps all image pairs in a single partition
- Created utility functions in `subgraph_utils.py` for handling subgraph operations
- Added test `test_graph_partitioner` for the partitioning functionality
- Updated `gtsfm_runner_base` to support graph partitioning


## Testing

`Run flake8 --max-line-length 120 --ignore E201,E202,E203,E231,W291,W293,E303,W391,E402,W503,E731 gtsfm tests`

The implementation has been ran through pytest as
```
pytest tests --cov=sfm \
--ignore tests/repro_tests \
--ignore tests/loader/test_argoverse_dataset_loader.py \
--ignore tests/runner/test_frontend_runner.py
```
Result as

```
======================================= short test summary info =======================================
FAILED tests/frontend/correspondence_generator/test_colmap_correspondence_generator.py::TestColmapCorrespondenceGenerator::test_data - AttributeError: 'pycolmap.Database' object has no attribute 'read_image_with_name'
================== 1 failed, 446 passed, 7 skipped, 8 warnings in 505.88s (0:08:25) ===================


```



