### PR TITLE
Add BinaryTreePartition class for hierarchical image-pair partitioning

### DIFF
--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -1,14 +1,11 @@
 name: gtsfm-v1
 channels:
-  # The GTSFM Mac environment closely follows the Linux conda environment file,
-  # except for two noticeable differences: no CUDA support and no DEGENSAC support.
-  # Note: this environment is tested on an M3 Ultra chip.
   - conda-forge
 dependencies:
-  # Python essentials
+  # python essentials
   - python=3.10
   - pip
-  # Formatting and development environment tools
+  # formatting and dev environment
   - black
   - coverage
   - mypy
@@ -16,14 +13,14 @@ dependencies:
   - pytest
   - flake8
   - isort
-  # Dask and related dependencies
-  - dask  # Equivalent to the dask[complete] pip distribution
+  # dask and related
+  - dask
   - asyncssh
   - python-graphviz
-  # Core functionality and APIs
+  # core functionality and APIs
   - matplotlib>=3.5
   - networkx
-  - numpy==1.26.4  # GTSAM requirement
+  - numpy==1.26.4 # gtsam requirement
   - nodejs
   - pandas
   - pillow>=9.0.0
@@ -31,16 +28,16 @@ dependencies:
   - seaborn
   - scipy
   - hydra-core
-  # Third-party algorithms for different modules
+  # # 3rd party algorithms for different modules
   - kornia>=0.7.3
-  # I/O
+  - pycolmap==3.11.1
+  # io
   - h5py
   - plotly>=5.0
   - tabulate
   - simplejson
   - pyparsing>=3.0.9
-  - pycolmap
-  # Testing utilities
+  # testing
   - parameterized
   - pip:
       - torch
@@ -50,5 +47,5 @@ dependencies:
       - pydegensac
       - colour
       - trimesh[easy]
-      - gtsam>=4.2
+      - gtsam==4.3a0
       - pydot

--- a/gtsfm/graph_partitioner/binary_tree_partition.py
+++ b/gtsfm/graph_partitioner/binary_tree_partition.py
@@ -186,12 +186,12 @@ class BinaryTreePartition(GraphPartitionerBase):
         leaf_idx_counter = [0]  # mutable counter to track leaf index
         node_to_idx = dict()
 
-        def dfs(n: BinaryTreeNode) -> List[Dict]:
-            if n.is_leaf():
+        def dfs(node: BinaryTreeNode) -> List[Dict]:
+            if node.is_leaf():
                 idx = leaf_idx_counter[0]
                 leaf_idx_counter[0] += 1
-                node_to_idx[n] = idx
-                exclusive_keys = set(n.keys)
+                node_to_idx[node] = idx
+                exclusive_keys = set(node.keys)
                 return [
                     {
                         "exclusive_keys": [gtsam.Symbol(u).index() for u in exclusive_keys],
@@ -203,19 +203,19 @@ class BinaryTreePartition(GraphPartitionerBase):
                     }
                 ]
 
-            left_part = dfs(n.left)
-            right_part = dfs(n.right)
+            left_part = dfs(node.left)
+            right_part = dfs(node.right)
 
-            if n.left.is_leaf() and n.right.is_leaf():
-                left_keys = set(n.left.keys)
-                right_keys = set(n.right.keys)
+            if node.left.is_leaf() and node.right.is_leaf():
+                left_keys = set(node.left.keys)
+                right_keys = set(node.right.keys)
                 shared_edges = [
                     (gtsam.Symbol(u).index(), gtsam.Symbol(v).index())
                     for u, v in nx_graph.edges()
                     if (u in left_keys and v in right_keys) or (u in right_keys and v in left_keys)
                 ]
-                i = node_to_idx[n.left]
-                j = node_to_idx[n.right]
+                i = node_to_idx[node.left]
+                j = node_to_idx[node.right]
                 shared_edge_map[(i, j)] = shared_edges
 
             return left_part + right_part

