### PR TITLE
Fix gtsam.Cal3 type hint to use CALIBRATION_TYPE

### DIFF
--- a/gtsfm/utils/pycolmap_utils.py
+++ b/gtsfm/utils/pycolmap_utils.py
@@ -77,7 +77,9 @@ def colmap_camera_to_gtsam_calibration(camera: ColmapCamera) -> CALIBRATION_TYPE
         raise ValueError(f"Unsupported COLMAP camera type: {camera_model_name}")
 
 
-def gtsfm_calibration_to_colmap_camera(camera_id, calibration: gtsam.Cal3, height: int, width: int) -> ColmapCamera:
+def gtsfm_calibration_to_colmap_camera(
+    camera_id, calibration: CALIBRATION_TYPE, height: int, width: int
+) -> ColmapCamera:
     """Convert a GTSAM calibration object to a pycolmap camera.
 
     Args:


### PR DESCRIPTION
gtsfm/utils/pycolmap_utils.py
Fix gtsam.Cal3 type hint to use CALIBRATION_TYPE

- Replace gtsam.Cal3 with CALIBRATION_TYPE in gtsfm_calibration_to_colmap_camera function
- Fixes AttributeError: module 'gtsam' has no attribute 'Cal3'
- CALIBRATION_TYPE is the proper Union type for GTSAM calibration objects