### PR TITLE
BA updates - save covariances, grid size -> patch size, more config options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,4 @@ benchmarks/**
 plot.jpg
 vggt/**
 palace_metis/**
+logs/

--- a/gtsfm/bundle/bundle_adjustment.py
+++ b/gtsfm/bundle/bundle_adjustment.py
@@ -75,6 +75,9 @@ class BundleAdjustmentOptions:
     calibration_prior_dist_sigma: float | Sequence[float] = 0.1
     calibration_prior_pp_sigma: float = 1e-5
     robust_noise_basin: float = 1.345
+    min_tracks_per_camera: int = 20
+    compute_pose_covariances: bool = False
+    optimizer_relative_cost_tol: float = 1e-3
 
     def to_optimizer(self, **overrides) -> "BundleAdjustmentOptimizer":
         """Construct a :class:`BundleAdjustmentOptimizer` from these options.
@@ -98,6 +101,9 @@ class BundleAdjustmentOptions:
             calibration_prior_dist_sigma=self.calibration_prior_dist_sigma,
             calibration_prior_pp_sigma=self.calibration_prior_pp_sigma,
             robust_noise_basin=self.robust_noise_basin,
+            min_tracks_per_camera=self.min_tracks_per_camera,
+            compute_pose_covariances=self.compute_pose_covariances,
+            optimizer_relative_cost_tol=self.optimizer_relative_cost_tol,
         )
         kwargs.update(overrides)
         return BundleAdjustmentOptimizer(**kwargs)
@@ -138,6 +144,9 @@ class BundleAdjustmentOptimizer:
         gnc_loss: RobustBAMode | str = RobustBAMode.GMC,
         factor_weight_outlier_threshold: float = 0.0,
         min_track_length: int = 2,
+        min_tracks_per_camera: int = 20,
+        compute_pose_covariances: bool = False,
+        optimizer_relative_cost_tol: float = 1e-5,
     ) -> None:
         """Initializes the parameters for bundle adjustment module.
 
@@ -167,6 +176,7 @@ class BundleAdjustmentOptimizer:
             gnc_loss (optional): GNC loss to use. Defaults to GMC.
             factor_weight_outlier_threshold (optional): Threshold weight for a reprojection factor to be kept.
             min_track_length: min number of measurements required to keep a track after weight filtering.
+            compute_pose_covariances: If true, compute marginal covariance for all camera pose variables and return it.
         """
         self._reproj_error_thresholds = reproj_error_thresholds
         if isinstance(robust_ba_mode, str):
@@ -197,9 +207,20 @@ class BundleAdjustmentOptimizer:
             self._gnc_loss = gnc_loss
         self._factor_weight_outlier_threshold = factor_weight_outlier_threshold
         self._min_track_length = min_track_length
+        self._min_tracks_per_camera = min_tracks_per_camera
+        self._compute_pose_covariances = compute_pose_covariances
+        self._optimizer_relative_cost_tol = optimizer_relative_cost_tol
 
     def __map_to_calibration_variable(self, camera_idx: int) -> int:
         return 0 if self._shared_calib else camera_idx
+
+    def __get_cameras_with_insufficient_tracks(self, initial_data: GtsfmData) -> set[int]:
+        """Get the cameras with insufficient fewer tracks that self._min_tracks_per_camera."""
+        cameras_with_insufficient_tracks = set()
+        for i in initial_data.get_valid_camera_indices():
+            if len(initial_data.get_measurements_for_camera(i)) < self._min_tracks_per_camera:
+                cameras_with_insufficient_tracks.add(i)
+        return cameras_with_insufficient_tracks
 
     def __reprojection_factors(
         self, initial_data: GtsfmData, cameras_to_model: List[int], robust_noise_basin: float | None = None
@@ -220,17 +241,17 @@ class BundleAdjustmentOptimizer:
         assert first_camera is not None, "First camera in initial data is None"
         sfm_factor_class = gtsfm_types.get_sfm_factor_for_calibration(first_camera.calibration())
 
-        cameras_with_tracks = set()
         for j in range(initial_data.number_tracks()):
             track = initial_data.get_track(j)  # SfmTrack
+            valid_measurements = [
+                m_idx for m_idx in range(track.numberMeasurements()) if track.measurement(m_idx)[0] in cameras_to_model
+            ]
+            if len(valid_measurements) < self._min_track_length:
+                continue
             # Retrieve the SfmMeasurement objects.
-            for m_idx in range(track.numberMeasurements()):
+            for m_idx in valid_measurements:
                 # `i` represents the camera index, and `uv` is the 2d measurement
                 i, uv = track.measurement(m_idx)
-                cameras_with_tracks.add(i)
-                # Note use of shorthand symbols `X` and `P`.
-                if i not in cameras_to_model:
-                    continue
                 graph.push_back(
                     sfm_factor_class(
                         uv,
@@ -241,14 +262,7 @@ class BundleAdjustmentOptimizer:
                     )  # type: ignore
                 )
 
-        cameras_without_tracks = {}
-        for i in cameras_to_model:
-            if i not in cameras_with_tracks:
-                cameras_without_tracks[i] = initial_data.get_camera(i)
-        if len(cameras_without_tracks) > 0:
-            logger.info(f"Cameras without tracks: {cameras_without_tracks.keys()}")
-
-        return graph, cameras_without_tracks
+        return graph
 
     def _between_factors(
         self, relative_pose_priors: Dict[Tuple[int, int], PosePrior], cameras_to_model: List[int]
@@ -353,14 +367,14 @@ class BundleAdjustmentOptimizer:
 
     def __construct_simple_factor_graph(
         self, cameras_to_model: List[int], initial_data: GtsfmData, robust_noise_basin: float | None = None
-    ) -> tuple[NonlinearFactorGraph, Dict[int, gtsfm_types.CAMERA_TYPE]]:
+    ) -> NonlinearFactorGraph:
         """Construct the factor graph with just reprojection factors and calibration priors."""
 
         graph = NonlinearFactorGraph()
         if not cameras_to_model:
-            return graph, {}
+            return graph
 
-        reprojection_graph, cameras_without_tracks = self.__reprojection_factors(
+        reprojection_graph = self.__reprojection_factors(
             initial_data=initial_data,
             cameras_to_model=cameras_to_model,
             robust_noise_basin=robust_noise_basin,
@@ -378,7 +392,7 @@ class BundleAdjustmentOptimizer:
         if self._use_calibration_prior:
             graph.push_back(self.__calibration_priors(initial_data, cameras_to_model))
 
-        return graph, cameras_without_tracks
+        return graph
 
     def __construct_factor_graph(
         self,
@@ -387,19 +401,17 @@ class BundleAdjustmentOptimizer:
         absolute_pose_priors: List[Optional[PosePrior]],
         relative_pose_priors: Dict[Tuple[int, int], PosePrior],
         robust_noise_basin: float | None = None,
-    ) -> tuple[NonlinearFactorGraph, Dict[int, gtsfm_types.CAMERA_TYPE]]:
+    ) -> NonlinearFactorGraph:
         """Construct the factor graph with reprojection factors, BetweenFactors, and prior factors."""
         # Create a factor graph.
-        graph, cameras_without_tracks = self.__construct_simple_factor_graph(
-            cameras_to_model, initial_data, robust_noise_basin
-        )
+        graph = self.__construct_simple_factor_graph(cameras_to_model, initial_data, robust_noise_basin)
 
         # Add priors
         graph.push_back(
             self._between_factors(relative_pose_priors=relative_pose_priors, cameras_to_model=cameras_to_model)
         )
 
-        return graph, cameras_without_tracks
+        return graph
 
     def __optimize_factor_graph(
         self, graph: NonlinearFactorGraph, initial_values: Values, ordering_type: str
@@ -414,6 +426,8 @@ class BundleAdjustmentOptimizer:
             params.setMaxIterations(self._max_iterations)
 
         if not self._use_gnc:
+            if self._optimizer_relative_cost_tol is not None:
+                params.setRelativeCostTol(self._optimizer_relative_cost_tol)
             lm = gtsam.LevenbergMarquardtOptimizer(graph, initial_values, params)
         else:
             gnc_params = gtsam.GncLMParams(params)
@@ -425,7 +439,8 @@ class BundleAdjustmentOptimizer:
                 raise ValueError(f"Unsupported GNC loss type: {self._gnc_loss}.")
             gnc_params.setVerbosityGNC(gtsam.GncLMParams.Verbosity.SUMMARY)
             gnc_params.setAllowNonNoiseModelFactors(True)
-            gnc_params.setRelativeCostTol(1e-3)
+            if self._optimizer_relative_cost_tol is not None:
+                gnc_params.setRelativeCostTol(self._optimizer_relative_cost_tol)
             lm = gtsam.GncLMOptimizer(graph, initial_values, gnc_params)
 
         # gnc does not support getAbsoluteErrorTol and getRelativeErrorTol params
@@ -474,6 +489,22 @@ class BundleAdjustmentOptimizer:
     def is_two_view_ba(self, initial_data: GtsfmData) -> bool:
         """Determines whether two-view bundle adjustment is being executed."""
         return len(initial_data.get_valid_camera_indices()) == 2
+
+    def __compute_camera_pose_covariances(
+        self, marginals: gtsam.Marginals, cameras_to_model: List[int]
+    ) -> Dict[int, NDArray[np.float64]]:
+        """Compute marginal covariance for all camera pose variables."""
+        pose_covariances: Dict[int, NDArray[np.float64]] = {}
+        for camera_idx in cameras_to_model:
+            try:
+                full_cov = np.asarray(marginals.marginalCovariance(X(camera_idx)))
+                pose_covariances[camera_idx] = full_cov[:CAM_POSE3_DOF, :CAM_POSE3_DOF]
+            except Exception:
+                logger.error(
+                    f"Error computing covariance for camera {camera_idx}, likely due to indeterminate linear system."
+                )
+                continue
+        return pose_covariances
 
     def __optimize_and_recover(
         self, initial_data: GtsfmData, graph: NonlinearFactorGraph, ordering_type: str
@@ -556,16 +587,26 @@ class BundleAdjustmentOptimizer:
             Final error value of the optimization problem.
         """
         cameras_to_model = sorted(initial_data.get_valid_camera_indices())
+        cameras_with_insufficient_tracks = self.__get_cameras_with_insufficient_tracks(initial_data)
+        cameras_to_model = [i for i in cameras_to_model if i not in cameras_with_insufficient_tracks]
+        logger.info(
+            "Cameras with insufficient tracks (fewer than %d): %s, will be excluded from BA.",
+            self._min_tracks_per_camera,
+            cameras_with_insufficient_tracks,
+        )
+        graph = self.__construct_simple_factor_graph(cameras_to_model, initial_data, robust_noise_basin)
+        optimized_data, result_values, final_error = self.__optimize_and_recover(
+            initial_data, graph, self._ordering_type
+        )
+        if self._compute_pose_covariances:
+            try:
+                marginals = gtsam.Marginals(graph, result_values)
+                optimized_data.set_camera_pose_covariances(
+                    self.__compute_camera_pose_covariances(marginals, cameras_to_model)
+                )
+            except Exception:
+                logger.info("Error computing marginals, likely due to indeterminate linear system.")
 
-        graph, cameras_without_tracks = self.__construct_simple_factor_graph(
-            cameras_to_model, initial_data, robust_noise_basin
-        )
-        if len(cameras_without_tracks) == len(initial_data.cameras()):
-            logger.warning("Skipping bundle adjustment because all cameras are without tracks.")
-            return initial_data, 0.0
-        optimized_data, _, final_error = self.__optimize_and_recover(
-            initial_data, graph, self._ordering_type if not cameras_without_tracks else "COLAMD"
-        )
         return optimized_data, final_error
 
     def run_iterative_robust_ba(
@@ -585,7 +626,7 @@ class BundleAdjustmentOptimizer:
         relative_pose_priors: Dict[Tuple[int, int], PosePrior],
         reproj_error_thresh: Optional[float],
         verbose: bool = True,
-    ) -> Tuple[GtsfmData, GtsfmData, List[bool], float]:
+    ) -> Tuple[Optional[GtsfmData], Optional[GtsfmData], Optional[List[bool]], Optional[float]]:
         """Runs bundle adjustment and optionally filters the resulting tracks by reprojection error.
 
         Args:
@@ -612,28 +653,50 @@ class BundleAdjustmentOptimizer:
             )
             return initial_data, initial_data, [False] * initial_data.number_tracks(), 0.0
 
+        running_two_view_ba = self.is_two_view_ba(initial_data)
+
         cameras_to_model = sorted(initial_data.get_valid_camera_indices())
-        graph, cameras_without_tracks = self.__construct_factor_graph(
+        if not running_two_view_ba:
+            cameras_with_insufficient_tracks = self.__get_cameras_with_insufficient_tracks(initial_data)
+            cameras_to_model = [i for i in cameras_to_model if i not in cameras_with_insufficient_tracks]
+            logger.info(
+                "Cameras with insufficient tracks (fewer than %d): %s, will be excluded from BA.",
+                self._min_track_length,
+                cameras_with_insufficient_tracks,
+            )
+
+        graph = self.__construct_factor_graph(
             cameras_to_model, initial_data, absolute_pose_priors, relative_pose_priors
         )
         optimized_data, result_values, final_error = self.__optimize_and_recover(
-            initial_data, graph, self._ordering_type if not cameras_without_tracks else "COLAMD"
+            initial_data, graph, self._ordering_type
         )
+        if not running_two_view_ba:
+            # Add the non-BA cameras from initial_data back.
+            for camera_idx in cameras_with_insufficient_tracks:
+                optimized_data.cameras[camera_idx] = initial_data.get_camera(camera_idx)
 
-        if self.is_two_view_ba(initial_data):
+        if running_two_view_ba or self._compute_pose_covariances:
             try:
-                # Calculate marginal covariances for all two pose variables.
                 marginals = gtsam.Marginals(graph, result_values)
-                graph_keys = self.get_two_view_ba_pose_graph_keys(initial_data)
-                for key in graph_keys:
-                    _ = marginals.marginalCovariance(key)
+                if running_two_view_ba:
+                    # Calculate marginal covariances for all two pose variables.
+                    graph_keys = self.get_two_view_ba_pose_graph_keys(initial_data)
+                    for key in graph_keys:
+                        _ = marginals.marginalCovariance(key)
+                if self._compute_pose_covariances:
+                    optimized_data.set_camera_pose_covariances(
+                        self.__compute_camera_pose_covariances(marginals, cameras_to_model)
+                    )
 
             except RuntimeError:
-                if not self._allow_indeterminate_linear_system:
+                if running_two_view_ba and not self._allow_indeterminate_linear_system:
                     logger.error(
                         "BA result discarded due to Indeterminate Linear System (ILS) when computing marginals."
                     )
                     return None, None, None, None
+                elif not running_two_view_ba:
+                    logger.info("Error computing marginals, likely due to indeterminate linear system.")
 
         # Convert the `Values` results to a `GtsfmData` instance.
         # Filter landmarks by reprojection error.
@@ -647,6 +710,13 @@ class BundleAdjustmentOptimizer:
         else:
             valid_mask = [True] * optimized_data.number_tracks()
             filtered_result = optimized_data
+        if self._compute_pose_covariances:
+            filtered_pose_covariances = {
+                i: cov
+                for i, cov in optimized_data.get_camera_pose_covariances().items()
+                if i in filtered_result.get_valid_camera_indices()
+            }
+            filtered_result.set_camera_pose_covariances(filtered_pose_covariances)
         return optimized_data, filtered_result, valid_mask, final_error
 
     def run_ba(
@@ -655,7 +725,7 @@ class BundleAdjustmentOptimizer:
         absolute_pose_priors: List[Optional[PosePrior]],
         relative_pose_priors: Dict[Tuple[int, int], PosePrior],
         verbose: bool = True,
-    ) -> Tuple[GtsfmData, GtsfmData, List[bool]]:
+    ) -> Tuple[Optional[GtsfmData], Optional[GtsfmData], Optional[List[bool]]]:
         """Runs bundle adjustment by forming a factor graph and optimizing it using Levenberg–Marquardt optimization.
 
         Args:

--- a/gtsfm/bundle/bundle_adjustment.py
+++ b/gtsfm/bundle/bundle_adjustment.py
@@ -427,7 +427,7 @@ class BundleAdjustmentOptimizer:
 
         if not self._use_gnc:
             if self._optimizer_relative_cost_tol is not None:
-                params.setRelativeCostTol(self._optimizer_relative_cost_tol)
+                params.setRelativeErrorTol(self._optimizer_relative_cost_tol)
             lm = gtsam.LevenbergMarquardtOptimizer(graph, initial_values, params)
         else:
             gnc_params = gtsam.GncLMParams(params)

--- a/gtsfm/bundle/bundle_adjustment.py
+++ b/gtsfm/bundle/bundle_adjustment.py
@@ -674,7 +674,7 @@ class BundleAdjustmentOptimizer:
         if not running_two_view_ba:
             # Add the non-BA cameras from initial_data back.
             for camera_idx in cameras_with_insufficient_tracks:
-                optimized_data.cameras_[camera_idx] = initial_data.get_camera(camera_idx)
+                optimized_data._cameras[camera_idx] = initial_data.get_camera(camera_idx)
 
         if running_two_view_ba or self._compute_pose_covariances:
             try:

--- a/gtsfm/bundle/bundle_adjustment.py
+++ b/gtsfm/bundle/bundle_adjustment.py
@@ -75,9 +75,9 @@ class BundleAdjustmentOptions:
     calibration_prior_dist_sigma: float | Sequence[float] = 0.1
     calibration_prior_pp_sigma: float = 1e-5
     robust_noise_basin: float = 1.345
-    min_tracks_per_camera: int = 20
+    min_tracks_per_camera: int = 15
     compute_pose_covariances: bool = False
-    optimizer_relative_cost_tol: float = 1e-3
+    optimizer_relative_cost_tol: float = 1e-5
 
     def to_optimizer(self, **overrides) -> "BundleAdjustmentOptimizer":
         """Construct a :class:`BundleAdjustmentOptimizer` from these options.
@@ -144,7 +144,7 @@ class BundleAdjustmentOptimizer:
         gnc_loss: RobustBAMode | str = RobustBAMode.GMC,
         factor_weight_outlier_threshold: float = 0.0,
         min_track_length: int = 2,
-        min_tracks_per_camera: int = 20,
+        min_tracks_per_camera: int = 15,
         compute_pose_covariances: bool = False,
         optimizer_relative_cost_tol: float = 1e-5,
     ) -> None:

--- a/gtsfm/bundle/bundle_adjustment.py
+++ b/gtsfm/bundle/bundle_adjustment.py
@@ -674,7 +674,7 @@ class BundleAdjustmentOptimizer:
         if not running_two_view_ba:
             # Add the non-BA cameras from initial_data back.
             for camera_idx in cameras_with_insufficient_tracks:
-                optimized_data.cameras[camera_idx] = initial_data.get_camera(camera_idx)
+                optimized_data.cameras_[camera_idx] = initial_data.get_camera(camera_idx)
 
         if running_two_view_ba or self._compute_pose_covariances:
             try:

--- a/gtsfm/common/gtsfm_data.py
+++ b/gtsfm/common/gtsfm_data.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, Union
 
 import gtsam  # type: ignore
 import numpy as np
+from numpy.typing import NDArray
 from gtsam import Pose3, SfmTrack, Similarity3, Values
 from gtsam.symbol_shorthand import K, P, X  # type: ignore
 
@@ -85,6 +86,7 @@ class GtsfmData:
         cameras: Optional[Mapping[int, gtsfm_types.CAMERA_TYPE]] = None,
         tracks: Optional[List[SfmTrack]] = None,
         gaussian_splats: Optional[GaussianSplatsType] = None,
+        pose_covariances: Optional[Mapping[int, NDArray[np.float64]]] = None,
     ) -> None:
         """Initializes the class.
 
@@ -99,6 +101,7 @@ class GtsfmData:
         self._image_info: dict[int, ImageInfo] = {}
         self._gaussian_splats: GaussianSplatsType | None = None
         self._camera_to_measurement_map: dict[int, list[tuple[int, int]]] | None = None
+        self._pose_covariances: dict[int, NDArray[np.float64]] = {}
 
         # Initialize from inputs if provided.
         if cameras is not None:
@@ -109,6 +112,8 @@ class GtsfmData:
                 self.add_track(track)
         if gaussian_splats is not None:
             self.set_gaussian_splats(gaussian_splats)
+        if pose_covariances is not None:
+            self.set_camera_pose_covariances(pose_covariances)
 
     def __repr__(self) -> str:
         """String representation of the object."""
@@ -216,7 +221,12 @@ class GtsfmData:
 
     @classmethod
     def from_values(
-        cls, values: Values, initial_data: Optional["GtsfmData"] = None, shared_calib: bool = False
+        cls,
+        values: Values,
+        initial_data: Optional["GtsfmData"] = None,
+        shared_calib: bool = False,
+        include_cameras_not_in_values: bool = True,
+        include_tracks_not_in_values: bool = False,
     ) -> "GtsfmData":
         """Instantiate a GtsfmData from optimized factor graph results.
 
@@ -224,6 +234,7 @@ class GtsfmData:
             values: Optimizer output containing poses, points, and calibrations.
             initial_data: Optional input data used to build the factor graph; provides topology for cameras and tracks.
             shared_calib: Whether all cameras shared a single calibration variable in the optimization.
+            include_cameras_not_in_values: Whether to include cameras that are not in values (but are in initial_data).
         """
 
         def _symbol_indices(value_keys: Iterable[int], char: str) -> List[int]:
@@ -236,7 +247,9 @@ class GtsfmData:
 
         keys_list = list(values.keys())
         pose_indices = (
-            initial_data.get_valid_camera_indices() if initial_data is not None else _symbol_indices(keys_list, "x")
+            initial_data.get_valid_camera_indices()
+            if initial_data is not None and include_cameras_not_in_values
+            else _symbol_indices(keys_list, "x")
         )
 
         if not pose_indices:
@@ -300,22 +313,32 @@ class GtsfmData:
 
         for i in pose_indices:
             cal_i = _calibration_for_idx(i)
-            result.add_camera(i, camera_class(values.atPose3(X(i)), cal_i))  # type: ignore
+            if values.exists(X(i)):
+                result.add_camera(i, camera_class(values.atPose3(X(i)), cal_i))  # type: ignore
+            elif initial_data and include_cameras_not_in_values:
+                result.add_camera(i, initial_data.get_camera(i))
 
-        track_indices = _symbol_indices(keys_list, "p")
+        track_indices = (
+            _symbol_indices(keys_list, "p") if initial_data is not None else initial_data.get_valid_camera_indices()
+        )
 
         for track_idx in track_indices:
-            point = values.atPoint3(P(track_idx))
-            result_track = SfmTrack(point)
-            if initial_data is not None:
-                input_track = initial_data.get_track(track_idx)
-                result_track.r = input_track.r
-                result_track.g = input_track.g
-                result_track.b = input_track.b
-                for measurement_idx in range(input_track.numberMeasurements()):
-                    i, uv = input_track.measurement(measurement_idx)
-                    result_track.addMeasurement(i, uv)
-            result.add_track(result_track)
+            if values.exists(P(track_idx)):
+                point = values.atPoint3(P(track_idx))
+                result_track = SfmTrack(point)
+                if initial_data is not None:
+                    input_track = initial_data.get_track(track_idx)
+                    result_track.r = input_track.r
+                    result_track.g = input_track.g
+                    result_track.b = input_track.b
+                    for measurement_idx in range(input_track.numberMeasurements()):
+                        i, uv = input_track.measurement(measurement_idx)
+                        if i in result.get_valid_camera_indices():
+                            result_track.addMeasurement(i, uv)
+                result.add_track(result_track)
+            elif initial_data is not None and include_tracks_not_in_values:
+                result_track = initial_data.get_track(track_idx)
+                result.add_track(result_track)
 
         if initial_data is not None:
             result._image_info = initial_data._clone_image_info()
@@ -427,6 +450,7 @@ class GtsfmData:
 
         if self._gaussian_splats is not None:
             cloned.set_gaussian_splats(self._gaussian_splats)
+        cloned._pose_covariances = self._clone_pose_covariances(indices=cloned.get_valid_camera_indices())
 
         return cloned
 
@@ -453,6 +477,15 @@ class GtsfmData:
                 info = self._image_info[idx]
                 cloned[idx] = ImageInfo(name=info.name, shape=info.shape)
         return cloned
+
+    def _clone_pose_covariances(self, indices: Optional[Iterable[int]] = None) -> dict[int, NDArray[np.float64]]:
+        """Create a shallow copy of per-camera pose covariance blocks."""
+        source_indices = indices if indices is not None else self._pose_covariances.keys()
+        return {
+            idx: np.array(self._pose_covariances[idx], copy=True)
+            for idx in list(source_indices)
+            if idx in self._pose_covariances
+        }
 
     def _default_image_filename(self, index: int) -> str:
         """Return a placeholder filename for ``index``."""
@@ -547,6 +580,23 @@ class GtsfmData:
     def get_camera_poses(self) -> Dict[int, Pose3]:
         """Returns poses as a dictionary, without missing poses."""
         return {i: cam.pose() for i, cam in self._cameras.items()}
+
+    def set_camera_pose_covariance(self, index: int, covariance: NDArray[np.float64]) -> None:
+        """Set pose covariance for one camera index."""
+        self._pose_covariances[index] = np.array(covariance, copy=True)
+
+    def set_camera_pose_covariances(self, pose_covariances: Mapping[int, NDArray[np.float64]]) -> None:
+        """Set pose covariances for multiple camera indices."""
+        self._pose_covariances = {idx: np.array(cov, copy=True) for idx, cov in pose_covariances.items()}
+
+    def get_camera_pose_covariance(self, index: int) -> Optional[NDArray[np.float64]]:
+        """Get pose covariance for one camera index, if available."""
+        covariance = self._pose_covariances.get(index)
+        return None if covariance is None else np.array(covariance, copy=True)
+
+    def get_camera_pose_covariances(self) -> Dict[int, NDArray[np.float64]]:
+        """Get all available camera pose covariances."""
+        return self._clone_pose_covariances()
 
     def get_track(self, index: int) -> SfmTrack:
         """Returns track at given index."""
@@ -674,6 +724,7 @@ class GtsfmData:
         if len(camera_edges) == 0:
             data = GtsfmData(self._number_images, gaussian_splats=self._gaussian_splats)
             data._image_info = self._clone_image_info()
+            data._pose_covariances = self._clone_pose_covariances()
             return data
 
         cameras_in_largest_cc = graph_utils.get_nodes_in_largest_connected_component(camera_edges)
@@ -692,6 +743,7 @@ class GtsfmData:
         number_images: int,
         image_info: Optional[Mapping[int, ImageInfo]] = None,
         gaussian_splats: Optional[GaussianSplatsType] = None,
+        pose_covariances: Optional[Mapping[int, NDArray[np.float64]]] = None,
     ) -> "GtsfmData":
         """Creates a GtsfmData object from a pre-existing set of cameras and tracks."""
         new_data = cls(number_images=number_images, gaussian_splats=gaussian_splats)
@@ -701,6 +753,8 @@ class GtsfmData:
             new_data._image_info = {
                 idx: ImageInfo(name=info.name, shape=info.shape) for idx, info in image_info.items()
             }
+        if pose_covariances is not None:
+            new_data.set_camera_pose_covariances(pose_covariances)
         return new_data
 
     @classmethod
@@ -752,6 +806,7 @@ class GtsfmData:
             new_data._camera_to_measurement_map = {
                 k: v for k, v in gtsfm_data._camera_to_measurement_map.items() if k in new_camera_indices
             }
+        new_data._pose_covariances = gtsfm_data._clone_pose_covariances(indices=new_camera_indices)
 
         return new_data
 
@@ -881,6 +936,7 @@ class GtsfmData:
                 filtered_data.set_image_info(i, name=source_info.name, shape=source_info.shape)
             filtered_data.add_track(track)
 
+        filtered_data._pose_covariances = self._clone_pose_covariances(indices=filtered_data.get_valid_camera_indices())
         return filtered_data, valid_mask
 
     def filter_landmark_measurements(
@@ -932,6 +988,7 @@ class GtsfmData:
                     continue
                 filtered_data.add_camera(i, camera_i)
 
+        filtered_data._pose_covariances = self._clone_pose_covariances(indices=filtered_data.get_valid_camera_indices())
         return filtered_data
 
     def align_via_sim3_and_transform(self, aTi: dict[int, Pose3]) -> "GtsfmData":
@@ -1057,6 +1114,9 @@ class GtsfmData:
             else:
                 merged_gaussians = merge_gaussian_splats(merged_gaussians, transformed_other_gaussians)
         merged_data.set_gaussian_splats(merged_gaussians)
+        # Keep only covariances for unchanged cameras from `self`. Cameras transformed from `other`
+        # would require uncertainty transport through Sim(3), which is not handled here.
+        merged_data._pose_covariances = self._clone_pose_covariances(indices=merged_data.get_valid_camera_indices())
 
         return merged_data
 
@@ -1074,6 +1134,7 @@ class GtsfmData:
             gaussian_splats=self._gaussian_splats,
         )
         downsampled._image_info = self._clone_image_info()
+        downsampled._pose_covariances = self._clone_pose_covariances(indices=downsampled.get_valid_camera_indices())
         return downsampled
 
     # COLMAP export functions
@@ -1108,6 +1169,26 @@ class GtsfmData:
                 to_write = [colmap_cam.id, colmap_cam.model, colmap_cam.width, colmap_cam.height, *colmap_cam.params]
                 line = " ".join([str(elem) for elem in to_write])
                 f.write(line + "\n")
+
+        if self._pose_covariances:
+            covariance_path = dir_path / "covariance.txt"
+            valid_camera_indices = self.get_valid_camera_indices()
+            with open(covariance_path, "w") as f:
+                f.write("# Camera pose covariance list with one line of data per camera:\n")
+                f.write("#   CAMERA_ID, COVARIANCE_6X6_ROW_MAJOR[]\n")
+                f.write(
+                    "# Number of covariances: "
+                    f"{sum(1 for i in valid_camera_indices if i in self._pose_covariances)}\n"
+                )
+
+                for i in valid_camera_indices:
+                    covariance = self._pose_covariances.get(i)
+                    if covariance is None:
+                        continue
+                    covariance_6x6 = np.asarray(covariance)[:6, :6]
+                    row_major_values = covariance_6x6.reshape(-1)
+                    line = " ".join([str(i), *[str(val) for val in row_major_values]])
+                    f.write(line + "\n")
 
     def write_images(self, save_dir: str | Path) -> None:
         """Writes the image data file in the COLMAP format.
@@ -1221,6 +1302,7 @@ class GtsfmData:
         """Emulates the COLMAP option to `Export model as text`.
 
         Three text files will be saved to disk: "points3D.txt", "images.txt", and "cameras.txt".
+        If pose covariances are available, "covariance.txt" is also saved.
 
         Args:
             save_dir: Folder where text files will be saved.

--- a/gtsfm/common/gtsfm_data.py
+++ b/gtsfm/common/gtsfm_data.py
@@ -319,7 +319,7 @@ class GtsfmData:
                 result.add_camera(i, initial_data.get_camera(i))
 
         track_indices = (
-            _symbol_indices(keys_list, "p") if initial_data is not None else initial_data.get_valid_camera_indices()
+            _symbol_indices(keys_list, "p") if initial_data is None else initial_data.get_valid_camera_indices()
         )
 
         for track_idx in track_indices:

--- a/gtsfm/common/gtsfm_data.py
+++ b/gtsfm/common/gtsfm_data.py
@@ -319,7 +319,7 @@ class GtsfmData:
                 result.add_camera(i, initial_data.get_camera(i))
 
         track_indices = (
-            _symbol_indices(keys_list, "p") if initial_data is None else initial_data.get_valid_camera_indices()
+            _symbol_indices(keys_list, "p") if initial_data is None else list(range(initial_data.number_tracks()))
         )
 
         for track_idx in track_indices:

--- a/gtsfm/configs/vggt_colmaptracker.yaml
+++ b/gtsfm/configs/vggt_colmaptracker.yaml
@@ -7,7 +7,7 @@ loader:
   _target_: gtsfm.loader.Olsson
   dataset_dir: ??? # Required: set to the dataset root on the command line.
   images_dir: null
-  max_resolution: 518 # VGGT recommended max resolution. Non editable. mode is fixed to "crop"
+  max_resolution: 518 # VGGT recommended max resolution. Non editable. mode can be set in cluster optimizer config.
 
 image_pairs_generator:
   _target_: gtsfm.retriever.image_pairs_generator.ImagePairsGenerator
@@ -17,8 +17,8 @@ image_pairs_generator:
       _target_: gtsfm.frontend.global_descriptor.MegaLoc
   retriever:
     _target_: gtsfm.retriever.Similarity
-    num_matched: 5
-    min_score: 0.25
+    num_matched: 15
+    min_score: 0.5
   batch_size: 16
 
 graph_partitioner:
@@ -32,25 +32,29 @@ cluster_optimizer:
   optimizer:
     _target_: gtsfm.cluster_optimizer.cluster_vggt.ClusterVGGT
 
-    # --- Geometry transformer ---
     geometry_transformer:
       _target_: gtsfm.frontend.vggt_geometry_transformer.VggtGeometryTransformer
       config:
         _target_: gtsfm.frontend.vggt_geometry_transformer.VggtGeometryConfig
-        confidence_threshold: 5.0
+        confidence_threshold: 0.1
         max_num_points: 100000
         seed: 42
 
-    # --- Use Colmap tracker ---
     tracker:
       _target_: gtsfm.frontend.multi_view_tracker.ColmapTracker
       config:
         _target_: gtsfm.frontend.multi_view_tracker.TrackingConfig
         tracking: true
-        vggt_max_reproj_error: 0 # 0.0 means no filtering based on reproj error
+        min_track_length: 3
+        vggt_max_reproj_error: 14.0
         min_triangulation_angle: 0.2
         ba_use_undistorted_camera_model: false
+        ba_track_patch_size: 14
+        enable_ba_track_patching: true
 
+    pre_ba_max_reproj_error: 14.0
+    post_ba_max_reproj_error: 3.0
+    drop_camera_with_no_track: false
     ba_options:
       _target_: gtsfm.bundle.bundle_adjustment.BundleAdjustmentOptions
       shared_calib: true
@@ -58,8 +62,11 @@ cluster_optimizer:
       use_gnc: true
       gnc_loss: TLS
       factor_weight_outlier_threshold: 1e-8
+      compute_pose_covariances: false
 
     # --- VGGT operational params ---
+    input_mode: crop
+    save_processed_image: true
     weights_path: null
     seed: 42
     model_cache_key: null
@@ -67,14 +74,23 @@ cluster_optimizer:
 # --- Merging options ---
 merging_options:
   _target_: gtsfm.cluster_merging.MergingOptions
-  run_bundle_adjustment: false
-  merge_duplicate_tracks: false
+  run_bundle_adjustment: true
+  merge_duplicate_tracks: true
   drop_child_if_merging_fail: true
-  drop_outlier_after_camera_merging: false
-  drop_camera_with_no_track: true
-  keep_all_cameras: false
+  drop_outlier_after_camera_merging: true
+  drop_camera_with_no_track: false
+  keep_all_cameras: true
   plot_reprojection_histograms: true
+  use_nonlinear_sim3_alignment: true
+  pre_ba_max_reproj_error: 14.0
+  pre_ba_min_track_length: 3
+  post_ba_max_reproj_error: 3.0
+  max_track_correspondences_for_sim3: 150
+  min_track_length: 3
   ba_options:
     _target_: gtsfm.bundle.bundle_adjustment.BundleAdjustmentOptions
     shared_calib: true
-    use_calibration_prior: false
+    use_calibration_prior: true
+    use_gnc: true
+    gnc_loss: GMC
+    compute_pose_covariances: false

--- a/gtsfm/configs/vggt_megaloc_phototourism.yaml
+++ b/gtsfm/configs/vggt_megaloc_phototourism.yaml
@@ -56,7 +56,7 @@ cluster_optimizer:
         vggt_max_reproj_error: 14.0
         min_triangulation_angle: 2.0
         min_track_length: 3
-        ba_track_patch_grid_size: 14
+        ba_track_patch_size: 14
         enable_ba_track_patching: true
         ba_use_undistorted_camera_model: false
 

--- a/gtsfm/frontend/multi_view_tracker.py
+++ b/gtsfm/frontend/multi_view_tracker.py
@@ -68,7 +68,7 @@ class TrackingConfig:
     vggt_max_reproj_error: float = 14.0
     min_triangulation_angle: float = 10.0
     min_track_length: int = 2
-    ba_track_patch_grid_size: int = 8
+    ba_track_patch_size: int = 8
     enable_ba_track_patching: bool = False
     ba_use_undistorted_camera_model: bool = False
     colmaptracker_config_path: str = str(_DEFAULT_VGGT_COLMAPTRACKER_CONFIG_PATH)
@@ -120,13 +120,14 @@ def _compute_image_patch(
     v: float,
     image_width: float,
     image_height: float,
-    patch_grid_size: int,
+    patch_size: int,
 ) -> tuple[int, int]:
     """Map a 2D pixel measurement to an image patch in an ``NxN`` grid."""
-    if patch_grid_size <= 1:
+    if patch_size <= 0:
         return (0, 0)
-    col = int(np.floor(np.clip(u, 0.0, image_width - 1e-6) / image_width * patch_grid_size))
-    row = int(np.floor(np.clip(v, 0.0, image_height - 1e-6) / image_height * patch_grid_size))
+
+    col = int(np.clip(u, 0.0, image_width) // patch_size)
+    row = int(np.clip(v, 0.0, image_height) // patch_size)
     return (row, col)
 
 
@@ -598,7 +599,7 @@ class MultiViewTracker:
                     v=v,
                     image_width=original_coords_np[local_id, 4],
                     image_height=original_coords_np[local_id, 5],
-                    patch_grid_size=config.ba_track_patch_grid_size,
+                    patch_size=config.ba_track_patch_size,
                 )
 
             if len(per_track_measurements) < config.min_track_length:

--- a/gtsfm/loader/colmap_loader.py
+++ b/gtsfm/loader/colmap_loader.py
@@ -82,7 +82,9 @@ class ColmapLoader(LoaderBase):
         else:
             self._colmap_files_subdir = self._dataset_dir
 
-        wTi_list, img_fnames, calibrations, _, _, _ = io_utils.read_scene_data_from_colmap_format(colmap_data_dir)
+        wTi_list, img_fnames, calibrations, _, _, _ = io_utils.read_scene_data_from_colmap_format(
+            self._colmap_files_subdir
+        )
         # TODO in future PR: if img_fnames is None, default to using everything inside image directory
 
         if calibrations is None:

--- a/gtsfm/loader/colmap_loader.py
+++ b/gtsfm/loader/colmap_loader.py
@@ -76,11 +76,11 @@ class ColmapLoader(LoaderBase):
         self._use_gt_intrinsics = use_gt_intrinsics
         self._use_gt_extrinsics = use_gt_extrinsics
         self._default_focal_length_factor = default_focal_length_factor
-        colmap_data_dir = (
-            os.path.join(self._dataset_dir, self._colmap_files_subdir)
-            if self._colmap_files_subdir is not None
-            else self._dataset_dir
-        )
+        if self._colmap_files_subdir is not None:
+            if not os.path.isabs(self._colmap_files_subdir):
+                self._colmap_files_subdir = os.path.join(self._dataset_dir, self._colmap_files_subdir)
+        else:
+            self._colmap_files_subdir = self._dataset_dir
 
         wTi_list, img_fnames, calibrations, _, _, _ = io_utils.read_scene_data_from_colmap_format(colmap_data_dir)
         # TODO in future PR: if img_fnames is None, default to using everything inside image directory

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -92,11 +92,13 @@ class TwoViewEstimator(DaskDBModuleBase):
             use_calibration_prior=True,
             robust_noise_basin=1.345,
             use_karcher_mean_factor=False,
+            use_pose_prior_first_camera=True,
             calibration_prior_focal_sigma=1e-5,
             calibration_prior_dist_sigma=1e-5,
-            cam_pose3_prior_noise_sigma=0.1,
+            cam_pose3_prior_noise_sigma=1e-3,
             measurement_noise_sigma=1.0,
             min_tracks_per_camera=5,
+            min_track_length=2,
         )
         self.postgres_params = postgres_params  # save connection parameters for use on remote worker
 

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -96,6 +96,7 @@ class TwoViewEstimator(DaskDBModuleBase):
             calibration_prior_dist_sigma=1e-5,
             cam_pose3_prior_noise_sigma=0.1,
             measurement_noise_sigma=1.0,
+            min_tracks_per_camera=5,
         )
         self.postgres_params = postgres_params  # save connection parameters for use on remote worker
 

--- a/tests/bundle/test_bundle_adjustment.py
+++ b/tests/bundle/test_bundle_adjustment.py
@@ -23,7 +23,7 @@ class TestBundleAdjustmentOptimizer(unittest.TestCase):
         super().setUp()
 
         reproj_error_thresholds = [100.0]
-        self.ba = BundleAdjustmentOptimizer(reproj_error_thresholds=reproj_error_thresholds)
+        self.ba = BundleAdjustmentOptimizer(reproj_error_thresholds=reproj_error_thresholds, min_tracks_per_camera=5)
 
         self.test_data = EXAMPLE_DATA
 


### PR DESCRIPTION
- Add functionality to compute and save the covariances using gtsam.Marginals. This is only for debugging, not for use in the algorithm. 
- Min track length pre-BA should be 3. 
- Do not BA cameras that have < 20 tracks. What do we we do with them? retain the pre-BA camera poses as these could be important to merge children upstream. Should we also retain the tracks? discarding them now, could revisit later if that causes problems. 
- change from grid-size to patch size for filtering tracks. grid-size is unclear, perhaps this was using recangular patches before? 
- expose some more options to customize BA, eg. relative cost tolerance. 