--- a/gtsfm/graph_partitioner/binary_tree_partition.py
+++ b/gtsfm/graph_partitioner/binary_tree_partition.py
@@ -1,0 +1,196 @@
+"""Implementation of a binary tree graph partitioner.
+
+This partitioner recursively partitions image pair graphs into a binary tree
+structure up to a specified depth, using METIS-based ordering. Leaf nodes
+represent explicit image keys and associated edge groupings.
+
+Authors: Shicong Ma
+"""
+
+from typing import Dict, List, Tuple
+
+import gtsam
+import networkx as nx
+from gtsam import SymbolicFactorGraph
+
+import gtsfm.utils.logger as logger_utils
+from gtsfm.graph_partitioner.graph_partitioner_base import GraphPartitionerBase
+
+logger = logger_utils.get_logger()
+
+
+class BinaryTreeNode:
+    """Node class for a binary tree representing partitioned sets of image keys."""
+
+    def __init__(self, keys: List[int], depth: int):
+        """
+        Initialize a BinaryTreeNode.
+
+        Args:
+            keys: Image indices at this node (only populated at leaf level).
+            depth: Depth level in the binary tree.
+        """
+        self.keys = keys  # Only at leaves
+        self.left = None
+        self.right = None
+        self.depth = depth
+
+    def is_leaf(self) -> bool:
+        """Check whether this node is a leaf node."""
+        return self.left is None and self.right is None
+
+
+class BinaryTreePartition(GraphPartitionerBase):
+    """Graph partitioner that uses a binary tree to recursively divide image pairs."""
+
+    def __init__(self, max_depth: int = 2):
+        """
+        Initialize the BinaryTreePartition object.
+
+        Args:
+            max_depth: Maximum depth of the binary tree; results in 2^depth partitions.
+        """
+        super().__init__(process_name="BinaryTreePartition")
+        self.max_depth = max_depth
+
+    def partition_image_pairs(self, image_pairs: List[Tuple[int, int]]) -> List[List[Tuple[int, int]]]:
+        """Partition image pairs into subgroups using a binary tree.
+
+        Args:
+            image_pairs: List of image index pairs (i, j), where i < j.
+
+        Returns:
+            A list of image pair subsets, one for each leaf in the binary tree.
+        """
+        if not image_pairs:
+            logger.warning("No image pairs provided for partitioning.")
+            return []
+
+        symbol_graph, _, nx_graph = self._build_graphs(image_pairs)
+        ordering = gtsam.Ordering.MetisSymbolicFactorGraph(symbol_graph)
+        binary_tree_root_node = self._build_binary_partition(ordering)
+
+        num_leaves = 2**self.max_depth
+        image_pairs_per_partition = [[] for _ in range(num_leaves)]
+
+        partition_details = self._compute_leaf_partition_details(binary_tree_root_node, nx_graph)
+
+        logger.info(f"BinaryTreePartition: partitioned into {len(partition_details)} leaf nodes.")
+
+        for i in range(num_leaves):
+            edges_explicit = partition_details[i].get("edges_within_explicit", [])
+            edges_shared = partition_details[i].get("edges_with_shared", [])
+            image_pairs_per_partition[i] = edges_explicit + edges_shared
+
+        for i, part in enumerate(partition_details):
+            explicit_keys = part.get("explicit_keys", [])
+            edges_within = part.get("edges_within_explicit", [])
+            edges_shared = part.get("edges_with_shared", [])
+
+            logger.info(
+                f"Partition {i}:\n"
+                f"  Explicit Image Keys that only exist within the current partition "
+                f"({len(explicit_keys)}): {sorted(explicit_keys)}\n"
+                f"  Internal Edges ({len(edges_within)}): {edges_within}\n"
+                f"  Shared Edges   ({len(edges_shared)}): {edges_shared}\n"
+            )
+
+        return image_pairs_per_partition
+
+    def _build_graphs(self, image_pairs: List[Tuple[int, int]]) -> Tuple[SymbolicFactorGraph, List[int], nx.Graph]:
+        """Construct GTSAM and NetworkX graphs from image pairs.
+
+        Args:
+            image_pairs: List of image index pairs.
+
+        Returns:
+            A tuple of (SymbolicFactorGraph, list of keys, NetworkX graph).
+        """
+        sfg = gtsam.SymbolicFactorGraph()
+        nxg = nx.Graph()
+        keys = set()
+
+        for i, j in image_pairs:
+            key_i = gtsam.symbol("x", i)
+            key_j = gtsam.symbol("x", j)
+            keys.add(key_i)
+            keys.add(key_j)
+
+            sfg.push_factor(key_i, key_j)
+            nxg.add_edge(key_i, key_j)
+
+        return sfg, list(keys), nxg
+
+    def _build_binary_partition(self, ordering: gtsam.Ordering) -> BinaryTreeNode:
+        """Build a binary tree of image keys based on a given ordering.
+
+        Args:
+            ordering: GTSAM Ordering object created via METIS.
+
+        Returns:
+            Root node of the binary tree.
+        """
+        ordered_keys = [ordering.at(i) for i in range(ordering.size())]
+
+        def split(keys: List[int], depth: int) -> BinaryTreeNode:
+            if depth == self.max_depth:
+                return BinaryTreeNode(keys, depth)
+
+            mid = len(keys) // 2
+            left_node = split(keys[:mid], depth + 1)
+            right_node = split(keys[mid:], depth + 1)
+            node = BinaryTreeNode([], depth)
+            node.left = left_node
+            node.right = right_node
+            return node
+
+        return split(ordered_keys, 0)
+
+    def _compute_leaf_partition_details(
+        self,
+        node: BinaryTreeNode,
+        nx_graph: nx.Graph,
+    ) -> List[Dict]:
+        """Recursively traverse the binary tree and return partition details per leaf.
+
+        Args:
+            node: Current binary tree node being processed.
+            nx_graph: NetworkX graph built from image pairs.
+
+        Returns:
+            A list of dictionaries containing partition details per leaf node.
+        """
+        if node.is_leaf():
+            explicit_keys = set(node.keys)
+            return [
+                {
+                    "explicit_keys": [gtsam.Symbol(u).index() for u in explicit_keys],
+                    "explicit_count": len(explicit_keys),
+                    "edges_within_explicit": [
+                        (gtsam.Symbol(u).index(), gtsam.Symbol(v).index())
+                        for u, v in nx_graph.edges()
+                        if u in explicit_keys and v in explicit_keys
+                    ],
+                    "edges_with_shared": [],  # placeholder
+                }
+            ]
+
+        # Recursively compute for children
+        left_partitions = self._compute_leaf_partition_details(node.left, nx_graph)
+        right_partitions = self._compute_leaf_partition_details(node.right, nx_graph)
+
+        if node.left.is_leaf() and node.right.is_leaf():
+            left_keys = set(node.left.keys)
+            right_keys = set(node.right.keys)
+
+            shared_edges = [
+                (gtsam.Symbol(u).index(), gtsam.Symbol(v).index())
+                for u, v in nx_graph.edges()
+                if (u in left_keys and v in right_keys) or (u in right_keys and v in left_keys)
+            ]
+
+            # Directly assign shared edges to the only two leaf partitions
+            left_partitions[0]["edges_with_shared"] = shared_edges
+            right_partitions[0]["edges_with_shared"] = shared_edges
+
+        return left_partitions + right_partitions

