### PR TITLE
Frontend changes

### DIFF
--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -58,6 +58,8 @@ dependencies:
       - trimesh[easy]
       - gtsam-develop==4.3a1.dev202604240153
       - pydot
+      - poselib==2.0.5
+      - bokeh==3.7.*
       # dust3r/mast3r
       - roma
       - tqdm

--- a/gtsfm/bundle/bundle_adjustment.py
+++ b/gtsfm/bundle/bundle_adjustment.py
@@ -660,7 +660,7 @@ class BundleAdjustmentOptimizer:
             valid_mask[track_idx] = is_valid
         return optimized_data, filtered_result, valid_mask, final_error
 
-    def _run_ba_stages(
+    def run_ba(
         self,
         initial_data: GtsfmData,
         absolute_pose_priors: List[Optional[PosePrior]],
@@ -716,35 +716,6 @@ class BundleAdjustmentOptimizer:
                 )
 
         return optimized_data, filtered_result, cumulative_valid_mask, step_times  # type: ignore
-
-    def run_ba(
-        self,
-        initial_data: GtsfmData,
-        absolute_pose_priors: List[Optional[PosePrior]],
-        relative_pose_priors: Dict[Tuple[int, int], PosePrior],
-        verbose: bool = True,
-    ) -> Tuple[GtsfmData, GtsfmData, List[bool]]:
-        """Runs bundle adjustment by forming a factor graph and optimizing it using Levenberg–Marquardt optimization.
-
-        Args:
-            initial_data: Initialized cameras, tracks w/ their 3d landmark from triangulation.
-            absolute_pose_priors: Priors to be used on cameras.
-            relative_pose_priors: Priors on the pose between two cameras.
-            verbose: Boolean flag to print out additional info for debugging.
-
-        Results:
-            Optimized camera poses, 3D point w/ tracks, and error metrics, aligned to GT (if provided).
-            Optimized camera poses after filtering landmarks (and cameras with no remaining landmarks).
-            Valid mask as a list of booleans, indicating for each input track whether it was below the re-projection
-                threshold.
-        """
-        optimized_data, filtered_result, valid_mask, _ = self._run_ba_stages(
-            initial_data=initial_data,
-            absolute_pose_priors=absolute_pose_priors,
-            relative_pose_priors=relative_pose_priors,
-            verbose=verbose,
-        )
-        return optimized_data, filtered_result, valid_mask
 
     def _run_ba_and_evaluate(
         self,

--- a/gtsfm/bundle/bundle_adjustment.py
+++ b/gtsfm/bundle/bundle_adjustment.py
@@ -477,23 +477,25 @@ class BundleAdjustmentOptimizer:
 
     def __optimize_and_recover(
         self, initial_data: GtsfmData, graph: NonlinearFactorGraph, ordering_type: str
-    ) -> Tuple[GtsfmData, Values, float]:
+    ) -> Tuple[GtsfmData, Values, float, List[bool]]:
         """Optimize the graph, report errors, and convert `Values` back to `GtsfmData`."""
         initial_values = initial_data.to_values(shared_calib=self._shared_calib)
         result_values, _, weights = self.__optimize_factor_graph(graph, initial_values, ordering_type)
         final_error = graph.error(result_values)
         optimized_data = GtsfmData.from_values(result_values, initial_data, self._shared_calib)
+        gnc_valid_mask = [True] * initial_data.number_tracks()
         if self._use_gnc and weights is not None and self._factor_weight_outlier_threshold > 0:
-            optimized_data = self.__filter_tracks_by_factor_weights(graph, optimized_data, weights)
-        return optimized_data, result_values, final_error
+            optimized_data, gnc_valid_mask = self.__filter_tracks_by_factor_weights(graph, optimized_data, weights)
+        return optimized_data, result_values, final_error, gnc_valid_mask
 
     def __filter_tracks_by_factor_weights(
         self, graph: NonlinearFactorGraph, optimized_data: GtsfmData, weights: NDArray[np.float64]
-    ) -> GtsfmData:
+    ) -> Tuple[GtsfmData, List[bool]]:
         """Filter tracks based on the weights of the reprojection factors, if GNC optimization is used."""
+        gnc_valid_mask = [True] * optimized_data.number_tracks()
         if weights is None:
             logger.error("Weights array is None, cannot filter tracks by factor weights.")
-            return optimized_data
+            return optimized_data, gnc_valid_mask
         cameras_to_model = sorted(optimized_data.get_valid_camera_indices())
         first_camera = optimized_data.get_camera(cameras_to_model[0])
         assert first_camera is not None, "First camera in optimized factor graph is None"
@@ -510,7 +512,7 @@ class BundleAdjustmentOptimizer:
                 cams_to_remove_per_track[track_id].add(camera_id)
 
         if not cams_to_remove_per_track:
-            return optimized_data
+            return optimized_data, gnc_valid_mask
 
         for track_id, camera_ids in cams_to_remove_per_track.items():
             track = optimized_data.get_track(track_id)
@@ -521,12 +523,16 @@ class BundleAdjustmentOptimizer:
                     new_measurements.append(track.measurement(m_idx))
             track.measurements = new_measurements
 
-        length_filtered_tracks = [
-            track for track in optimized_data.get_tracks() if track.numberMeasurements() >= self._min_track_length
-        ]
+        length_filtered_tracks = []
+        for track_idx, track in enumerate(optimized_data.get_tracks()):
+            if track.numberMeasurements() >= self._min_track_length:
+                length_filtered_tracks.append(track)
+            else:
+                gnc_valid_mask[track_idx] = False
+
         if len(length_filtered_tracks) == optimized_data.number_tracks():
             optimized_data._camera_to_measurement_map = None
-            return optimized_data
+            return optimized_data, gnc_valid_mask
 
         image_info = {
             image_id: optimized_data.get_image_info(image_id) for image_id in optimized_data.get_all_image_ids()
@@ -540,7 +546,7 @@ class BundleAdjustmentOptimizer:
             gaussian_splats=optimized_data.get_gaussian_splats(),
         )
 
