### PR TITLE
Added Missing Pose Prior on First Camera Param

### DIFF
--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -92,6 +92,7 @@ class TwoViewEstimator(DaskDBModuleBase):
             use_calibration_prior=True,
             robust_noise_basin=1.345,
             use_karcher_mean_factor=False,
+            use_pose_prior_first_camera=True,
             calibration_prior_focal_sigma=1e-5,
             calibration_prior_dist_sigma=1e-5,
             cam_pose3_prior_noise_sigma=0.1,


### PR DESCRIPTION
_use_pose_prior_first_camera was not being passed to the TwoViewBundleAdjustmentOptimizer