--- a/gtsfm/graph_partitioner/binary_tree_partition.py
+++ b/gtsfm/graph_partitioner/binary_tree_partition.py
@@ -113,7 +113,12 @@ class BinaryTreePartition(GraphPartitionerBase):
         return image_pairs_per_partition
 
     def get_inter_partition_edges(self) -> Dict[Tuple[int, int], List[Tuple[int, int]]]:
-        """Getter for inter-partition edges between leaf partitions."""
+        """Getter for inter-partition edges between leaf partitions.
+
+        Returns:
+            A dictionary mapping (leaf_idx_a, leaf_idx_b) to a list of edges
+            connecting nodes in the two leaf partitions. Only sibling pairs are included.
+        """
         return self.inter_partition_edges_map
 
     def _build_graphs(self, image_pairs: List[Tuple[int, int]]) -> Tuple[SymbolicFactorGraph, List[int], nx.Graph]:
@@ -206,6 +211,8 @@ class BinaryTreePartition(GraphPartitionerBase):
             left_part = dfs(node.left)
             right_part = dfs(node.right)
 
+            # Identify inter-partition edges between two sibling leaf nodes,
+            # and map them using their assigned leaf indices.
             if node.left.is_leaf() and node.right.is_leaf():
                 left_keys = set(node.left.keys)
                 right_keys = set(node.right.keys)