-        return filtered_data
+        return filtered_data, gnc_valid_mask
 
     def run_simple_ba(
         self, initial_data: GtsfmData, robust_noise_basin: float | None = None
@@ -563,7 +569,7 @@ class BundleAdjustmentOptimizer:
         if len(cameras_without_tracks) == len(initial_data.cameras()):
             logger.warning("Skipping bundle adjustment because all cameras are without tracks.")
             return initial_data, 0.0
-        optimized_data, _, final_error = self.__optimize_and_recover(
+        optimized_data, _, final_error, _ = self.__optimize_and_recover(
             initial_data, graph, self._ordering_type if not cameras_without_tracks else "COLAMD"
         )
         return optimized_data, final_error
@@ -616,7 +622,7 @@ class BundleAdjustmentOptimizer:
         graph, cameras_without_tracks = self.__construct_factor_graph(
             cameras_to_model, initial_data, absolute_pose_priors, relative_pose_priors
         )
-        optimized_data, result_values, final_error = self.__optimize_and_recover(
+        optimized_data, result_values, final_error, gnc_valid_mask = self.__optimize_and_recover(
             initial_data, graph, self._ordering_type if not cameras_without_tracks else "COLAMD"
         )
 
@@ -640,13 +646,18 @@ class BundleAdjustmentOptimizer:
         if reproj_error_thresh is not None:
             if verbose:
                 logger.info("[Result] Number of tracks before filtering: %d", optimized_data.number_tracks())
-            filtered_result, valid_mask = optimized_data.filter_landmarks(reproj_error_thresh)
+            filtered_result, postfilter_valid_mask = optimized_data.filter_landmarks(reproj_error_thresh)
             if verbose:
                 logger.info("[Result] Number of tracks after filtering: %d", filtered_result.number_tracks())
 
         else:
-            valid_mask = [True] * optimized_data.number_tracks()
+            postfilter_valid_mask = [True] * optimized_data.number_tracks()
             filtered_result = optimized_data
+
+        valid_mask = [False] * initial_data.number_tracks()
+        kept_track_indices = [track_idx for track_idx, is_valid in enumerate(gnc_valid_mask) if is_valid]
+        for track_idx, is_valid in zip(kept_track_indices, postfilter_valid_mask):
+            valid_mask[track_idx] = is_valid
         return optimized_data, filtered_result, valid_mask, final_error
 
     def _run_ba_stages(

--- a/gtsfm/bundle/bundle_adjustment.py
+++ b/gtsfm/bundle/bundle_adjustment.py
@@ -601,11 +601,11 @@ class BundleAdjustmentOptimizer:
             cameras_with_insufficient_tracks,
         )
         graph = self.__construct_simple_factor_graph(cameras_to_model, initial_data, robust_noise_basin)
-        if len(cameras_without_tracks) == len(initial_data.cameras()):
+        if len(cameras_with_insufficient_tracks) == len(initial_data.cameras()):
             logger.warning("Skipping bundle adjustment because all cameras are without tracks.")
             return initial_data, 0.0
         optimized_data, result_values, final_error, _ = self.__optimize_and_recover(
-            initial_data, graph, self._ordering_type if not cameras_without_tracks else "COLAMD"
+            initial_data, graph, self._ordering_type if not cameras_with_insufficient_tracks else "COLAMD"
         )
         if self._compute_pose_covariances:
             try:

--- a/gtsfm/bundle/bundle_adjustment.py
+++ b/gtsfm/bundle/bundle_adjustment.py
@@ -829,7 +829,7 @@ class BundleAdjustmentOptimizer:
                 GtsfmMetricsGroup(METRICS_GROUP, []),
             )
         start_time = time.time()
-        optimized_data, filtered_result, valid_mask, step_times = self._run_ba_stages(
+        optimized_data, filtered_result, valid_mask, step_times = self.run_ba(
             initial_data=initial_data,
             absolute_pose_priors=absolute_pose_priors,
             relative_pose_priors=relative_pose_priors,

--- a/gtsfm/bundle/bundle_adjustment.py
+++ b/gtsfm/bundle/bundle_adjustment.py
@@ -649,6 +649,63 @@ class BundleAdjustmentOptimizer:
             filtered_result = optimized_data
         return optimized_data, filtered_result, valid_mask, final_error
 
+    def _run_ba_stages(
+        self,
+        initial_data: GtsfmData,
+        absolute_pose_priors: List[Optional[PosePrior]],
+        relative_pose_priors: Dict[Tuple[int, int], PosePrior],
+        verbose: bool = True,
+    ) -> Tuple[GtsfmData, GtsfmData, List[bool], List[float]]:
+        """Run all configured BA stages, feeding each stage with the previous filtered output."""
+        num_ba_steps = len(self._reproj_error_thresholds)
+        assert num_ba_steps > 0, "No BA steps to perform"
+
+        current_input = initial_data
+        active_track_indices = list(range(initial_data.number_tracks()))
+        cumulative_valid_mask = [True] * initial_data.number_tracks()
+        step_times: List[float] = []
+
+        for step, reproj_error_thresh in enumerate(self._reproj_error_thresholds):
+            step_start_time = time.time()
+            optimized_data, filtered_result, stage_valid_mask, final_error = self.run_ba_stage_with_filtering(
+                current_input,
+                absolute_pose_priors,
+                relative_pose_priors,
+                reproj_error_thresh,
+                verbose,
+            )
+            step_times.append(time.time() - step_start_time)
+
+            if optimized_data is None or filtered_result is None or stage_valid_mask is None:
+                return optimized_data, filtered_result, stage_valid_mask, step_times  # type: ignore
+
+            if len(stage_valid_mask) != len(active_track_indices):
+                raise ValueError(
+                    "Bundle adjustment stage returned a validity mask whose length does not match the input tracks."
+                )
+
+            next_active_track_indices = []
+            for original_track_idx, is_valid in zip(active_track_indices, stage_valid_mask):
+                cumulative_valid_mask[original_track_idx] = is_valid
+                if is_valid:
+                    next_active_track_indices.append(original_track_idx)
+            active_track_indices = next_active_track_indices
+            current_input = filtered_result
+
+            if num_ba_steps > 1:
+                logger.info(
+                    "[BA Stage @ thresh=%.2f px %d/%d] Error: %.2f, Number of tracks: %d"
+                    % (
+                        reproj_error_thresh if reproj_error_thresh is not None else float("nan"),
+                        step + 1,
+                        num_ba_steps,
+                        final_error,
+                        filtered_result.number_tracks(),
+                    )
+                )
+
+        return optimized_data, filtered_result, cumulative_valid_mask, step_times  # type: ignore
+
     def run_ba(
         self,
         initial_data: GtsfmData,
@@ -670,24 +727,13 @@ class BundleAdjustmentOptimizer:
             Valid mask as a list of booleans, indicating for each input track whether it was below the re-projection
                 threshold.
         """
-        num_ba_steps = len(self._reproj_error_thresholds)
-        for step, reproj_error_thresh in enumerate(self._reproj_error_thresholds):
-            # Use intermediate result as initial condition for next step.
-            (optimized_data, filtered_result, valid_mask, final_error) = self.run_ba_stage_with_filtering(
-                initial_data,
-                absolute_pose_priors,
-                relative_pose_priors,
-                reproj_error_thresh,
-                verbose,
-            )
-            # Print intermediate results.
-            if num_ba_steps > 1:
-                logger.info(
-                    "[BA Step %d/%d] Error: %.2f, Number of tracks: %d"
-                    % (step + 1, num_ba_steps, final_error, filtered_result.number_tracks())
-                )
-
-        return optimized_data, filtered_result, valid_mask  # type: ignore
+        optimized_data, filtered_result, valid_mask, _ = self._run_ba_stages(
+            initial_data=initial_data,
+            absolute_pose_priors=absolute_pose_priors,
+            relative_pose_priors=relative_pose_priors,
+            verbose=verbose,
+        )
+        return optimized_data, filtered_result, valid_mask
 
     def _run_ba_and_evaluate(
         self,
@@ -713,35 +759,13 @@ class BundleAdjustmentOptimizer:
                 [False] * initial_data.number_tracks(),
                 GtsfmMetricsGroup(METRICS_GROUP, []),
             )
-        step_times = []
         start_time = time.time()
-
-        num_ba_steps = len(self._reproj_error_thresholds)
-        assert num_ba_steps > 0, "No BA steps to perform"
-
-        for step, reproj_error_thresh in enumerate(self._reproj_error_thresholds):
-            step_start_time = time.time()
-            (optimized_data, filtered_result, valid_mask, final_error) = self.run_ba_stage_with_filtering(
-                initial_data=initial_data,
-                absolute_pose_priors=absolute_pose_priors,
-                relative_pose_priors=relative_pose_priors,
-                reproj_error_thresh=reproj_error_thresh,
-                verbose=verbose,
-            )
-            step_times.append(time.time() - step_start_time)
-
-            # Print intermediate results.
-            if num_ba_steps > 1:
-                logger.info(
-                    "[BA Stage @ thresh=%.2f px %d/%d] Error: %.2f, Number of tracks: %d"
-                    % (
-                        reproj_error_thresh if reproj_error_thresh is not None else float("nan"),
-                        step + 1,
-                        num_ba_steps,
-                        final_error,
-                        filtered_result.number_tracks(),
-                    )
-                )
+        optimized_data, filtered_result, valid_mask, step_times = self._run_ba_stages(
+            initial_data=initial_data,
+            absolute_pose_priors=absolute_pose_priors,
+            relative_pose_priors=relative_pose_priors,
+            verbose=verbose,
+        )
         total_time = time.time() - start_time
 
         metrics = self.evaluate(optimized_data, filtered_result, cameras_gt, save_dir)  # type: ignore
@@ -780,7 +804,10 @@ class BundleAdjustmentOptimizer:
         # Align the sparse multi-view estimate after BA to the ground truth pose graph.
         aligned_filtered_data = filtered_data.align_via_sim3_and_transform(poses_gt)
         ba_pose_error_metrics = metrics_utils.compute_ba_pose_metrics(
-            gt_wTi=poses_gt, computed_wTi=aligned_filtered_data.get_camera_poses(), save_dir=save_dir
+            gt_wTi=poses_gt,
+            computed_wTi=aligned_filtered_data.get_camera_poses(),
+            save_dir=save_dir,
+            metric_constructed_only=True,
         )
         ba_metrics.extend(metrics_group=ba_pose_error_metrics)
 

--- a/gtsfm/cluster_merging.py
+++ b/gtsfm/cluster_merging.py
@@ -316,6 +316,17 @@ class MergedNodeResult:
     pre_ba_metrics: GtsfmMetricsGroup
 
 
+@dataclass(frozen=True)
+class MergedNodeSummary:
+    """Lightweight summary of a merged node safe to return to the client."""
+
+    merge_success: bool
+    num_images: int
+    num_tracks: int
+    metrics: GtsfmMetricsGroup
+    pre_ba_metrics: GtsfmMetricsGroup
+
+
 def _sanitize_component(value: str, fallback: str) -> str:
     sanitized = re.sub(r"[^A-Za-z0-9]+", "_", value).strip("_").lower()
     return sanitized or fallback
@@ -634,6 +645,34 @@ def schedule_exports(
     export_payload_tree = Tree.zip(handles_tree, merged_future_tree).map_with_children(_to_payload_with_future)
 
     return submit_tree_map(client, export_payload_tree, _run_export_task, pure=False)
+
+
+def _summarize_merged_result(result: MergedNodeResult) -> MergedNodeSummary:
+    """Project a merged result down to the small client-facing payload."""
+    scene = result.scene
+    if scene is None:
+        return MergedNodeSummary(
+            merge_success=False,
+            num_images=0,
+            num_tracks=0,
+            metrics=result.metrics,
+            pre_ba_metrics=result.pre_ba_metrics,
+        )
+
+    return MergedNodeSummary(
+        merge_success=True,
+        num_images=scene.number_images(),
+        num_tracks=scene.number_tracks(),
+        metrics=result.metrics,
+        pre_ba_metrics=result.pre_ba_metrics,
+    )
+
+
+def schedule_summaries(client: Client, merged_future_tree: Tree[Future]) -> Tree[Future]:
+    """Schedule extraction of lightweight merge summaries for client-side reporting."""
+    return merged_future_tree.map(
+        lambda merged_future: client.submit(_summarize_merged_result, merged_future, pure=False)
+    )
 
 
 def _drop_outlier_tracks(scene: GtsfmData) -> GtsfmData:
@@ -956,8 +995,10 @@ def combine_results(
 __all__ = [
     "MergingOptions",
     "MergedNodeResult",
+    "MergedNodeSummary",
     "combine_results",
     "schedule_exports",
+    "schedule_summaries",
     "compute_merging_metrics",
     "annotate_scene_with_metadata",
 ]

--- a/gtsfm/configs/megaloc_sift_gp_metis.yaml
+++ b/gtsfm/configs/megaloc_sift_gp_metis.yaml
@@ -44,7 +44,9 @@ cluster_optimizer:
       eval_threshold_px: 4
       ba_reproj_error_thresholds: [0.5]
       bundle_adjust_2view_maxiters: 100
-      
+      ba_focal_length_prior_sigma: 20.0
+      ba_dist_prior_sigma: 0.1
+
       verifier:
         _target_: gtsfm.frontend.verifier.poselib_verifier.PoseLibVerifier
         estimation_threshold_px: 2

--- a/gtsfm/configs/megaloc_sift_gp_metis.yaml
+++ b/gtsfm/configs/megaloc_sift_gp_metis.yaml
@@ -1,0 +1,143 @@
+# Updated front-end configuration.
+
+# @package _global_
+_target_: gtsfm.scene_optimizer.SceneOptimizer
+loader:
+  _target_: gtsfm.loader.Olsson
+image_pairs_generator:
+  _target_: gtsfm.retriever.image_pairs_generator.ImagePairsGenerator
+  global_descriptor:
+    _target_: gtsfm.frontend.cacher.global_descriptor_cacher.GlobalDescriptorCacher
+    global_descriptor_obj:
+      _target_: gtsfm.frontend.global_descriptor.MegaLoc
+  retriever:
+    _target_: gtsfm.retriever.Similarity
+    num_matched: 100
+    min_score: 0.15
+  batch_size: 16
+
+graph_partitioner:
+  _target_: gtsfm.graph_partitioner.Metis
+
+cluster_optimizer:
+  _target_: gtsfm.cluster_optimizer.Multiview
+  correspondence_generator:
+    _target_: gtsfm.frontend.correspondence_generator.det_desc_correspondence_generator.DetDescCorrespondenceGenerator
+    
+    detector_descriptor:
+      _target_: gtsfm.frontend.cacher.detector_descriptor_cacher.DetectorDescriptorCacher
+      detector_descriptor_obj:
+        _target_: gtsfm.frontend.detector_descriptor.colmap_sift.ColmapSIFTDetectorDescriptor
+        max_keypoints: 8192
+    
+    matcher:
+      _target_: gtsfm.frontend.cacher.matcher_cacher.MatcherCacher
+      matcher_obj:
+        _target_: gtsfm.frontend.matcher.twoway_matcher.TwoWayMatcher
+        ratio_test_threshold: 0.8
+  
+  two_view_estimator:
+    _target_: gtsfm.two_view_estimator_cacher.TwoViewEstimatorCacher
+    two_view_estimator_obj:
+      _target_: gtsfm.two_view_estimator.TwoViewEstimator
+      bundle_adjust_2view: True
+      eval_threshold_px: 4
+      ba_reproj_error_thresholds: [0.5]
+      bundle_adjust_2view_maxiters: 100
+      
+      verifier:
+        _target_: gtsfm.frontend.verifier.poselib_verifier.PoseLibVerifier
+        estimation_threshold_px: 2
+
+      triangulation_options:
+        _target_: gtsfm.data_association.point3d_initializer.TriangulationOptions
+        mode:
+          _target_: gtsfm.data_association.point3d_initializer.TriangulationSamplingMode
+          value: NO_RANSAC
+      
+      inlier_support_processor:
+        _target_: gtsfm.two_view_estimator.InlierSupportProcessor
+        min_num_inliers_est_model: 30
+        min_inlier_ratio_est_model: 0.15
+
+  save_gtsfm_data: True
+  save_3d_viz: False
+  save_two_view_viz: False
+  pose_angular_error_thresh: 5
+  multiview_optimizer:
+    _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer
+    run_view_graph_calibration: true
+    
+    view_graph_estimator:
+      _target_: gtsfm.view_graph_estimator.cycle_consistent_rotation_estimator.CycleConsistentRotationViewGraphEstimator
+      edge_error_aggregation_criterion: MIN_EDGE_ERROR
+    
+    rot_avg_module:
+      _target_: gtsfm.averaging.rotation.shonan.ShonanRotationAveraging
+      weight_by_inliers: True
+    
+    trans_avg_module:
+      _target_: gtsfm.averaging.translation.averaging_1dsfm.TranslationAveraging1DSFM
+      robust_measurement_noise: True
+      projection_sampling_method: SAMPLE_INPUT_MEASUREMENTS
+      reject_outliers: False
+      use_all_tracks_for_averaging: True
+      use_relative_camera_poses: True
+    
+    data_association_module:
+      _target_: gtsfm.data_association.data_assoc.DataAssociation
+      min_track_len: 3
+      triangulation_options:
+        _target_: gtsfm.data_association.point3d_initializer.TriangulationOptions
+        reproj_error_threshold: 10
+        mode:
+          _target_: gtsfm.data_association.point3d_initializer.TriangulationSamplingMode
+          value: RANSAC_SAMPLE_UNIFORM
+        max_num_hypotheses: 100
+      save_track_patches_viz: False
+
+    global_positioner:
+      _target_: gtsfm.global_positioner.global_positioner.GlobalPositioner
+      noise_sigma: 0.01
+      huber_loss_scale: 0.1
+      max_iterations: 50
+      min_track_measurements: 3
+      max_reproj_error: 10.0
+      save_iteration_visualization: True
+    
+    bundle_adjustment_module:
+      _target_: gtsfm.bundle.bundle_adjustment.BundleAdjustmentOptimizer
+      # reproj_error_thresholds: [10, 5, 3] # for (multistage) post-optimization filtering
+      robust_ba_mode: "GMC"
+      shared_calib: false
+      cam_pose3_prior_noise_sigma: 0.1
+      calibration_prior_focal_sigma: 200.0
+      measurement_noise_sigma: 1.0
+      use_calibration_prior: false
+      use_gnc: true
+      gnc_loss: TLS
+      use_pose_prior_all_cameras: false
+      use_pose_prior_first_camera: false
+      factor_weight_outlier_threshold: 1e-8
+
+  dense_multiview_optimizer:
+    _target_: gtsfm.densify.mvs_patchmatchnet.MVSPatchmatchNet
+
+  gaussian_splatting_optimizer:
+    _target_: gtsfm.splat.gaussian_splatting.GaussianSplatting
+    cfg:
+      _target_: gtsfm.splat.gaussian_splatting.Config
+
+merging_options:
+  _target_: gtsfm.cluster_merging.MergingOptions
+  run_bundle_adjustment: true
+  metric_constructed_only: true
+  ba_options:
+    _target_: gtsfm.bundle.bundle_adjustment.BundleAdjustmentOptions
+    shared_calib: false
+    use_calibration_prior: false
+    use_gnc: true
+    gnc_loss: TLS
+    use_pose_prior_all_cameras: false
+    use_pose_prior_first_camera: false
+    factor_weight_outlier_threshold: 1e-8

--- a/gtsfm/configs/megaloc_sift_gp_single.yaml
+++ b/gtsfm/configs/megaloc_sift_gp_single.yaml
@@ -57,10 +57,9 @@ cluster_optimizer:
       
       inlier_support_processor:
         _target_: gtsfm.two_view_estimator.InlierSupportProcessor
-        # min_num_inliers_est_model: 15
-        # min_inlier_ratio_est_model: 0.1
         min_num_inliers_est_model: 30
         min_inlier_ratio_est_model: 0.15
+
   save_gtsfm_data: True
   save_3d_viz: False
   save_two_view_viz: False

--- a/gtsfm/configs/megaloc_sift_gp_single.yaml
+++ b/gtsfm/configs/megaloc_sift_gp_single.yaml
@@ -44,7 +44,9 @@ cluster_optimizer:
       eval_threshold_px: 4
       ba_reproj_error_thresholds: [0.5]
       bundle_adjust_2view_maxiters: 100
-      
+      ba_focal_length_prior_sigma: 20.0
+      ba_dist_prior_sigma: 0.1
+
       verifier:
         _target_: gtsfm.frontend.verifier.poselib_verifier.PoseLibVerifier
         estimation_threshold_px: 2

--- a/gtsfm/configs/megaloc_sift_gp_single.yaml
+++ b/gtsfm/configs/megaloc_sift_gp_single.yaml
@@ -1,0 +1,130 @@
+# Updated front-end configuration.
+
+# @package _global_
+_target_: gtsfm.scene_optimizer.SceneOptimizer
+loader:
+  _target_: gtsfm.loader.Olsson
+image_pairs_generator:
+  _target_: gtsfm.retriever.image_pairs_generator.ImagePairsGenerator
+  global_descriptor:
+    _target_: gtsfm.frontend.cacher.global_descriptor_cacher.GlobalDescriptorCacher
+    global_descriptor_obj:
+      _target_: gtsfm.frontend.global_descriptor.MegaLoc
+  retriever:
+    _target_: gtsfm.retriever.Similarity
+    num_matched: 100
+    min_score: 0.15
+  batch_size: 16
+
+graph_partitioner:
+  _target_: gtsfm.graph_partitioner.Single
+
+cluster_optimizer:
+  _target_: gtsfm.cluster_optimizer.Multiview
+  correspondence_generator:
+    _target_: gtsfm.frontend.correspondence_generator.det_desc_correspondence_generator.DetDescCorrespondenceGenerator
+    
+    detector_descriptor:
+      _target_: gtsfm.frontend.cacher.detector_descriptor_cacher.DetectorDescriptorCacher
+      detector_descriptor_obj:
+        _target_: gtsfm.frontend.detector_descriptor.colmap_sift.ColmapSIFTDetectorDescriptor
+        max_keypoints: 8192
+    
+    matcher:
+      _target_: gtsfm.frontend.cacher.matcher_cacher.MatcherCacher
+      matcher_obj:
+        _target_: gtsfm.frontend.matcher.twoway_matcher.TwoWayMatcher
+        ratio_test_threshold: 0.8
+  
+  two_view_estimator:
+    _target_: gtsfm.two_view_estimator_cacher.TwoViewEstimatorCacher
+    two_view_estimator_obj:
+      _target_: gtsfm.two_view_estimator.TwoViewEstimator
+      bundle_adjust_2view: True
+      eval_threshold_px: 4
+      ba_reproj_error_thresholds: [0.5]
+      bundle_adjust_2view_maxiters: 100
+      
+      verifier:
+        _target_: gtsfm.frontend.verifier.poselib_verifier.PoseLibVerifier
+        estimation_threshold_px: 2
+      
+      triangulation_options:
+        _target_: gtsfm.data_association.point3d_initializer.TriangulationOptions
+        mode:
+          _target_: gtsfm.data_association.point3d_initializer.TriangulationSamplingMode
+          value: NO_RANSAC
+      
+      inlier_support_processor:
+        _target_: gtsfm.two_view_estimator.InlierSupportProcessor
+        # min_num_inliers_est_model: 15
+        # min_inlier_ratio_est_model: 0.1
+        min_num_inliers_est_model: 30
+        min_inlier_ratio_est_model: 0.15
+  save_gtsfm_data: True
+  save_3d_viz: False
+  save_two_view_viz: False
+  pose_angular_error_thresh: 5
+  multiview_optimizer:
+    _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer
+    run_view_graph_calibration: true
+    
+    view_graph_estimator:
+      _target_: gtsfm.view_graph_estimator.cycle_consistent_rotation_estimator.CycleConsistentRotationViewGraphEstimator
+      edge_error_aggregation_criterion: MIN_EDGE_ERROR
+      
+    rot_avg_module:
+      _target_: gtsfm.averaging.rotation.shonan.ShonanRotationAveraging
+      weight_by_inliers: True
+    
+    trans_avg_module:
+      _target_: gtsfm.averaging.translation.averaging_1dsfm.TranslationAveraging1DSFM
+      robust_measurement_noise: True
+      projection_sampling_method: SAMPLE_INPUT_MEASUREMENTS
+      reject_outliers: False
+      use_all_tracks_for_averaging: True
+      use_relative_camera_poses: True
+    
+    data_association_module:
+      _target_: gtsfm.data_association.data_assoc.DataAssociation
+      min_track_len: 3
+      triangulation_options:
+        _target_: gtsfm.data_association.point3d_initializer.TriangulationOptions
+        reproj_error_threshold: 10
+        mode:
+          _target_: gtsfm.data_association.point3d_initializer.TriangulationSamplingMode
+          value: RANSAC_SAMPLE_UNIFORM
+        max_num_hypotheses: 100
+      save_track_patches_viz: False
+
+    global_positioner:
+      _target_: gtsfm.global_positioner.global_positioner.GlobalPositioner
+      noise_sigma: 0.01
+      huber_loss_scale: 0.1
+      max_iterations: 50
+      min_track_measurements: 3
+      max_reproj_error: 10.0
+      save_iteration_visualization: True
+      
+    bundle_adjustment_module:
+      _target_: gtsfm.bundle.bundle_adjustment.BundleAdjustmentOptimizer
+      # reproj_error_thresholds: [10, 5, 3] # for (multistage) post-optimization filtering
+      robust_ba_mode: "GMC"
+      shared_calib: false
+      cam_pose3_prior_noise_sigma: 0.1
+      calibration_prior_focal_sigma: 200.0
+      measurement_noise_sigma: 1.0
+      use_calibration_prior: false
+      use_gnc: true
+      gnc_loss: TLS
+      use_pose_prior_all_cameras: false
+      use_pose_prior_first_camera: false
+      factor_weight_outlier_threshold: 1e-8
+
+  dense_multiview_optimizer:
+    _target_: gtsfm.densify.mvs_patchmatchnet.MVSPatchmatchNet
+
+  gaussian_splatting_optimizer:
+    _target_: gtsfm.splat.gaussian_splatting.GaussianSplatting
+    cfg:
+      _target_: gtsfm.splat.gaussian_splatting.Config

--- a/gtsfm/configs/megaloc_sift_metis.yaml
+++ b/gtsfm/configs/megaloc_sift_metis.yaml
@@ -44,7 +44,9 @@ cluster_optimizer:
       eval_threshold_px: 4
       ba_reproj_error_thresholds: [0.5]
       bundle_adjust_2view_maxiters: 100
-      
+      ba_focal_length_prior_sigma: 20.0
+      ba_dist_prior_sigma: 0.1
+
       verifier:
         _target_: gtsfm.frontend.verifier.poselib_verifier.PoseLibVerifier
         estimation_threshold_px: 2

--- a/gtsfm/configs/megaloc_sift_metis.yaml
+++ b/gtsfm/configs/megaloc_sift_metis.yaml
@@ -1,0 +1,134 @@
+# Updated front-end configuration.
+
+# @package _global_
+_target_: gtsfm.scene_optimizer.SceneOptimizer
+loader:
+  _target_: gtsfm.loader.Olsson
+image_pairs_generator:
+  _target_: gtsfm.retriever.image_pairs_generator.ImagePairsGenerator
+  global_descriptor:
+    _target_: gtsfm.frontend.cacher.global_descriptor_cacher.GlobalDescriptorCacher
+    global_descriptor_obj:
+      _target_: gtsfm.frontend.global_descriptor.MegaLoc
+  retriever:
+    _target_: gtsfm.retriever.Similarity
+    num_matched: 100
+    min_score: 0.15
+  batch_size: 16
+
+graph_partitioner:
+  _target_: gtsfm.graph_partitioner.Metis
+
+cluster_optimizer:
+  _target_: gtsfm.cluster_optimizer.Multiview
+  correspondence_generator:
+    _target_: gtsfm.frontend.correspondence_generator.det_desc_correspondence_generator.DetDescCorrespondenceGenerator
+    
+    detector_descriptor:
+      _target_: gtsfm.frontend.cacher.detector_descriptor_cacher.DetectorDescriptorCacher
+      detector_descriptor_obj:
+        _target_: gtsfm.frontend.detector_descriptor.colmap_sift.ColmapSIFTDetectorDescriptor
+        max_keypoints: 8192
+    
+    matcher:
+      _target_: gtsfm.frontend.cacher.matcher_cacher.MatcherCacher
+      matcher_obj:
+        _target_: gtsfm.frontend.matcher.twoway_matcher.TwoWayMatcher
+        ratio_test_threshold: 0.8
+  
+  two_view_estimator:
+    _target_: gtsfm.two_view_estimator_cacher.TwoViewEstimatorCacher
+    two_view_estimator_obj:
+      _target_: gtsfm.two_view_estimator.TwoViewEstimator
+      bundle_adjust_2view: True
+      eval_threshold_px: 4
+      ba_reproj_error_thresholds: [0.5]
+      bundle_adjust_2view_maxiters: 100
+      
+      verifier:
+        _target_: gtsfm.frontend.verifier.poselib_verifier.PoseLibVerifier
+        estimation_threshold_px: 2
+
+      triangulation_options:
+        _target_: gtsfm.data_association.point3d_initializer.TriangulationOptions
+        mode:
+          _target_: gtsfm.data_association.point3d_initializer.TriangulationSamplingMode
+          value: NO_RANSAC
+      
+      inlier_support_processor:
+        _target_: gtsfm.two_view_estimator.InlierSupportProcessor
+        min_num_inliers_est_model: 30
+        min_inlier_ratio_est_model: 0.15
+
+  save_gtsfm_data: True
+  save_3d_viz: False
+  save_two_view_viz: False
+  pose_angular_error_thresh: 5
+  multiview_optimizer:
+    _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer
+    run_view_graph_calibration: true
+    
+    view_graph_estimator:
+      _target_: gtsfm.view_graph_estimator.cycle_consistent_rotation_estimator.CycleConsistentRotationViewGraphEstimator
+      edge_error_aggregation_criterion: MIN_EDGE_ERROR
+    
+    rot_avg_module:
+      _target_: gtsfm.averaging.rotation.shonan.ShonanRotationAveraging
+      weight_by_inliers: True
+    
+    trans_avg_module:
+      _target_: gtsfm.averaging.translation.averaging_1dsfm.TranslationAveraging1DSFM
+      robust_measurement_noise: True
+      projection_sampling_method: SAMPLE_INPUT_MEASUREMENTS
+      reject_outliers: False
+      use_all_tracks_for_averaging: True
+      use_relative_camera_poses: True
+    
+    data_association_module:
+      _target_: gtsfm.data_association.data_assoc.DataAssociation
+      min_track_len: 3
+      triangulation_options:
+        _target_: gtsfm.data_association.point3d_initializer.TriangulationOptions
+        reproj_error_threshold: 10
+        mode:
+          _target_: gtsfm.data_association.point3d_initializer.TriangulationSamplingMode
+          value: RANSAC_SAMPLE_UNIFORM
+        max_num_hypotheses: 100
+      save_track_patches_viz: False
+    
+    bundle_adjustment_module:
+      _target_: gtsfm.bundle.bundle_adjustment.BundleAdjustmentOptimizer
+      # reproj_error_thresholds: [10, 5, 3] # for (multistage) post-optimization filtering
+      robust_ba_mode: "GMC"
+      shared_calib: false
+      cam_pose3_prior_noise_sigma: 0.1
+      calibration_prior_focal_sigma: 200.0
+      measurement_noise_sigma: 1.0
+      use_calibration_prior: false
+      use_gnc: true
+      gnc_loss: TLS
+      use_pose_prior_all_cameras: false
+      use_pose_prior_first_camera: false
+      factor_weight_outlier_threshold: 1e-8
+
+  dense_multiview_optimizer:
+    _target_: gtsfm.densify.mvs_patchmatchnet.MVSPatchmatchNet
+
+  gaussian_splatting_optimizer:
+    _target_: gtsfm.splat.gaussian_splatting.GaussianSplatting
+    cfg:
+      _target_: gtsfm.splat.gaussian_splatting.Config
+
+merging_options:
+  _target_: gtsfm.cluster_merging.MergingOptions
+  run_bundle_adjustment: true
+  metric_constructed_only: true
+  ba_options:
+    _target_: gtsfm.bundle.bundle_adjustment.BundleAdjustmentOptions
+    shared_calib: false
+    use_calibration_prior: false
+    use_gnc: true
+    gnc_loss: TLS
+    use_pose_prior_all_cameras: false
+    use_pose_prior_first_camera: false
+    factor_weight_outlier_threshold: 1e-8

--- a/gtsfm/configs/megaloc_sift_single.yaml
+++ b/gtsfm/configs/megaloc_sift_single.yaml
@@ -57,10 +57,9 @@ cluster_optimizer:
       
       inlier_support_processor:
         _target_: gtsfm.two_view_estimator.InlierSupportProcessor
-        # min_num_inliers_est_model: 15
-        # min_inlier_ratio_est_model: 0.1
         min_num_inliers_est_model: 30
         min_inlier_ratio_est_model: 0.15
+
   save_gtsfm_data: True
   save_3d_viz: False
   save_two_view_viz: False

--- a/gtsfm/configs/megaloc_sift_single.yaml
+++ b/gtsfm/configs/megaloc_sift_single.yaml
@@ -1,0 +1,121 @@
+# Updated front-end configuration.
+
+# @package _global_
+_target_: gtsfm.scene_optimizer.SceneOptimizer
+loader:
+  _target_: gtsfm.loader.Olsson
+image_pairs_generator:
+  _target_: gtsfm.retriever.image_pairs_generator.ImagePairsGenerator
+  global_descriptor:
+    _target_: gtsfm.frontend.cacher.global_descriptor_cacher.GlobalDescriptorCacher
+    global_descriptor_obj:
+      _target_: gtsfm.frontend.global_descriptor.MegaLoc
+  retriever:
+    _target_: gtsfm.retriever.Similarity
+    num_matched: 100
+    min_score: 0.15
+  batch_size: 16
+
+graph_partitioner:
+  _target_: gtsfm.graph_partitioner.Single
+
+cluster_optimizer:
+  _target_: gtsfm.cluster_optimizer.Multiview
+  correspondence_generator:
+    _target_: gtsfm.frontend.correspondence_generator.det_desc_correspondence_generator.DetDescCorrespondenceGenerator
+    
+    detector_descriptor:
+      _target_: gtsfm.frontend.cacher.detector_descriptor_cacher.DetectorDescriptorCacher
+      detector_descriptor_obj:
+        _target_: gtsfm.frontend.detector_descriptor.colmap_sift.ColmapSIFTDetectorDescriptor
+        max_keypoints: 8192
+    
+    matcher:
+      _target_: gtsfm.frontend.cacher.matcher_cacher.MatcherCacher
+      matcher_obj:
+        _target_: gtsfm.frontend.matcher.twoway_matcher.TwoWayMatcher
+        ratio_test_threshold: 0.8
+  
+  two_view_estimator:
+    _target_: gtsfm.two_view_estimator_cacher.TwoViewEstimatorCacher
+    two_view_estimator_obj:
+      _target_: gtsfm.two_view_estimator.TwoViewEstimator
+      bundle_adjust_2view: True
+      eval_threshold_px: 4
+      ba_reproj_error_thresholds: [0.5]
+      bundle_adjust_2view_maxiters: 100
+      
+      verifier:
+        _target_: gtsfm.frontend.verifier.poselib_verifier.PoseLibVerifier
+        estimation_threshold_px: 2
+      
+      triangulation_options:
+        _target_: gtsfm.data_association.point3d_initializer.TriangulationOptions
+        mode:
+          _target_: gtsfm.data_association.point3d_initializer.TriangulationSamplingMode
+          value: NO_RANSAC
+      
+      inlier_support_processor:
+        _target_: gtsfm.two_view_estimator.InlierSupportProcessor
+        # min_num_inliers_est_model: 15
+        # min_inlier_ratio_est_model: 0.1
+        min_num_inliers_est_model: 30
+        min_inlier_ratio_est_model: 0.15
+  save_gtsfm_data: True
+  save_3d_viz: False
+  save_two_view_viz: False
+  pose_angular_error_thresh: 5
+  multiview_optimizer:
+    _target_: gtsfm.multi_view_optimizer.MultiViewOptimizer
+    run_view_graph_calibration: true
+    
+    view_graph_estimator:
+      _target_: gtsfm.view_graph_estimator.cycle_consistent_rotation_estimator.CycleConsistentRotationViewGraphEstimator
+      edge_error_aggregation_criterion: MIN_EDGE_ERROR
+      
+    rot_avg_module:
+      _target_: gtsfm.averaging.rotation.shonan.ShonanRotationAveraging
+      weight_by_inliers: True
+    
+    trans_avg_module:
+      _target_: gtsfm.averaging.translation.averaging_1dsfm.TranslationAveraging1DSFM
+      robust_measurement_noise: True
+      projection_sampling_method: SAMPLE_INPUT_MEASUREMENTS
+      reject_outliers: False
+      use_all_tracks_for_averaging: True
+      use_relative_camera_poses: True
+    
+    data_association_module:
+      _target_: gtsfm.data_association.data_assoc.DataAssociation
+      min_track_len: 3
+      triangulation_options:
+        _target_: gtsfm.data_association.point3d_initializer.TriangulationOptions
+        reproj_error_threshold: 10
+        mode:
+          _target_: gtsfm.data_association.point3d_initializer.TriangulationSamplingMode
+          value: RANSAC_SAMPLE_UNIFORM
+        max_num_hypotheses: 100
+      save_track_patches_viz: False
+      
+    bundle_adjustment_module:
+      _target_: gtsfm.bundle.bundle_adjustment.BundleAdjustmentOptimizer
+      # reproj_error_thresholds: [10, 5, 3] # for (multistage) post-optimization filtering
+      robust_ba_mode: "GMC"
+      shared_calib: false
+      cam_pose3_prior_noise_sigma: 0.1
+      calibration_prior_focal_sigma: 200.0
+      measurement_noise_sigma: 1.0
+      use_calibration_prior: false
+      use_gnc: true
+      gnc_loss: TLS
+      use_pose_prior_all_cameras: false
+      use_pose_prior_first_camera: false
+      factor_weight_outlier_threshold: 1e-8
+
+  dense_multiview_optimizer:
+    _target_: gtsfm.densify.mvs_patchmatchnet.MVSPatchmatchNet
+
+  gaussian_splatting_optimizer:
+    _target_: gtsfm.splat.gaussian_splatting.GaussianSplatting
+    cfg:
+      _target_: gtsfm.splat.gaussian_splatting.Config

--- a/gtsfm/configs/megaloc_sift_single.yaml
+++ b/gtsfm/configs/megaloc_sift_single.yaml
@@ -44,7 +44,9 @@ cluster_optimizer:
       eval_threshold_px: 4
       ba_reproj_error_thresholds: [0.5]
       bundle_adjust_2view_maxiters: 100
-      
+      ba_focal_length_prior_sigma: 20.0
+      ba_dist_prior_sigma: 0.1
+
       verifier:
         _target_: gtsfm.frontend.verifier.poselib_verifier.PoseLibVerifier
         estimation_threshold_px: 2

--- a/gtsfm/frontend/verifier/poselib_verifier.py
+++ b/gtsfm/frontend/verifier/poselib_verifier.py
@@ -1,0 +1,142 @@
+"""PoseLib-based verifier using 5-point E-matrix with LO-RANSAC and local BA.
+
+PoseLib's estimate_relative_pose provides:
+- 5-point essential matrix solver (more constrained than 8-point F-matrix)
+- Locally Optimized RANSAC (refines hypotheses on inlier sets)
+- Local bundle adjustment within RANSAC loop
+- Integrated pose estimation (no separate F→E→pose decomposition chain)
+
+Inlier re-scoring is done separately in the multi-view optimizer (GLOMAP style).
+
+Reference: PoseLib (https://github.com/PoseLib/PoseLib)
+"""
+
+from typing import Optional, Tuple
+
+import numpy as np
+import poselib
+from gtsam import Cal3_S2, Cal3Bundler, Cal3DS2, Cal3Fisheye, Rot3, Unit3
+
+import gtsfm.utils.logger as logger_utils
+from gtsfm.common.keypoints import Keypoints
+from gtsfm.common.types import CALIBRATION_TYPE
+from gtsfm.frontend.verifier.verifier_base import VerifierBase
+
+logger = logger_utils.get_logger()
+
+
+class PoseLibVerifier(VerifierBase):
+    """Verifier using PoseLib's estimate_relative_pose with 5-point solver + LO-RANSAC + local BA.
+
+    Returns PoseLib's raw inliers.
+    """
+
+    def __init__(
+        self,
+        estimation_threshold_px: float = 2.0,
+        max_iterations: int = 100000,
+        confidence: float = 0.999999,
+    ) -> None:
+        super().__init__(use_intrinsics_in_verification=True, estimation_threshold_px=estimation_threshold_px)
+        self._max_iterations = max_iterations
+        self._confidence = confidence
+
+    def _cal3bundler_to_poselib_camera(self, K: CALIBRATION_TYPE, width: int, height: int) -> poselib.Camera:
+        """Convert GTSAM calibration to PoseLib Camera."""
+        if isinstance(K, Cal3Bundler):
+            fx = K.fx()
+            k1 = K.k1()
+            k2 = K.k2()
+            cx = K.px()
+            cy = K.py()
+            if abs(k1) < 1e-10 and abs(k2) < 1e-10:
+                return poselib.Camera("PINHOLE", [fx, fx, cx, cy], width, height)
+            if abs(k2) < 1e-10:
+                return poselib.Camera("SIMPLE_RADIAL", [fx, cx, cy, k1], width, height)
+            return poselib.Camera("RADIAL", [fx, cx, cy, k1, k2], width, height)
+
+        if isinstance(K, Cal3_S2):
+            return poselib.Camera("PINHOLE", [K.fx(), K.fy(), K.px(), K.py()], width, height)
+
+        if isinstance(K, Cal3DS2):
+            return poselib.Camera(
+                "OPENCV",
+                [K.fx(), K.fy(), K.px(), K.py(), K.k1(), K.k2(), K.p1(), K.p2()],
+                width,
+                height,
+            )
+
+        if isinstance(K, Cal3Fisheye):
+            return poselib.Camera(
+                "OPENCV_FISHEYE",
+                [K.fx(), K.fy(), K.px(), K.py(), K.k1(), K.k2(), K.k3(), K.k4()],
+                width,
+                height,
+            )
+
+        raise ValueError(f"Unsupported GTSAM calibration type for PoseLib: {type(K)}")
+
+    def verify(
+        self,
+        keypoints_i1: Keypoints,
+        keypoints_i2: Keypoints,
+        match_indices: np.ndarray,
+        camera_intrinsics_i1: CALIBRATION_TYPE,
+        camera_intrinsics_i2: CALIBRATION_TYPE,
+    ) -> Tuple[Optional[Rot3], Optional[Unit3], np.ndarray, float]:
+        """Estimate relative pose using PoseLib's 5-point solver with LO-RANSAC."""
+        if match_indices.shape[0] < self._min_matches:
+            return self._failure_result
+
+        pts1 = keypoints_i1.coordinates[match_indices[:, 0]]
+        pts2 = keypoints_i2.coordinates[match_indices[:, 1]]
+
+        K1 = camera_intrinsics_i1.K()
+        K2 = camera_intrinsics_i2.K()
+        w1 = int(2 * K1[0, 2])
+        h1 = int(2 * K1[1, 2])
+        w2 = int(2 * K2[0, 2])
+        h2 = int(2 * K2[1, 2])
+
+        cam1 = self._cal3bundler_to_poselib_camera(camera_intrinsics_i1, w1, h1)
+        cam2 = self._cal3bundler_to_poselib_camera(camera_intrinsics_i2, w2, h2)
+
+        ransac_opt = {
+            "max_reproj_error": self._estimation_threshold_px,
+            "max_iterations": self._max_iterations,
+            "min_iterations": 100,
+            "success_prob": self._confidence,
+        }
+        bundle_opt = {"max_iterations": 25}
+
+        try:
+            pose, info = poselib.estimate_relative_pose(
+                pts1,
+                pts2,
+                cam1,
+                cam2,
+                ransac_opt=ransac_opt,
+                bundle_opt=bundle_opt,
+            )
+        except Exception as e:
+            logger.debug("PoseLib estimate_relative_pose failed: %s", e)
+            return self._failure_result
+
+        inlier_mask = np.array(info.get("inliers", []), dtype=bool)
+        if len(inlier_mask) == 0 or inlier_mask.sum() < self._min_matches:
+            return self._failure_result
+
+        R = np.array(pose.R)
+        t = np.array(pose.t)
+
+        if np.linalg.norm(t) < 1e-12:
+            return self._failure_result
+
+        i2Ri1 = Rot3(R)
+        i2Ui1 = Unit3(t)
+
+        inlier_idxs = np.where(inlier_mask)[0]
+        v_corr_idxs = match_indices[inlier_idxs]
+        inlier_ratio = float(inlier_mask.sum()) / len(inlier_mask)
+
+        return i2Ri1, i2Ui1, v_corr_idxs, inlier_ratio

--- a/gtsfm/loader/colmap_loader.py
+++ b/gtsfm/loader/colmap_loader.py
@@ -7,9 +7,10 @@ import os
 from pathlib import Path
 from typing import List, Optional
 
+from gtsam import Cal3Bundler, Pose3  # type:ignore
+
 import gtsfm.utils.io as io_utils
 import gtsfm.utils.logger as logger_utils
-from gtsam import Cal3Bundler, Pose3  # type:ignore
 from gtsfm.common.image import Image
 from gtsfm.loader.loader_base import LoaderBase
 
@@ -165,8 +166,10 @@ class ColmapLoader(LoaderBase):
             raise IndexError(f"Image index {index} is invalid. Valid indices are in [0,{len(self) - 1}].")
 
         if not self._use_gt_intrinsics:
-            # get intrinsics from exif
-            intrinsics = io_utils.load_image(self._image_paths[index]).get_intrinsics_from_exif()
+            # get intrinsics from exif, falling back to default focal length heuristic if exif is unavailable
+            intrinsics = io_utils.load_image(self._image_paths[index]).get_intrinsics(
+                default_focal_length_factor=self._default_focal_length_factor or 1.2
+            )
         else:
             intrinsics = self._calibrations[index]
             if self._default_focal_length_factor is not None and intrinsics.fx() <= 0:

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -3,10 +3,13 @@
 Authors: Ayush Baid, John Lambert
 """
 
+import dataclasses
+import logging
 import os
 from pathlib import Path
 from typing import Dict, List, Mapping, Optional, Tuple
 
+import cv2
 import numpy as np
 from dask.delayed import Delayed, delayed
 from dask.distributed import Future
@@ -29,11 +32,15 @@ from gtsfm.global_positioner.global_positioner import GlobalPositioner
 from gtsfm.products.one_view_data import OneViewData
 from gtsfm.products.two_view_result import TwoViewResult
 from gtsfm.products.visibility_graph import AnnotatedGraph
+from gtsfm.utils import verification as verification_utils
 from gtsfm.view_graph_estimator.cycle_consistent_rotation_estimator import (
     CycleConsistentRotationViewGraphEstimator,
     EdgeErrorAggregationCriterion,
 )
+from gtsfm.view_graph_estimator.view_graph_calibration import calibrate_view_graph
 from gtsfm.view_graph_estimator.view_graph_estimator_base import ViewGraphEstimatorBase
+
+logger = logging.getLogger(__name__)
 
 
 class MultiViewOptimizer:
@@ -73,6 +80,7 @@ class MultiViewOptimizer:
         bundle_adjustment_module: GlobalBundleAdjustment,
         view_graph_estimator: Optional[ViewGraphEstimatorBase] = None,
         global_positioner: Optional[GlobalPositioner] = None,
+        run_view_graph_calibration: bool = False,
     ) -> None:
         self.view_graph_estimator = view_graph_estimator
         self.rot_avg_module = rot_avg_module
@@ -81,6 +89,7 @@ class MultiViewOptimizer:
         self.ba_optimizer = bundle_adjustment_module
         self.global_positioner = global_positioner
         self._run_view_graph_estimator: bool = self.view_graph_estimator is not None
+        self._run_view_graph_calibration = run_view_graph_calibration
 
         self.view_graph_estimator_v2 = CycleConsistentRotationViewGraphEstimator(
             edge_error_aggregation_criterion=EdgeErrorAggregationCriterion.MEDIAN_EDGE_ERROR
@@ -172,6 +181,30 @@ class MultiViewOptimizer:
             viewgraph_two_view_reports_graph = two_view_reports
             viewgraph_estimation_metrics = delayed(GtsfmMetricsGroup("view_graph_estimation_metrics", []))
 
+        # View graph calibration: refine focal lengths from F-matrices
+        if self._run_view_graph_calibration:
+            all_intrinsics, edges_to_remove = delayed(calibrate_view_graph, nout=2)(
+                viewgraph_v_corr_idxs_graph, keypoints_graph, all_intrinsics, num_images
+            )
+            # Remove edges with high calibration error
+            viewgraph_i2Ri1_graph, viewgraph_i2Ui1_graph, viewgraph_v_corr_idxs_graph = delayed(_filter_edges, nout=3)(
+                viewgraph_i2Ri1_graph, viewgraph_i2Ui1_graph, viewgraph_v_corr_idxs_graph, edges_to_remove
+            )
+            # Re-estimate relative poses with refined intrinsics
+            viewgraph_i2Ri1_graph, viewgraph_i2Ui1_graph = delayed(reestimate_relative_poses, nout=2)(
+                viewgraph_i2Ri1_graph,
+                viewgraph_i2Ui1_graph,
+                viewgraph_v_corr_idxs_graph,
+                keypoints_graph,
+                all_intrinsics,
+            )
+            viewgraph_two_view_reports_graph = delayed(_sync_two_view_reports_after_calibration)(
+                viewgraph_two_view_reports_graph,
+                viewgraph_i2Ri1_graph,
+                viewgraph_i2Ui1_graph,
+                viewgraph_v_corr_idxs_graph,
+            )
+
         # Prune the graph to a single connected component.
         gt_wTi = {k: val.pose_gt for k, val in one_view_data_dict.items()}
         gt_wTi_list = [gt_wTi[i] for i in sorted(list(gt_wTi.keys()))]
@@ -193,7 +226,10 @@ class MultiViewOptimizer:
         if self.global_positioner is not None:
             # Path B: Global positioner replaces trans_avg + data_assoc.
             ba_input_graph, gp_metrics = delayed(self.global_positioner.run, nout=2)(
-                num_images, delayed_wRi, tracks2d_graph, all_intrinsics,
+                num_images,
+                delayed_wRi,
+                tracks2d_graph,
+                all_intrinsics,
                 output_root=output_root,
             )
             ta_metrics = gp_metrics
@@ -251,6 +287,134 @@ class MultiViewOptimizer:
         ba_input_graph = delayed(GtsfmData.align_via_sim3_and_transform)(ba_input_graph, gt_wTi_dict)
 
         return ba_input_graph, ba_result_graph, viewgraph_two_view_reports_graph, multiview_optimizer_metrics_graph
+
+
+def _filter_edges(
+    i2Ri1_dict: Dict[Tuple[int, int], Rot3],
+    i2Ui1_dict: Dict[Tuple[int, int], Unit3],
+    v_corr_idxs_dict: AnnotatedGraph[np.ndarray],
+    edges_to_remove: set,
+) -> Tuple[Dict[Tuple[int, int], Rot3], Dict[Tuple[int, int], Unit3], AnnotatedGraph[np.ndarray]]:
+    """Remove edges flagged by view graph calibration."""
+    if not edges_to_remove:
+        return i2Ri1_dict, i2Ui1_dict, v_corr_idxs_dict
+    filtered_R = {k: v for k, v in i2Ri1_dict.items() if k not in edges_to_remove}
+    filtered_U = {k: v for k, v in i2Ui1_dict.items() if k not in edges_to_remove}
+    filtered_corr = {k: v for k, v in v_corr_idxs_dict.items() if k not in edges_to_remove}
+    logger.info("Edge filtering: removed %d edges, %d remain.", len(edges_to_remove), len(filtered_R))
+    return filtered_R, filtered_U, filtered_corr
+
+
+def _sync_two_view_reports_after_calibration(
+    two_view_reports: AnnotatedGraph[TwoViewEstimationReport],
+    i2Ri1_dict: Dict[Tuple[int, int], Rot3],
+    i2Ui1_dict: Dict[Tuple[int, int], Unit3],
+    v_corr_idxs_dict: AnnotatedGraph[np.ndarray],
+) -> AnnotatedGraph[TwoViewEstimationReport]:
+    """Keep view-graph reports consistent with the calibrated edge set and poses.
+
+    After view-graph calibration, edges may be removed and surviving edges may get
+    updated relative poses. The reports returned from the earlier view-graph estimator
+    should reflect that final state.
+    """
+    synced_reports: AnnotatedGraph[TwoViewEstimationReport] = {}
+
+    for edge, report in two_view_reports.items():
+        if report is None or edge not in i2Ri1_dict or edge not in i2Ui1_dict or edge not in v_corr_idxs_dict:
+            continue
+
+        v_corr_idxs = v_corr_idxs_dict[edge]
+        synced_reports[edge] = dataclasses.replace(
+            report,
+            v_corr_idxs=v_corr_idxs,
+            num_inliers_est_model=v_corr_idxs.shape[0],
+            i2Ri1=i2Ri1_dict[edge],
+            i2Ui1=i2Ui1_dict[edge],
+        )
+
+    return synced_reports
+
+
+def reestimate_relative_poses(
+    i2Ri1_dict: Dict[Tuple[int, int], Rot3],
+    i2Ui1_dict: Dict[Tuple[int, int], Unit3],
+    v_corr_idxs_dict: AnnotatedGraph[np.ndarray],
+    keypoints_list: List[Keypoints],
+    intrinsics: List[gtsfm_types.CALIBRATION_TYPE],
+) -> Tuple[Dict[Tuple[int, int], Rot3], Dict[Tuple[int, int], Unit3]]:
+    """Re-estimate relative poses using refined intrinsics.
+
+    After view graph calibration improves focal lengths, re-compute E-matrices
+    and decompose into relative rotation/translation using the updated intrinsics.
+
+    Args:
+        i2Ri1_dict: Current relative rotations.
+        i2Ui1_dict: Current relative translation directions.
+        v_corr_idxs_dict: Verified correspondence indices per image pair.
+        keypoints_list: Keypoints for all images.
+        intrinsics: Refined intrinsics from view graph calibration.
+
+    Returns:
+        Updated relative rotations and translation directions.
+    """
+
+    updated_i2Ri1 = {}
+    updated_i2Ui1 = {}
+    num_updated = 0
+    num_failed = 0
+
+    for i1, i2 in i2Ri1_dict:
+        if (i1, i2) not in v_corr_idxs_dict:
+            updated_i2Ri1[(i1, i2)] = i2Ri1_dict[(i1, i2)]
+            updated_i2Ui1[(i1, i2)] = i2Ui1_dict[(i1, i2)]
+            continue
+
+        v_corr_idxs = v_corr_idxs_dict[(i1, i2)]
+        if v_corr_idxs.shape[0] < 5:
+            updated_i2Ri1[(i1, i2)] = i2Ri1_dict[(i1, i2)]
+            updated_i2Ui1[(i1, i2)] = i2Ui1_dict[(i1, i2)]
+            continue
+
+        coords_i1 = keypoints_list[i1].coordinates[v_corr_idxs[:, 0]]
+        coords_i2 = keypoints_list[i2].coordinates[v_corr_idxs[:, 1]]
+
+        K1 = intrinsics[i1]
+        K2 = intrinsics[i2]
+
+        # Estimate F-matrix from verified correspondences.
+        F, mask = cv2.findFundamentalMat(coords_i1, coords_i2, method=cv2.FM_8POINT)
+        if F is None or F.shape != (3, 3):
+            updated_i2Ri1[(i1, i2)] = i2Ri1_dict[(i1, i2)]
+            updated_i2Ui1[(i1, i2)] = i2Ui1_dict[(i1, i2)]
+            num_failed += 1
+            continue
+
+        # Convert F → E using refined intrinsics, then decompose.
+        i2Ei1 = verification_utils.fundamental_to_essential_matrix(F, K1, K2)
+        i2Ri1_new, i2Ui1_new = verification_utils.recover_relative_pose_from_essential_matrix(
+            i2Ei1,
+            coords_i1,
+            coords_i2,
+            K1,
+            K2,
+        )
+
+        if i2Ri1_new is not None and i2Ui1_new is not None:
+            updated_i2Ri1[(i1, i2)] = i2Ri1_new
+            updated_i2Ui1[(i1, i2)] = i2Ui1_new
+            num_updated += 1
+        else:
+            updated_i2Ri1[(i1, i2)] = i2Ri1_dict[(i1, i2)]
+            updated_i2Ui1[(i1, i2)] = i2Ui1_dict[(i1, i2)]
+            num_failed += 1
+
+    logger.info(
+        "Re-estimated relative poses: %d updated, %d failed, %d total.",
+        num_updated,
+        num_failed,
+        len(i2Ri1_dict),
+    )
+    return updated_i2Ri1, updated_i2Ui1
 
 
 def init_cameras(

--- a/gtsfm/multi_view_optimizer.py
+++ b/gtsfm/multi_view_optimizer.py
@@ -37,7 +37,7 @@ from gtsfm.view_graph_estimator.cycle_consistent_rotation_estimator import (
     CycleConsistentRotationViewGraphEstimator,
     EdgeErrorAggregationCriterion,
 )
-from gtsfm.view_graph_estimator.view_graph_calibration import calibrate_view_graph
+from gtsfm.view_graph_estimator import view_graph_calibration
 from gtsfm.view_graph_estimator.view_graph_estimator_base import ViewGraphEstimatorBase
 
 logger = logging.getLogger(__name__)
@@ -183,7 +183,7 @@ class MultiViewOptimizer:
 
         # View graph calibration: refine focal lengths from F-matrices
         if self._run_view_graph_calibration:
-            all_intrinsics, edges_to_remove = delayed(calibrate_view_graph, nout=2)(
+            all_intrinsics, edges_to_remove = delayed(view_graph_calibration.calibrate_view_graph, nout=2)(
                 viewgraph_v_corr_idxs_graph, keypoints_graph, all_intrinsics, num_images
             )
             # Remove edges with high calibration error

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -241,7 +241,7 @@ class SceneOptimizer:
 
         logger.info("🔥 GTSFM: Scheduling cluster optimizations...")
         one_view_data_dict = self.loader.get_one_view_data_dict()
-        merged_scene: Optional[GtsfmData] = None
+        merged_scene: Optional[cluster_merging.MergedNodeSummary] = None
 
         with performance_report(filename="dask_reports/scene-optimizer.html"):
             if cluster_tree is None:
@@ -286,40 +286,40 @@ class SceneOptimizer:
 
                 merged_future_tree = submit_tree_map_with_children(client, reconstruction_tree, merge_fn)
                 export_tree = cluster_merging.schedule_exports(client, handles_tree, merged_future_tree)
-                root_merge_future: Optional[Future] = merged_future_tree.value
-                for handle_node, merged_node, export_node in zip(
+                summary_tree = cluster_merging.schedule_summaries(client, merged_future_tree)
+                root_merge_summary: Optional[cluster_merging.MergedNodeSummary] = None
+                for handle_node, summary_node, export_node in zip(
                     PreOrderIter(handles_tree),
-                    PreOrderIter(merged_future_tree),
+                    PreOrderIter(summary_tree),
                     PreOrderIter(export_tree),
                 ):
                     handle = handle_node.value
-                    merge_future = merged_node.value
+                    summary_future = summary_node.value
                     export_future = export_node.value
 
                     metrics_groups = list(handle.metrics.result())
                     handle.io_barrier.result()
                     export_future.result()
                     if handle.cluster_path == ():
-                        merged_result = merge_future.result()
+                        merged_summary = summary_future.result()
                         base_metrics_groups.extend(metrics_groups)
-                        base_metrics_groups.append(merged_result.metrics)
-                        base_metrics_groups.append(merged_result.pre_ba_metrics)
-                        root_merge_future = merge_future
+                        base_metrics_groups.append(merged_summary.metrics)
+                        base_metrics_groups.append(merged_summary.pre_ba_metrics)
+                        root_merge_summary = merged_summary
                     else:
-                        merged_result = merge_future.result()
-                        metrics_groups.append(merged_result.metrics)
-                        metrics_groups.append(merged_result.pre_ba_metrics)
+                        merged_summary = summary_future.result()
+                        metrics_groups.append(merged_summary.metrics)
+                        metrics_groups.append(merged_summary.pre_ba_metrics)
                         save_metrics_reports(metrics_groups, str(handle.output_paths.metrics))
-                if root_merge_future is not None:
+                if root_merge_summary is not None:
                     logger.info("🔥 GTSFM: Running cluster optimization and merging...")
-                    root_merge_result = root_merge_future.result()
-                    merged_scene = root_merge_result.scene
+                    merged_scene = root_merge_summary
 
-        if merged_scene is not None:
+        if merged_scene is not None and merged_scene.merge_success:
             logger.info(
                 "Merged scene contains %d images and %d tracks.",
-                merged_scene.number_images(),
-                merged_scene.number_tracks(),
+                merged_scene.num_images,
+                merged_scene.num_tracks,
             )
         else:
             logger.warning("Merging failed, no final merged scene found.")

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -58,6 +58,7 @@ class TwoViewEstimator(DaskDBModuleBase):
         ba_reproj_error_thresholds: List[Optional[float]] = [0.5],
         allow_indeterminate_linear_system: bool = False,
         postgres_params=None,
+        ba_focal_length_prior_sigma=1e-5,
     ) -> None:
         """Initializes the two-view estimator from verifier.
 
@@ -93,7 +94,7 @@ class TwoViewEstimator(DaskDBModuleBase):
             robust_noise_basin=1.345,
             use_karcher_mean_factor=False,
             use_pose_prior_first_camera=True,
-            calibration_prior_focal_sigma=20.0,
+            calibration_prior_focal_sigma=ba_focal_length_prior_sigma,
             calibration_prior_dist_sigma=0.1,
             cam_pose3_prior_noise_sigma=0.1,
             measurement_noise_sigma=1.0,
@@ -269,7 +270,7 @@ class TwoViewEstimator(DaskDBModuleBase):
         relative_pose_prior_for_ba = {(0, 1): i2Ti1_prior} if i2Ti1_prior is not None else {}
 
         # Optimize!
-        _, ba_output, valid_mask = self._ba_optimizer.run_ba(
+        _, ba_output, valid_mask, _ = self._ba_optimizer.run_ba(
             ba_input, absolute_pose_priors=[], relative_pose_priors=relative_pose_prior_for_ba, verbose=False
         )
         if ba_output is None:

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -20,8 +20,8 @@ import gtsfm.common.types as gtsfm_types
 import gtsfm.utils.geometry_comparisons as comp_utils
 import gtsfm.utils.logger as logger_utils
 import gtsfm.utils.metrics as metric_utils
-from gtsfm.bundle.two_view_ba import TwoViewBundleAdjustment
 from gtsfm.bundle.bundle_adjustment import RobustBAMode
+from gtsfm.bundle.two_view_ba import TwoViewBundleAdjustment
 from gtsfm.common.dask_db_module_base import DaskDBModuleBase
 from gtsfm.common.gtsfm_data import GtsfmData
 from gtsfm.common.keypoints import Keypoints
@@ -93,8 +93,8 @@ class TwoViewEstimator(DaskDBModuleBase):
             robust_noise_basin=1.345,
             use_karcher_mean_factor=False,
             use_pose_prior_first_camera=True,
-            calibration_prior_focal_sigma=1e-5,
-            calibration_prior_dist_sigma=1e-5,
+            calibration_prior_focal_sigma=20.0,
+            calibration_prior_dist_sigma=0.1,
             cam_pose3_prior_noise_sigma=0.1,
             measurement_noise_sigma=1.0,
         )

--- a/gtsfm/utils/align.py
+++ b/gtsfm/utils/align.py
@@ -3,7 +3,6 @@
 Authors: Ayush Baid, John Lambert
 """
 
-import copy
 from typing import Optional, Sequence
 
 import gtsam  # type: ignore
@@ -160,8 +159,8 @@ def sim3_from_Pose3s_exhaustive(aTi_list: list[Pose3], bTi_list: list[Pose3]) ->
 
     for i1 in range(n_to_align):
         for i2 in range(i1 + 1, n_to_align):
-            aTi_sample = copy.deepcopy([aTi_list[i1], aTi_list[i2]])
-            bTi_sample = copy.deepcopy([bTi_list[i1], bTi_list[i2]])
+            aTi_sample = [aTi_list[i1], aTi_list[i2]]
+            bTi_sample = [bTi_list[i1], bTi_list[i2]]
 
             aSb_candidate = sim3_from_Pose3s(aTi_sample, bTi_sample)
 
@@ -229,8 +228,8 @@ def sim3_from_Pose3s_robust(
     ).reshape(-1, 2)
 
     for i1, i2 in sample_pose_pairs:
-        aTi_sample = copy.deepcopy([aTi_list[i1], aTi_list[i2]])
-        bTi_sample = copy.deepcopy([bTi_list[i1], bTi_list[i2]])
+        aTi_sample = [aTi_list[i1], aTi_list[i2]]
+        bTi_sample = [bTi_list[i1], bTi_list[i2]]
 
         aSb_candidate = sim3_from_Pose3s(aTi_sample, bTi_sample)
 

--- a/gtsfm/utils/metrics.py
+++ b/gtsfm/utils/metrics.py
@@ -412,7 +412,7 @@ def compute_translation_angle_metric(
 def compute_pose_auc_metric(
     rotation_angular_errors: Union[Sequence[float], np.ndarray],
     translation_angular_errors: Union[Sequence[float], np.ndarray],
-    thresholds_deg: Sequence[float] = (1.0, 2.5, 5.0, 10.0, 20.0),
+    thresholds_deg: Sequence[float] = (1.0, 2.5, 3.0, 5.0, 10.0, 20.0),
     save_dir: Optional[str] = None,
     metric_name_prefix: str = "pose_auc",
 ) -> List[GtsfmMetric]:
@@ -562,21 +562,19 @@ def compute_intrinsics_metrics(
 
     metrics = [
         GtsfmMetric(
-            "focal_length_error_px", np.array(focal_abs_errors, dtype=np.float32),
+            "focal_length_error_px",
+            np.array(focal_abs_errors, dtype=np.float32),
             store_full_data=store_full_data,
         ),
         GtsfmMetric(
-            "focal_length_error_pct", np.array(focal_pct_errors, dtype=np.float32),
+            "focal_length_error_pct",
+            np.array(focal_pct_errors, dtype=np.float32),
             store_full_data=store_full_data,
         ),
     ]
     if len(k1_errors) > 0:
-        metrics.append(
-            GtsfmMetric("k1_error", np.array(k1_errors, dtype=np.float32), store_full_data=store_full_data)
-        )
-        metrics.append(
-            GtsfmMetric("k2_error", np.array(k2_errors, dtype=np.float32), store_full_data=store_full_data)
-        )
+        metrics.append(GtsfmMetric("k1_error", np.array(k1_errors, dtype=np.float32), store_full_data=store_full_data))
+        metrics.append(GtsfmMetric("k2_error", np.array(k2_errors, dtype=np.float32), store_full_data=store_full_data))
     return GtsfmMetricsGroup(name="intrinsics_metrics", metrics=metrics)
 
 

--- a/gtsfm/view_graph_estimator/view_graph_calibration.py
+++ b/gtsfm/view_graph_estimator/view_graph_calibration.py
@@ -1,0 +1,266 @@
+"""View graph calibration: estimate camera focal lengths from fundamental matrices.
+
+Joint optimization of all focal lengths using Fetzer et al. (WACV 2020) residuals.
+For each F-matrix edge, measures how close E = K2^T F K1 is to a valid essential matrix
+(valid E has singular values σ1 = σ2, σ3 = 0).
+
+Reference: Fetzer et al., "Stable Intrinsic Auto-Calibration from Fundamental Matrices
+of Devices with Uncorrelated Camera Parameters", WACV 2020.
+"""
+
+import logging
+from typing import Dict, List, Optional, Tuple
+
+import cv2
+import numpy as np
+from gtsam import Cal3Bundler
+from scipy.optimize import least_squares
+
+import gtsfm.common.types as gtsfm_types
+from gtsfm.common.keypoints import Keypoints
+
+logger = logging.getLogger(__name__)
+
+
+def estimate_fundamental_from_correspondences(
+    coords_i1: np.ndarray,
+    coords_i2: np.ndarray,
+) -> Optional[np.ndarray]:
+    """Estimate F-matrix from verified correspondences using 8-point algorithm.
+
+    Args:
+        coords_i1: (N, 2) pixel coordinates in image 1.
+        coords_i2: (N, 2) pixel coordinates in image 2.
+
+    Returns:
+        3x3 fundamental matrix, or None if estimation fails.
+    """
+    if len(coords_i1) < 8:
+        return None
+    F, mask = cv2.findFundamentalMat(coords_i1, coords_i2, method=cv2.FM_8POINT)
+    if F is None or F.shape != (3, 3):
+        return None
+    return F
+
+
+def _fetzer_residuals(
+    focal_lengths: np.ndarray,
+    edges: List[Tuple[int, int, np.ndarray, np.ndarray, np.ndarray]],
+    cam_idx_to_var_idx: Dict[int, int],
+    precomputed: Optional[Dict] = None,
+) -> np.ndarray:
+    """Compute Fetzer residuals for all edges (vectorized).
+
+    For each edge, constructs E = K2^T F K1 from current focal lengths and measures
+    deviation from a valid essential matrix via singular value ratios.
+
+    Args:
+        focal_lengths: Current focal length estimates, one per optimized camera.
+        edges: List of (cam_idx1, cam_idx2, F, pp1, pp2) tuples.
+        cam_idx_to_var_idx: Maps camera index to position in focal_lengths array.
+        precomputed: Optional dict with precomputed index arrays for vectorization.
+
+    Returns:
+        Stacked residuals, 2 per edge.
+    """
+    n = len(edges)
+    if precomputed is None:
+        # Fallback to loop (used for final residual evaluation).
+        residuals = np.zeros(2 * n)
+        for i, (cam1, cam2, F, pp1, pp2) in enumerate(edges):
+            f1 = focal_lengths[cam_idx_to_var_idx[cam1]]
+            f2 = focal_lengths[cam_idx_to_var_idx[cam2]]
+            K1 = np.array([[f1, 0, pp1[0]], [0, f1, pp1[1]], [0, 0, 1.0]])
+            K2 = np.array([[f2, 0, pp2[0]], [0, f2, pp2[1]], [0, 0, 1.0]])
+            E = K2.T @ F @ K1
+            _, s, _ = np.linalg.svd(E)
+            if s[0] > 1e-12:
+                residuals[2 * i] = s[1] / s[0] - 1.0
+                residuals[2 * i + 1] = s[2] / s[0]
+        return residuals
+
+    # Vectorized path using precomputed arrays.
+    idx1 = precomputed["idx1"]
+    idx2 = precomputed["idx2"]
+    F_stack = precomputed["F_stack"]  # (n, 3, 3)
+    pp1_stack = precomputed["pp1_stack"]  # (n, 2)
+    pp2_stack = precomputed["pp2_stack"]  # (n, 2)
+
+    f1 = focal_lengths[idx1]  # (n,)
+    f2 = focal_lengths[idx2]  # (n,)
+
+    # Build K1, K2 as batch: K = [[f, 0, px], [0, f, py], [0, 0, 1]]
+    K1 = np.zeros((n, 3, 3))
+    K1[:, 0, 0] = f1
+    K1[:, 1, 1] = f1
+    K1[:, 0, 2] = pp1_stack[:, 0]
+    K1[:, 1, 2] = pp1_stack[:, 1]
+    K1[:, 2, 2] = 1.0
+
+    K2 = np.zeros((n, 3, 3))
+    K2[:, 0, 0] = f2
+    K2[:, 1, 1] = f2
+    K2[:, 0, 2] = pp2_stack[:, 0]
+    K2[:, 1, 2] = pp2_stack[:, 1]
+    K2[:, 2, 2] = 1.0
+
+    # E = K2^T @ F @ K1, batched.
+    K2T = np.transpose(K2, (0, 2, 1))
+    E = K2T @ F_stack @ K1  # (n, 3, 3)
+
+    # Batch SVD.
+    _, S, _ = np.linalg.svd(E)  # S shape (n, 3)
+
+    residuals = np.zeros(2 * n)
+    valid = S[:, 0] > 1e-12
+    residuals[0::2] = np.where(valid, S[:, 1] / np.maximum(S[:, 0], 1e-12) - 1.0, 0.0)
+    residuals[1::2] = np.where(valid, S[:, 2] / np.maximum(S[:, 0], 1e-12), 0.0)
+
+    return residuals
+
+
+def calibrate_view_graph(
+    v_corr_idxs_dict: Dict[Tuple[int, int], np.ndarray],
+    keypoints_list: List[Keypoints],
+    initial_intrinsics: List[gtsfm_types.CALIBRATION_TYPE],
+    num_images: int,
+    min_correspondences: int = 30,
+    min_focal_ratio: float = 0.5,
+    max_focal_ratio: float = 2.0,
+    max_edge_error: float = 0.5,
+) -> Tuple[List[gtsfm_types.CALIBRATION_TYPE], set]:
+    """Refine camera focal lengths via joint Fetzer optimization over all F-matrix edges.
+
+    Also filters edges with high calibration error (GLOMAP FilterImagePairs).
+
+    Args:
+        v_corr_idxs_dict: Verified correspondence indices per image pair.
+        keypoints_list: Keypoints for all images.
+        initial_intrinsics: Initial intrinsics (e.g., from EXIF or heuristic).
+        num_images: Total number of images.
+        min_correspondences: Minimum correspondences to attempt F estimation.
+        min_focal_ratio: Minimum allowed ratio of optimized/initial focal length.
+        max_focal_ratio: Maximum allowed ratio of optimized/initial focal length.
+        max_edge_error: Maximum Fetzer residual norm to keep an edge.
+
+    Returns:
+        Refined intrinsics list (same length as initial_intrinsics).
+        Set of edge keys (i1, i2) to remove from the view graph.
+    """
+    # Step 1: Estimate F-matrices and collect optimization edges.
+    edges = []  # (cam_idx1, cam_idx2, F, pp1, pp2)
+    cameras_in_edges = set()
+
+    for (i1, i2), v_corr_idxs in v_corr_idxs_dict.items():
+        if v_corr_idxs.shape[0] < min_correspondences:
+            continue
+
+        coords_i1 = keypoints_list[i1].coordinates[v_corr_idxs[:, 0]]
+        coords_i2 = keypoints_list[i2].coordinates[v_corr_idxs[:, 1]]
+
+        F = estimate_fundamental_from_correspondences(coords_i1, coords_i2)
+        if F is None:
+            continue
+
+        K1 = initial_intrinsics[i1].K()
+        K2 = initial_intrinsics[i2].K()
+        pp1 = np.array([K1[0, 2], K1[1, 2]])
+        pp2 = np.array([K2[0, 2], K2[1, 2]])
+
+        edges.append((i1, i2, F, pp1, pp2))
+        cameras_in_edges.add(i1)
+        cameras_in_edges.add(i2)
+
+    if not edges:
+        logger.info("View graph calibration: no valid edges, skipping.")
+        return list(initial_intrinsics), set()
+
+    # Step 2: Set up optimization variables.
+    sorted_cameras = sorted(cameras_in_edges)
+    cam_idx_to_var_idx = {cam: var for var, cam in enumerate(sorted_cameras)}
+    initial_focals = np.array([initial_intrinsics[cam].K()[0, 0] for cam in sorted_cameras])
+
+    logger.info(
+        "View graph calibration (Fetzer): %d edges, %d cameras. " "Initial focals: min=%.1f, med=%.1f, max=%.1f",
+        len(edges),
+        len(sorted_cameras),
+        initial_focals.min(),
+        np.median(initial_focals),
+        initial_focals.max(),
+    )
+
+    # Precompute arrays for vectorized residual evaluation.
+    precomputed = {
+        "idx1": np.array([cam_idx_to_var_idx[e[0]] for e in edges]),
+        "idx2": np.array([cam_idx_to_var_idx[e[1]] for e in edges]),
+        "F_stack": np.array([e[2] for e in edges]),  # (n, 3, 3)
+        "pp1_stack": np.array([e[3] for e in edges]),  # (n, 2)
+        "pp2_stack": np.array([e[4] for e in edges]),  # (n, 2)
+    }
+
+    # Step 3: Joint optimization with Cauchy robust loss.
+    result = least_squares(
+        _fetzer_residuals,
+        x0=initial_focals,
+        args=(edges, cam_idx_to_var_idx, precomputed),
+        loss="cauchy",
+        f_scale=0.1,
+        bounds=(100.0, np.inf),
+        max_nfev=200,
+    )
+
+    optimized_focals = result.x
+
+    # Step 4: Validate and build refined intrinsics.
+    refined = list(initial_intrinsics)
+    num_refined = 0
+    num_rejected = 0
+
+    for var_idx, cam_idx in enumerate(sorted_cameras):
+        old_focal = initial_focals[var_idx]
+        new_focal = optimized_focals[var_idx]
+        ratio = new_focal / old_focal if old_focal > 0 else 0
+
+        if min_focal_ratio <= ratio <= max_focal_ratio:
+            old_K = initial_intrinsics[cam_idx]
+            if isinstance(old_K, Cal3Bundler):
+                refined[cam_idx] = Cal3Bundler(
+                    fx=float(new_focal),
+                    k1=old_K.k1(),
+                    k2=old_K.k2(),
+                    u0=old_K.px(),
+                    v0=old_K.py(),
+                )
+                num_refined += 1
+        else:
+            num_rejected += 1
+
+    # Step 5: Filter edges with high calibration error.
+    final_residuals = _fetzer_residuals(optimized_focals, edges, cam_idx_to_var_idx)
+    edges_to_remove = set()
+    for i, (cam1, cam2, F, pp1, pp2) in enumerate(edges):
+        edge_error = np.linalg.norm(final_residuals[2 * i : 2 * i + 2])
+        if edge_error > max_edge_error:
+            edges_to_remove.add((cam1, cam2))
+
+    logger.info(
+        "View graph calibration (Fetzer): refined %d, rejected %d / %d cameras. "
+        "Optimized focals: min=%.1f, med=%.1f, max=%.1f. "
+        "Filtered %d / %d edges by calibration error (threshold=%.2f). "
+        "Solver: %s in %d evaluations, cost %.4f → %.4f.",
+        num_refined,
+        num_rejected,
+        len(sorted_cameras),
+        optimized_focals.min(),
+        np.median(optimized_focals),
+        optimized_focals.max(),
+        len(edges_to_remove),
+        len(edges),
+        max_edge_error,
+        result.message,
+        result.nfev,
+        0.5 * np.sum(_fetzer_residuals(initial_focals, edges, cam_idx_to_var_idx) ** 2),
+        result.cost,
+    )
+
+    return refined, edges_to_remove

--- a/gtsfm/view_graph_estimator/view_graph_calibration.py
+++ b/gtsfm/view_graph_estimator/view_graph_calibration.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Optional, Tuple
 
 import cv2
 import numpy as np
-from gtsam import Cal3Bundler
+from gtsam import Cal3Bundler, Cal3_S2, Cal3DS2
 from scipy.optimize import least_squares
 
 import gtsfm.common.types as gtsfm_types
@@ -223,6 +223,7 @@ def calibrate_view_graph(
 
         if min_focal_ratio <= ratio <= max_focal_ratio:
             old_K = initial_intrinsics[cam_idx]
+            # We assume fx == fy here.
             if isinstance(old_K, Cal3Bundler):
                 refined[cam_idx] = Cal3Bundler(
                     fx=float(new_focal),
@@ -230,6 +231,28 @@ def calibrate_view_graph(
                     k2=old_K.k2(),
                     u0=old_K.px(),
                     v0=old_K.py(),
+                )
+                num_refined += 1
+            elif isinstance(old_K, Cal3_S2):
+                refined[cam_idx] = Cal3_S2(
+                    fx=float(new_focal),
+                    fy=float(new_focal),
+                    s=old_K.skew(),
+                    u0=old_K.px(),
+                    v0=old_K.py(),
+                )
+                num_refined += 1
+            elif isinstance(old_K, Cal3DS2):
+                refined[cam_idx] = Cal3DS2(
+                    fx=float(new_focal),
+                    fy=float(new_focal),
+                    s=old_K.skew(),
+                    u0=old_K.px(),
+                    v0=old_K.py(),
+                    k1=old_K.k1(),
+                    k2=old_K.k2(),
+                    p1=old_K.p1(),
+                    p2=old_K.p2(),
                 )
                 num_refined += 1
         else:

--- a/tests/bundle/test_bundle_adjustment.py
+++ b/tests/bundle/test_bundle_adjustment.py
@@ -64,7 +64,7 @@ class TestBundleAdjustmentOptimizer(unittest.TestCase):
         absolute_pose_priors = [None] * EXAMPLE_DATA.number_images()
         relative_pose_priors = {}
 
-        expected_result, _, _ = self.ba.run_ba(
+        expected_result, _, _, _ = self.ba.run_ba(
             self.test_data, absolute_pose_priors=absolute_pose_priors, relative_pose_priors=relative_pose_priors
         )
 
@@ -152,7 +152,7 @@ class TestBundleAdjustmentOptimizer(unittest.TestCase):
             return stage_outputs[len(call_inputs) - 1]
 
         with patch.object(ba, "run_ba_stage_with_filtering", side_effect=capture_stage_input):
-            _, final_filtered, valid_mask = ba.run_ba(
+            _, final_filtered, valid_mask, _ = ba.run_ba(
                 input_data,
                 absolute_pose_priors=[],
                 relative_pose_priors={},

--- a/tests/bundle/test_bundle_adjustment.py
+++ b/tests/bundle/test_bundle_adjustment.py
@@ -163,6 +163,39 @@ class TestBundleAdjustmentOptimizer(unittest.TestCase):
         self.assertIs(final_filtered, stage3_filtered)
         self.assertEqual(valid_mask, [False, False, True])
 
+    def test_stage_mask_maps_gnc_filtered_tracks_to_input_tracks(self):
+        """Ensure GNC-pruned tracks are represented in the stage validity mask."""
+        ba = BundleAdjustmentOptimizer(reproj_error_thresholds=[5.0])
+
+        initial_data = MagicMock(spec=GtsfmData)
+        initial_data.number_tracks.return_value = 4
+        initial_data.get_valid_camera_indices.return_value = [0, 1, 2]
+
+        optimized_data = MagicMock(spec=GtsfmData)
+        optimized_data.number_tracks.return_value = 3
+
+        filtered_result = MagicMock(spec=GtsfmData)
+        optimized_data.filter_landmarks.return_value = (filtered_result, [True, False, True])
+
+        with patch.object(
+            ba,
+            "_BundleAdjustmentOptimizer__construct_factor_graph",
+            return_value=(MagicMock(), {}),
+        ), patch.object(
+            ba,
+            "_BundleAdjustmentOptimizer__optimize_and_recover",
+            return_value=(optimized_data, MagicMock(), 1.0, [True, False, True, True]),
+        ):
+            _, _, valid_mask, _ = ba.run_ba_stage_with_filtering(
+                initial_data,
+                absolute_pose_priors=[],
+                relative_pose_priors={},
+                reproj_error_thresh=5.0,
+                verbose=False,
+            )
+
+        self.assertEqual(valid_mask, [True, False, False, True])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/bundle/test_bundle_adjustment.py
+++ b/tests/bundle/test_bundle_adjustment.py
@@ -165,7 +165,11 @@ class TestBundleAdjustmentOptimizer(unittest.TestCase):
 
     def test_stage_mask_maps_gnc_filtered_tracks_to_input_tracks(self):
         """Ensure GNC-pruned tracks are represented in the stage validity mask."""
-        ba = BundleAdjustmentOptimizer(reproj_error_thresholds=[5.0])
+        # min_tracks_per_camera=0 disables the insufficient-tracks check, so the BA
+        # path doesn't try to mutate optimized_data._cameras (which the MagicMock
+        # spec=GtsfmData wouldn't expose since it's set in __init__ rather than at
+        # class level).
+        ba = BundleAdjustmentOptimizer(reproj_error_thresholds=[5.0], min_tracks_per_camera=0)
 
         initial_data = MagicMock(spec=GtsfmData)
         initial_data.number_tracks.return_value = 4
@@ -180,7 +184,7 @@ class TestBundleAdjustmentOptimizer(unittest.TestCase):
         with patch.object(
             ba,
             "_BundleAdjustmentOptimizer__construct_factor_graph",
-            return_value=(MagicMock(), {}),
+            return_value=MagicMock(),
         ), patch.object(
             ba,
             "_BundleAdjustmentOptimizer__optimize_and_recover",

--- a/tests/bundle/test_bundle_adjustment.py
+++ b/tests/bundle/test_bundle_adjustment.py
@@ -4,6 +4,7 @@ Authors: Ayush Baid
 """
 
 import unittest
+from unittest.mock import MagicMock, patch
 
 import dask
 import gtsam  # type: ignore
@@ -121,6 +122,46 @@ class TestBundleAdjustmentOptimizer(unittest.TestCase):
 
         self.assertEqual(computed_result.number_images(), self.test_data.number_images())
         self.assertAlmostEqual(error, 0.3675, places=2)
+
+    def test_multistage_ba_uses_previous_filtered_result(self):
+        """Ensure each BA stage consumes the previous stage's filtered output."""
+        ba = BundleAdjustmentOptimizer(reproj_error_thresholds=[10.0, 5.0, 3.0])
+
+        input_data = MagicMock(spec=GtsfmData)
+        input_data.number_tracks.return_value = 3
+
+        stage1_filtered = MagicMock(spec=GtsfmData)
+        stage1_filtered.number_tracks.return_value = 2
+
+        stage2_filtered = MagicMock(spec=GtsfmData)
+        stage2_filtered.number_tracks.return_value = 1
+
+        stage3_filtered = MagicMock(spec=GtsfmData)
+        stage3_filtered.number_tracks.return_value = 1
+
+        stage_outputs = [
+            (MagicMock(spec=GtsfmData), stage1_filtered, [True, False, True], 1.0),
+            (MagicMock(spec=GtsfmData), stage2_filtered, [False, True], 0.5),
+            (MagicMock(spec=GtsfmData), stage3_filtered, [True], 0.1),
+        ]
+
+        call_inputs = []
+
+        def capture_stage_input(stage_input, *args, **kwargs):
+            call_inputs.append(stage_input)
+            return stage_outputs[len(call_inputs) - 1]
+
+        with patch.object(ba, "run_ba_stage_with_filtering", side_effect=capture_stage_input):
+            _, final_filtered, valid_mask = ba.run_ba(
+                input_data,
+                absolute_pose_priors=[],
+                relative_pose_priors={},
+                verbose=False,
+            )
+
+        self.assertEqual(call_inputs, [input_data, stage1_filtered, stage2_filtered])
+        self.assertIs(final_filtered, stage3_filtered)
+        self.assertEqual(valid_mask, [False, False, True])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR makes a significant number of changes to the frontend:
1. Change the focal length calibration by adding `view_graph_calibration.py`
2. Adds PoseLib (https://github.com/PoseLib/PoseLib) to compute R and t 
3. Switches to using ColmapSift features (4 new config files)
4. Makes the view graph more denser
5. Fixes small issues in stage BA so now in multistage BA, previous BA outputs are used.
6. Colmap loader uses 1.2 or `_default_focal_length_factor `if `_use_gt_intrinsics `is set as False.


Run with command

`./run --config_name megaloc_sift_single --loader colmap --dataset_dir benchmarks/phototourism/british_museum/ --output_root <output_folder> --worker_memory_limit "48GB" +loader.colmap_files_subdir=sparse loader.use_gt_intrinsics=false`