### PR TITLE
Update logging verbosity for visualization code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,7 @@ cache/
 
 # Dev notebooks
 notebooks/
+
+
+results/**
+result_metrics/**

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -178,7 +178,7 @@ class LoaderBase(GTSFMProcess):
             target_h,
             target_w,
         ) = img_utils.get_downsampling_factor_per_axis(img_full_res.height, img_full_res.width, self._max_resolution)
-        logger.info(
+        logger.debug(
             "Image %d resized from (H,W)=(%d,%d) -> (%d,%d)",
             index,
             img_full_res.height,

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -52,10 +52,10 @@ REACT_RESULTS_PATH = Path(__file__).resolve().parent.parent / "rtf_vis_tool" / "
 logger = logger_utils.get_logger()
 
 mpl_logger = logging.getLogger("matplotlib")
-mpl_logger.setLevel(logging.WARNING)
+mpl_logger.setLevel(logging.ERROR)
 
 pil_logger = logging.getLogger("PIL")
-pil_logger.setLevel(logging.INFO)
+pil_logger.setLevel(logging.ERROR)
 
 
 class SceneOptimizer:

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -2,6 +2,7 @@
 
 Authors: Ayush Baid, John Lambert
 """
+
 import dataclasses
 import logging
 import timeit
@@ -30,10 +31,10 @@ from gtsfm.frontend.verifier.verifier_base import VerifierBase
 logger = logger_utils.get_logger()
 
 mpl_logger = logging.getLogger("matplotlib")
-mpl_logger.setLevel(logging.WARNING)
+mpl_logger.setLevel(logging.ERROR)
 
 pil_logger = logging.getLogger("PIL")
-pil_logger.setLevel(logging.INFO)
+pil_logger.setLevel(logging.ERROR)
 
 PRE_BA_REPORT_TAG = "PRE_BA_2VIEW_REPORT"
 POST_BA_REPORT_TAG = "POST_BA_2VIEW_REPORT"
@@ -203,7 +204,7 @@ class TwoViewEstimator:
         )
         if ba_output is None:
             # Indeterminate linear system was met.
-            return None, None, np.zeros((0,2), dtype=np.int32)
+            return None, None, np.zeros((0, 2), dtype=np.int32)
 
         # Unpack results.
         valid_corr_idxs = verified_corr_idxs[triangulated_indices][valid_mask]
@@ -625,24 +626,26 @@ def get_two_view_reports_summary(
                 "i2_filename": images[i2].file_name,
                 "rotation_angular_error": round_fn(report.R_error_deg),
                 "translation_angular_error": round_fn(report.U_error_deg),
-                "num_inliers_gt_model": int(report.num_inliers_gt_model)
-                if report.num_inliers_gt_model is not None
-                else None,
+                "num_inliers_gt_model": (
+                    int(report.num_inliers_gt_model) if report.num_inliers_gt_model is not None else None
+                ),
                 "inlier_ratio_gt_model": round_fn(report.inlier_ratio_gt_model),
-                "inlier_avg_reproj_error_gt_model": round_fn(
-                    np.nanmean(report.reproj_error_gt_model[report.v_corr_idxs_inlier_mask_gt])
-                )
-                if report.reproj_error_gt_model is not None and report.v_corr_idxs_inlier_mask_gt is not None
-                else None,
-                "outlier_avg_reproj_error_gt_model": round_fn(
-                    np.nanmean(report.reproj_error_gt_model[np.logical_not(report.v_corr_idxs_inlier_mask_gt)])
-                )
-                if report.reproj_error_gt_model is not None and report.v_corr_idxs_inlier_mask_gt is not None
-                else None,
+                "inlier_avg_reproj_error_gt_model": (
+                    round_fn(np.nanmean(report.reproj_error_gt_model[report.v_corr_idxs_inlier_mask_gt]))
+                    if report.reproj_error_gt_model is not None and report.v_corr_idxs_inlier_mask_gt is not None
+                    else None
+                ),
+                "outlier_avg_reproj_error_gt_model": (
+                    round_fn(
+                        np.nanmean(report.reproj_error_gt_model[np.logical_not(report.v_corr_idxs_inlier_mask_gt)])
+                    )
+                    if report.reproj_error_gt_model is not None and report.v_corr_idxs_inlier_mask_gt is not None
+                    else None
+                ),
                 "inlier_ratio_est_model": round_fn(report.inlier_ratio_est_model),
-                "num_inliers_est_model": int(report.num_inliers_est_model)
-                if report.num_inliers_est_model is not None
-                else None,
+                "num_inliers_est_model": (
+                    int(report.num_inliers_est_model) if report.num_inliers_est_model is not None else None
+                ),
             }
         )
     return metrics_list

--- a/gtsfm/two_view_estimator_cacher.py
+++ b/gtsfm/two_view_estimator_cacher.py
@@ -2,6 +2,7 @@
 
 Authors: Ayush Baid
 """
+
 import logging
 from pathlib import Path
 from typing import Any, List, Optional
@@ -27,10 +28,10 @@ CACHE_ROOT_PATH = Path(__file__).resolve().parent.parent / "cache"
 logger = logger_utils.get_logger()
 
 mpl_logger = logging.getLogger("matplotlib")
-mpl_logger.setLevel(logging.WARNING)
+mpl_logger.setLevel(logging.ERROR)
 
 pil_logger = logging.getLogger("PIL")
-pil_logger.setLevel(logging.INFO)
+pil_logger.setLevel(logging.ERROR)
 
 
 class TwoViewEstimatorCacher(TwoViewEstimator):

--- a/gtsfm/utils/logger.py
+++ b/gtsfm/utils/logger.py
@@ -2,6 +2,7 @@
 
 Authors: Ayush Baid, John Lambert.
 """
+
 import logging
 import sys
 from logging import Logger


### PR DESCRIPTION
Currently we have too verbose logging for visualization code, leading to our logs being flooded with warnings like "font family Times New Roman not found". 

This PR limits such code to only log errors and ignore warnings. 