--- a/gtsfm/utils/io.py
+++ b/gtsfm/utils/io.py
@@ -2,7 +2,6 @@
 
 Authors: Ayush Baid, John Lambert
 """
-
 import glob
 import os
 import pickle
@@ -16,7 +15,7 @@ import h5py
 import numpy as np
 import open3d
 import simplejson as json
-from gtsam import Cal3Bundler, Cal3DS2, Point3, Pose3, Rot3, SfmTrack
+from gtsam import Cal3Bundler, Point3, Pose3, Rot3, SfmTrack
 from PIL import Image as PILImage
 from PIL.ExifTags import GPSTAGS, TAGS
 
@@ -224,16 +223,10 @@ def colmap2gtsfm(
         elif camera_model_name == "RADIAL":
             f, cx, cy, k1, k2 = cameras[img.camera_id].params[:5]
             fx = f
-        elif camera_model_name == "OPENCV":
-            fx, fy, cx, cy, k1, k2, p1, p2 = cameras[img.camera_id].params[:8]
         else:
             raise ValueError(f"Unsupported COLMAP camera type: {camera_model_name}")
 
-        if camera_model_name == "OPENCV":
-            intrinsics_gtsfm.append(Cal3DS2(fx, fy, 0.0, cx, cy, k1, k2, p1, p2))
-        else:
-            intrinsics_gtsfm.append(Cal3Bundler(fx, k1, k2, cx, cy))
-
+        intrinsics_gtsfm.append(Cal3Bundler(fx, k1, k2, cx, cy))
         image_id_to_idx[img.id] = idx
         img_h, img_w = cameras[img.camera_id].height, cameras[img.camera_id].width
         img_dims.append((img_h, img_w))

--- a/gtsfm/utils/io.py
+++ b/gtsfm/utils/io.py
@@ -2,6 +2,7 @@
 
 Authors: Ayush Baid, John Lambert
 """
+
 import glob
 import os
 import pickle
@@ -15,7 +16,7 @@ import h5py
 import numpy as np
 import open3d
 import simplejson as json
-from gtsam import Cal3Bundler, Point3, Pose3, Rot3, SfmTrack
+from gtsam import Cal3Bundler, Cal3DS2, Point3, Pose3, Rot3, SfmTrack
 from PIL import Image as PILImage
 from PIL.ExifTags import GPSTAGS, TAGS
 
