### PR TITLE
Add optional view-graph (joint intrinsic) calibration to ClusterVGGTWithFrontend

### DIFF
--- a/gtsfm/cluster_optimizer/cluster_vggt.py
+++ b/gtsfm/cluster_optimizer/cluster_vggt.py
@@ -13,9 +13,10 @@ from PIL import Image as PILImage
 
 import gtsfm.common.types as gtsfm_types
 import gtsfm.utils.metrics as metrics_utils
-from gtsfm.bundle.bundle_adjustment import BundleAdjustmentOptions
+from gtsfm.bundle.bundle_adjustment import BundleAdjustmentOptions, multi_view_retriangulate_from_2d_tracks
 from gtsfm.cluster_optimizer.cluster_optimizer_base import ClusterComputationGraph, ClusterContext, ClusterOptimizerBase
 from gtsfm.common.gtsfm_data import GtsfmData
+from gtsfm.common.sfm_track import SfmTrack2d
 from gtsfm.evaluation.metrics import GtsfmMetric, GtsfmMetricsGroup
 from gtsfm.frontend.multi_view_tracker import MultiViewTracker
 from gtsfm.frontend.vggt_geometry_transformer import (
@@ -50,10 +51,19 @@ def _run_cluster_ba(
     drop_camera_with_no_track: bool = False,
     min_track_length: int = 2,
     cluster_label: Optional[str] = None,
+    tracks_2d: Optional[list[SfmTrack2d]] = None,
+    use_multi_view_retriangulation: bool = False,
 ) -> tuple[GtsfmData, GtsfmData]:
     """Run cluster-level BA on a GtsfmData result.
 
     This is a module-level function so it can be used with ``dask.delayed``.
+
+    Args:
+        tracks_2d: (optional) Union-find 2D tracks. Required when
+            ``use_multi_view_retriangulation=True``.
+        use_multi_view_retriangulation: When True, after the initial BA, re-triangulate
+            ``tracks_2d`` against the post-BA cameras (recovers tracks dropped earlier
+            in the pipeline) and run a second BA on the augmented track set.
 
     Returns:
         Tuple of (post_ba_result, pre_ba_result).
@@ -89,6 +99,20 @@ def _run_cluster_ba(
         gtsfm_data_with_ba = gtsfm_data_with_ba.filter_landmark_measurements(
             post_ba_max_reproj_error
         )
+
+        # Optional retri stage: re-triangulate union-find tracks against the post-BA
+        # cameras and run another BA on the augmented set. Recovers tracks dropped
+        # earlier in the pipeline; mirrors the retri stage in
+        # BundleAdjustmentOptimizer._run_ba_and_evaluate.
+        if use_multi_view_retriangulation and tracks_2d is not None:
+            retri_data = multi_view_retriangulate_from_2d_tracks(
+                gtsfm_data_with_ba, tracks_2d, min_track_length=min_track_length,
+            )
+            if retri_data.number_tracks() > 0:
+                gtsfm_data_with_ba, _ = optimizer.run_simple_ba(retri_data)
+                gtsfm_data_with_ba = gtsfm_data_with_ba.filter_landmark_measurements(
+                    post_ba_max_reproj_error
+                )
 
         logger.info(
             "%s🔍 #valid tracks after BA: %d out of %d",

--- a/gtsfm/cluster_optimizer/cluster_vggt_with_frontend.py
+++ b/gtsfm/cluster_optimizer/cluster_vggt_with_frontend.py
@@ -30,6 +30,7 @@ from gtsfm.multi_view_optimizer import get_2d_tracks
 from gtsfm.products.visibility_graph import visibility_graph_keys
 from gtsfm.two_view_estimator import TwoViewEstimator
 from gtsfm.ui.gtsfm_process import UiMetadata
+from gtsfm.view_graph_estimator.view_graph_calibration import calibrate_view_graph
 import gtsam
 
 from gtsfm.utils import torch as torch_utils
@@ -132,6 +133,7 @@ def _build_gtsfm_data_from_vggt_depth(
     image_indices: tuple[int, ...],
     num_images: int,
     min_track_length: int = 2,
+    refined_intrinsics: Optional[list[gtsfm_types.CALIBRATION_TYPE]] = None,
 ) -> GtsfmData:
     """Build GtsfmData using VGGT cameras (rescaled to original resolution) and frontend 2D tracks.
 
@@ -159,14 +161,19 @@ def _build_gtsfm_data_from_vggt_depth(
     _, H_vggt, W_vggt = dense_points.shape[:3]
     global_to_local = {gidx: lidx for lidx, gidx in enumerate(image_indices)}
 
-    # Register cameras with intrinsics rescaled to original image resolution.
+    # Register cameras with intrinsics in original image resolution. If
+    # `refined_intrinsics` is supplied (from view-graph calibration), use those
+    # directly; otherwise rescale VGGT's predicted intrinsics from VGGT pixel space.
     gtsfm_data = GtsfmData(number_images=num_images)
     for global_idx, camera in cameras.items():
         if global_idx in image_shapes and global_idx in global_to_local:
-            _, orig_W = image_shapes[global_idx]
-            local_idx = global_to_local[global_idx]
-            scaled_W = float(original_coords[local_idx, 4])
-            camera = _scale_camera_intrinsics(camera, scale=orig_W / scaled_W)
+            if refined_intrinsics is not None:
+                camera = type(camera)(camera.pose(), refined_intrinsics[global_idx])
+            else:
+                _, orig_W = image_shapes[global_idx]
+                local_idx = global_to_local[global_idx]
+                scaled_W = float(original_coords[local_idx, 4])
+                camera = _scale_camera_intrinsics(camera, scale=orig_W / scaled_W)
         gtsfm_data.add_camera(global_idx, camera)
 
     for track_2d in tracks_2d:
@@ -220,6 +227,45 @@ def _build_gtsfm_data_from_vggt_depth(
     return gtsfm_data
 
 
+def _refine_vggt_intrinsics_via_view_graph(
+    vggt_result: VggtGeometryResult,
+    v_corr_idxs: dict,
+    keypoints_list: list,
+    image_shapes: dict[int, tuple[int, int]],
+    image_indices: tuple[int, ...],
+    num_images: int,
+) -> list[gtsfm_types.CALIBRATION_TYPE]:
+    """Refine focal lengths via Fetzer joint optimization over F-matrix edges.
+
+    Returns intrinsics in ORIGINAL image coordinates (suitable for use with the
+    frontend keypoints). VGGT's predicted intrinsics are rescaled to original
+    image coords first, then handed to `calibrate_view_graph` as the initial
+    estimate. VGGT's predicted poses are unchanged — only intrinsics are refined.
+    """
+    initial_intrinsics: list[gtsfm_types.CALIBRATION_TYPE] = []
+    global_to_local = {gidx: lidx for lidx, gidx in enumerate(image_indices)}
+    for global_idx in range(num_images):
+        if global_idx in vggt_result.cameras and global_idx in image_shapes:
+            local_idx = global_to_local[global_idx]
+            _, orig_W = image_shapes[global_idx]
+            scaled_W = float(vggt_result.original_coords[local_idx, 4])
+            scale = orig_W / scaled_W if scaled_W > 0 else 1.0
+            scaled_cam = _scale_camera_intrinsics(vggt_result.cameras[global_idx], scale=scale)
+            initial_intrinsics.append(scaled_cam.calibration())
+        else:
+            # Placeholder for images outside this cluster; calibrate_view_graph won't touch
+            # cameras with no edges, so the placeholder value never reaches the BA solve.
+            initial_intrinsics.append(gtsam.Cal3Bundler(1.0, 0.0, 0.0, 0.0, 0.0))
+
+    refined, _edges_to_remove = calibrate_view_graph(
+        v_corr_idxs_dict=v_corr_idxs,
+        keypoints_list=keypoints_list,
+        initial_intrinsics=initial_intrinsics,
+        num_images=num_images,
+    )
+    return refined
+
+
 class ClusterVGGTWithFrontend(ClusterMVO):
     """Cluster optimizer that combines a traditional MVO frontend with VGGT poses.
 
@@ -250,6 +296,10 @@ class ClusterVGGTWithFrontend(ClusterMVO):
         save_two_view_viz: bool = False,
         pose_angular_error_thresh: float = 3,
         output_worker: Optional[str] = None,
+        # Refine VGGT's predicted intrinsics via joint Fetzer optimization over the
+        # frontend's F-matrices before cluster BA. Off by default. Useful when the
+        # input images are uncalibrated and VGGT's predicted focals are unreliable.
+        use_view_graph_calibration: bool = False,
     ) -> None:
         super().__init__(
             correspondence_generator=correspondence_generator,
@@ -268,6 +318,7 @@ class ClusterVGGTWithFrontend(ClusterMVO):
         self._metric_constructed_only = metric_constructed_only
         self._input_mode = input_mode
         self._seed = seed
+        self._use_view_graph_calibration = use_view_graph_calibration
 
         self._weights_path = Path(weights_path) if weights_path is not None else None
         self._loader_kwargs: dict[str, Any] = {}
@@ -343,6 +394,19 @@ class ClusterVGGTWithFrontend(ClusterMVO):
         # 4. Original image shapes (needed to map frontend pixel coords → VGGT pixel coords).
         image_shapes_graph = delayed(_get_image_shapes)(context.loader, global_indices)
 
+        # 4b. Optional: refine VGGT's predicted intrinsics via Fetzer joint
+        # optimization over the frontend's F-matrices (keeps VGGT's predicted poses).
+        refined_intrinsics_graph = None
+        if self._use_view_graph_calibration:
+            refined_intrinsics_graph = delayed(_refine_vggt_intrinsics_via_view_graph)(
+                vggt_result_graph,
+                v_corr_idxs_graph,
+                frontend_graphs.padded_keypoints,
+                image_shapes_graph,
+                global_indices,
+                context.num_images,
+            )
+
         # 5. Build GtsfmData: lift 2D tracks to 3D using VGGT depth map.
         ba_input_graph = delayed(_build_gtsfm_data_from_vggt_depth)(
             vggt_result_graph,
@@ -351,6 +415,7 @@ class ClusterVGGTWithFrontend(ClusterMVO):
             image_indices=global_indices,
             num_images=context.num_images,
             min_track_length=self._min_track_length,
+            refined_intrinsics=refined_intrinsics_graph,
         )
 
         # 6. Cluster-level BA.

--- a/gtsfm/cluster_optimizer/cluster_vggt_with_frontend.py
+++ b/gtsfm/cluster_optimizer/cluster_vggt_with_frontend.py
@@ -300,6 +300,10 @@ class ClusterVGGTWithFrontend(ClusterMVO):
         # frontend's F-matrices before cluster BA. Off by default. Useful when the
         # input images are uncalibrated and VGGT's predicted focals are unreliable.
         use_view_graph_calibration: bool = False,
+        # Re-triangulate union-find 2D tracks against the post-BA cameras and run a
+        # second BA on the augmented set. Recovers tracks dropped earlier in the
+        # pipeline; mirrors the retri stage in BundleAdjustmentOptimizer.
+        use_multi_view_retriangulation: bool = False,
     ) -> None:
         super().__init__(
             correspondence_generator=correspondence_generator,
@@ -319,6 +323,7 @@ class ClusterVGGTWithFrontend(ClusterMVO):
         self._input_mode = input_mode
         self._seed = seed
         self._use_view_graph_calibration = use_view_graph_calibration
+        self._use_multi_view_retriangulation = use_multi_view_retriangulation
 
         self._weights_path = Path(weights_path) if weights_path is not None else None
         self._loader_kwargs: dict[str, Any] = {}
@@ -427,6 +432,8 @@ class ClusterVGGTWithFrontend(ClusterMVO):
             drop_camera_with_no_track=self._drop_camera_with_no_track,
             min_track_length=self._min_track_length,
             cluster_label=context.label,
+            tracks_2d=tracks_2d_graph,
+            use_multi_view_retriangulation=self._use_multi_view_retriangulation,
         )
 
         # 7. Metrics + I/O.

--- a/gtsfm/configs/vggt_sift_frontend_megaloc.yaml
+++ b/gtsfm/configs/vggt_sift_frontend_megaloc.yaml
@@ -99,6 +99,8 @@ cluster_optimizer:
     model_cache_key: null
     # Refine VGGT predicted intrinsics via Fetzer joint optimization on F-matrices.
     use_view_graph_calibration: false
+    # Re-triangulate union-find 2D tracks against post-BA cameras and run another BA.
+    use_multi_view_retriangulation: false
 
 # --- Merging options ---
 merging_options:

--- a/gtsfm/configs/vggt_sift_frontend_megaloc.yaml
+++ b/gtsfm/configs/vggt_sift_frontend_megaloc.yaml
@@ -97,6 +97,8 @@ cluster_optimizer:
     input_mode: crop
     seed: 42
     model_cache_key: null
+    # Refine VGGT predicted intrinsics via Fetzer joint optimization on F-matrices.
+    use_view_graph_calibration: false
 
 # --- Merging options ---
 merging_options:

--- a/gtsfm/configs/vggt_sift_frontend_megaloc_phototourism.yaml
+++ b/gtsfm/configs/vggt_sift_frontend_megaloc_phototourism.yaml
@@ -99,6 +99,8 @@ cluster_optimizer:
     model_cache_key: null
     # Refine VGGT predicted intrinsics via Fetzer joint optimization on F-matrices.
     use_view_graph_calibration: false
+    # Re-triangulate union-find 2D tracks against post-BA cameras and run another BA.
+    use_multi_view_retriangulation: false
 
 # --- Merging options ---
 merging_options:

--- a/gtsfm/configs/vggt_sift_frontend_megaloc_phototourism.yaml
+++ b/gtsfm/configs/vggt_sift_frontend_megaloc_phototourism.yaml
@@ -97,6 +97,8 @@ cluster_optimizer:
     input_mode: crop
     seed: 42
     model_cache_key: null
+    # Refine VGGT predicted intrinsics via Fetzer joint optimization on F-matrices.
+    use_view_graph_calibration: false
 
 # --- Merging options ---
 merging_options:

--- a/gtsfm/configs/vggt_unified_frontend_megaloc.yaml
+++ b/gtsfm/configs/vggt_unified_frontend_megaloc.yaml
@@ -92,6 +92,8 @@ cluster_optimizer:
     input_mode: crop
     seed: 42
     model_cache_key: null
+    # Refine VGGT predicted intrinsics via Fetzer joint optimization on F-matrices.
+    use_view_graph_calibration: false
 
 # --- Merging options ---
 merging_options:

--- a/gtsfm/configs/vggt_unified_frontend_megaloc.yaml
+++ b/gtsfm/configs/vggt_unified_frontend_megaloc.yaml
@@ -94,6 +94,8 @@ cluster_optimizer:
     model_cache_key: null
     # Refine VGGT predicted intrinsics via Fetzer joint optimization on F-matrices.
     use_view_graph_calibration: false
+    # Re-triangulate union-find 2D tracks against post-BA cameras and run another BA.
+    use_multi_view_retriangulation: false
 
 # --- Merging options ---
 merging_options:


### PR DESCRIPTION
When use_view_graph_calibration=True, refines VGGT's predicted intrinsics via joint Fetzer optimization over the frontend's F-matrix edges (existing calibrate_view_graph from gtsfm/view_graph_estimator/view_graph_calibration.py) before the cluster BA. VGGT's predicted poses are unchanged; only the intrinsics handed to BA are swapped from VGGT-predicted to view-graph-refined.

Useful for uncalibrated phototourism scenes where VGGT's predicted focals may be unreliable.

Default off (use_view_graph_calibration: false) → behavior identical to master.

Also enabled optional Structure Refinement after cluster BA

## Diff

- `_refine_vggt_intrinsics_via_view_graph` helper at module level: rescales VGGT's predicted intrinsics from VGGT pixel space to original image coords, feeds them as initial estimate to `calibrate_view_graph`, returns refined intrinsics in original image coords.
- `_build_gtsfm_data_from_vggt_depth` accepts optional `refined_intrinsics` — when provided, uses them for the BA cameras instead of rescaling VGGT's. Depth lookup is unaffected (uses VGGT pixel coords directly).
- `ClusterVGGTWithFrontend.__init__` adds `use_view_graph_calibration: bool = False`.
- `create_computation_graph` adds one conditional dispatch block.
-  wire post-BA retri into _run_cluster_ba, expose use_multi_view_retriangulation on ClusterVGGTWithFrontend + 3 yamls
- 3 yamls (vggt_sift_frontend_megaloc, _phototourism, vggt_unified_frontend_megaloc) expose the flag with default false.

## How to enable

```yaml
cluster_optimizer:
  optimizer:
    _target_: gtsfm.cluster_optimizer.VggtWithFrontend
    ...
    use_view_graph_calibration: true
```