@@ -223,10 +224,16 @@ def colmap2gtsfm(
         elif camera_model_name == "RADIAL":
             f, cx, cy, k1, k2 = cameras[img.camera_id].params[:5]
             fx = f
+        elif camera_model_name == "OPENCV":
+            fx, fy, cx, cy, k1, k2, p1, p2 = cameras[img.camera_id].params[:8]
         else:
             raise ValueError(f"Unsupported COLMAP camera type: {camera_model_name}")
 
-        intrinsics_gtsfm.append(Cal3Bundler(fx, k1, k2, cx, cy))
+        if camera_model_name == "OPENCV":
+            intrinsics_gtsfm.append(Cal3DS2(fx, fy, 0.0, cx, cy, k1, k2, p1, p2))
+        else:
+            intrinsics_gtsfm.append(Cal3Bundler(fx, k1, k2, cx, cy))
+
         image_id_to_idx[img.id] = idx
         img_h, img_w = cameras[img.camera_id].height, cameras[img.camera_id].width
         img_dims.append((img_h, img_w))

--- a/tests/test_binary_tree_partition.py
+++ b/tests/test_binary_tree_partition.py
@@ -95,17 +95,16 @@ class TestBinaryTreePartition(unittest.TestCase):
         image_pairs = [(0, 1), (1, 2), (2, 3)]
         partitioner = BinaryTreePartition(max_depth=1)
         partitions = partitioner.partition_image_pairs(image_pairs)
-        shared = partitioner.get_shared_edges()
+        inter = partitioner.get_inter_partition_edges()
 
         # Check number of partitions
         self.assertEqual(len(partitions), 2)
 
-        # Gather all exclusive edges
+        # Gather all intra-partition and inter-partition edges
         flattened = set((min(u, v), max(u, v)) for p in partitions for u, v in p)
 
-        # Add shared edges
-        for shared_edges in shared.values():
-            for u, v in shared_edges:
+        for inter_edges in inter.values():
+            for u, v in inter_edges:
                 flattened.add((min(u, v), max(u, v)))
 
         # All input edges should appear
@@ -182,7 +181,7 @@ class TestBinaryTreePartition(unittest.TestCase):
         self.assertEqual(sum(len(n.keys) for n in leaf_nodes), 8)
 
     def test_compute_leaf_partition_details(self):
-        """Test that leaf partitions correctly report internal and shared edges."""
+        """Test that leaf partitions correctly report intra- and inter-partition edges."""
         partitioner = BinaryTreePartition(max_depth=1)
         image_pairs = [(0, 1), (1, 2), (2, 3)]  # Line graph
 
@@ -196,17 +195,16 @@ class TestBinaryTreePartition(unittest.TestCase):
         root.left = left
         root.right = right
 
-        leaf_details, shared_map = partitioner._compute_leaf_partition_details(root, nxg)
+        leaf_details, inter_edges_map = partitioner._compute_leaf_partition_details(root, nxg)
 
         self.assertEqual(len(leaf_details), 2)
 
-        # Collect internal and shared edges
         flattened_edges = set()
         for d in leaf_details:
-            for u, v in d["edges_within_exclusive"]:
+            for u, v in d["intra_partition_edges"]:
                 flattened_edges.add((min(u, v), max(u, v)))
-        for shared_edges in shared_map.values():
-            for u, v in shared_edges:
+        for inter_edges in inter_edges_map.values():
+            for u, v in inter_edges:
                 flattened_edges.add((min(u, v), max(u, v)))
 
         for u, v in image_pairs:

--- a/tests/test_binary_tree_partition.py
+++ b/tests/test_binary_tree_partition.py
@@ -1,0 +1,205 @@
+"""Unit tests for the BinaryTreePartition graph partitioner.
+
+This module tests the functionality of the BinaryTreePartition class, ensuring that:
+- It correctly splits image pairs into leaf partitions.
+- The resulting partitions contain valid and non-duplicated edges.
+- The binary tree structure is valid.
+- Edge cases like empty input are handled gracefully.
+
+Author: Shicong Ma
+"""
+
+import unittest
+from typing import List, Tuple
+
+import gtsam
+
+from gtsfm.graph_partitioner.binary_tree_partition import BinaryTreeNode, BinaryTreePartition
+
+
+class TestBinaryTreePartition(unittest.TestCase):
+    """Unit tests for BinaryTreePartition."""
+
+    def setUp(self):
+        """Set up a simple 4x4 grid graph for testing."""
+        self.rows, self.cols = 4, 4
+        self.total_nodes = self.rows * self.cols
+        self.image_pairs = self._create_grid_edges(self.rows, self.cols)
+
+    def _create_grid_edges(self, rows: int, cols: int) -> List[Tuple[int, int]]:
+        """Create a simple 2D grid of image pairs.
+
+        Args:
+            rows: Number of rows in the grid.
+            cols: Number of columns in the grid.
+
+        Returns:
+            List of edges between adjacent grid points.
+        """
+        edges = []
+        for r in range(rows):
+            for c in range(cols):
+                current_idx = r * cols + c
+                if c + 1 < cols:
+                    edges.append((current_idx, current_idx + 1))
+                if r + 1 < rows:
+                    edges.append((current_idx, current_idx + cols))
+        return edges
+
+    def test_partition_leaf_count(self):
+        """Test that partitioner creates the correct number of leaf partitions."""
+        partitioner = BinaryTreePartition(max_depth=2)
+        partitions = partitioner.partition_image_pairs(self.image_pairs)
+        expected_num_leaves = 2**partitioner.max_depth
+        self.assertEqual(len(partitions), expected_num_leaves)
+
+    def test_no_duplicate_undirected_edges(self):
+        """Test that undirected edges are not duplicated (e.g., both (u,v) and (v,u))."""
+        partitioner = BinaryTreePartition(max_depth=2)
+        partitions = partitioner.partition_image_pairs(self.image_pairs)
+        undirected_edges = set()
+        for partition in partitions:
+            for u, v in partition:
+                edge = (min(u, v), max(u, v))
+                undirected_edges.add(edge)
+        self.assertEqual(len(undirected_edges), len(set(undirected_edges)))
+
+    def test_edge_validity(self):
+        """Test that all edges are valid integer indices within the image grid."""
+        partitioner = BinaryTreePartition(max_depth=2)
+        partitions = partitioner.partition_image_pairs(self.image_pairs)
+        for partition in partitions:
+            for u, v in partition:
+                self.assertIsInstance(u, int)
+                self.assertIsInstance(v, int)
+                self.assertGreaterEqual(u, 0)
+                self.assertLess(u, self.total_nodes)
+                self.assertGreaterEqual(v, 0)
+                self.assertLess(v, self.total_nodes)
+
+    def test_non_empty_partitions(self):
+        """Test that at least one partition contains edges."""
+        partitioner = BinaryTreePartition(max_depth=2)
+        partitions = partitioner.partition_image_pairs(self.image_pairs)
+        non_empty_count = sum(1 for p in partitions if len(p) > 0)
+        self.assertGreater(non_empty_count, 0)
+
+    def test_empty_input(self):
+        """Test that empty image pair input returns an empty partition list."""
+        partitioner = BinaryTreePartition(max_depth=2)
+        partitions = partitioner.partition_image_pairs([])
+        self.assertEqual(partitions, [])
+
+    def test_known_input_partition(self):
+        """Test partitioning of a simple known image pair set."""
+        image_pairs = [(0, 1), (1, 2), (2, 3)]
+        partitioner = BinaryTreePartition(max_depth=1)
+        partitions = partitioner.partition_image_pairs(image_pairs)
+        self.assertEqual(len(partitions), 2)
+
+        # All original edges should appear in at least one partition (either internal or shared)
+        flattened = set()
+        for p in partitions:
+            for u, v in p:
+                flattened.add((min(u, v), max(u, v)))
+        for u, v in image_pairs:
+            self.assertIn((min(u, v), max(u, v)), flattened)
+
+    def test_binary_tree_structure(self):
+        """Test binary tree structure has correct number of leaves and leaf depths."""
+        partitioner = BinaryTreePartition(max_depth=3)
+
+        # Use synthetic ordering for test
+        ordering = type(
+            "FakeOrdering",
+            (),
+            {"size": lambda self: 8, "at": lambda self, idx: ord("a") + idx},  # returns int ASCII code
+        )()
+
+        root = partitioner._build_binary_partition(ordering)
+
+        leaf_nodes = []
+
+        def dfs(node):
+            if node.is_leaf():
+                leaf_nodes.append(node)
+            if node.left:
+                dfs(node.left)
+            if node.right:
+                dfs(node.right)
+
+        dfs(root)
+        self.assertEqual(len(leaf_nodes), 2**partitioner.max_depth)
+        self.assertTrue(all(n.depth == partitioner.max_depth for n in leaf_nodes))
+
+    def test_build_graphs(self):
+        """Test that _build_graphs constructs the correct symbolic and networkx graphs."""
+        partitioner = BinaryTreePartition()
+        test_pairs = [(0, 1), (1, 2)]
+        sfg, keys, nxg = partitioner._build_graphs(test_pairs)
+
+        # Check symbolic graph has correct number of factors
+        self.assertEqual(sfg.size(), len(test_pairs))
+
+        # Check nx graph has correct nodes and edges
+        self.assertEqual(
+            set(nxg.edges()),
+            {(gtsam.symbol("x", 0), gtsam.symbol("x", 1)), (gtsam.symbol("x", 1), gtsam.symbol("x", 2))},
+        )
+        self.assertEqual(len(nxg.nodes), 3)
+        self.assertEqual(len(keys), 3)
+
+    def test_build_binary_partition(self):
+        """Test that binary tree is built correctly with specified depth and balanced splitting."""
+        partitioner = BinaryTreePartition(max_depth=2)
+
+        # Fake ordering: integers 0 through 7
+        ordering = type("FakeOrdering", (), {"size": lambda self: 8, "at": lambda self, idx: idx})()
+
+        root = partitioner._build_binary_partition(ordering)
+
+        # Collect leaf nodes and check depth
+        leaf_nodes = []
+
+        def dfs(node):
+            if node.is_leaf():
+                leaf_nodes.append(node)
+            if node.left:
+                dfs(node.left)
+            if node.right:
+                dfs(node.right)
+
+        dfs(root)
+        self.assertEqual(len(leaf_nodes), 2**partitioner.max_depth)
+        self.assertTrue(all(n.depth == partitioner.max_depth for n in leaf_nodes))
+        self.assertEqual(sum(len(n.keys) for n in leaf_nodes), 8)
+
+    def test_compute_leaf_partition_details(self):
+        """Test that leaf partitions correctly report internal and shared edges."""
+        partitioner = BinaryTreePartition(max_depth=1)
+        image_pairs = [(0, 1), (1, 2), (2, 3)]  # Line graph
+
+        # Build graph and partition tree
+        _, _, nxg = partitioner._build_graphs(image_pairs)
+
+        # Manually create a binary tree with leaves split as [0,1] and [2,3]
+        left = BinaryTreeNode([gtsam.symbol("x", 0), gtsam.symbol("x", 1)], depth=1)
+        right = BinaryTreeNode([gtsam.symbol("x", 2), gtsam.symbol("x", 3)], depth=1)
+        root = BinaryTreeNode([], depth=0)
+        root.left = left
+        root.right = right
+
+        details = partitioner._compute_leaf_partition_details(root, nxg)
+        self.assertEqual(len(details), 2)
+
+        # Check that shared edge (1,2) is included in both
+        flattened_edges = set()
+        for d in details:
+            for u, v in d["edges_within_explicit"] + d["edges_with_shared"]:
+                flattened_edges.add((min(u, v), max(u, v)))
+        for u, v in image_pairs:
+            self.assertIn((min(u, v), max(u, v)), flattened_edges)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR introduces a new BinaryTreePartition class to the GTSFM graph partitioning module. The partitioner supports hierarchical binary tree-based splitting of image-pair graphs, enabling configurable partition depths for scalable and efficient scene processing.

Key Features:

- Implements BinaryTreePartition as a subclass of GraphPartitionerBase.
- Partitions image pairs into 2^max_depth leaf partitions using METIS-based symbolic ordering.
- Constructs a binary tree structure with configurable maximum depth.
