### PR TITLE
VGGT Omega implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "thirdparty/FastVGGT"]
 	path = thirdparty/FastVGGT
 	url = https://github.com/mystorm16/FastVGGT.git
+[submodule "thirdparty/vggt-omega"]
+	path = thirdparty/vggt-omega
+	url = https://github.com/facebookresearch/vggt-omega.git

--- a/gtsfm/cluster_optimizer/__init__.py
+++ b/gtsfm/cluster_optimizer/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     "Anysplat",
     "Cacher",
     "VggtWithFrontend",
+    "VggtOmegaWithFrontend",
     "logger",
     "save_metrics_reports",
 ]
@@ -20,11 +21,12 @@ __all__ = [
 # Provide symbols to type checkers/IDEs without incurring runtime imports.
 if TYPE_CHECKING:
     from .cluster_anysplat import ClusterAnySplat as Anysplat
+    from .cluster_fast_vggt import ClusterFastVGGT as FastVggt
     from .cluster_mvo import ClusterMVO as Multiview
     from .cluster_optimizer_base import ClusterOptimizerBase as Base
     from .cluster_optimizer_cacher import ClusterOptimizerCacher as Cacher
     from .cluster_vggt import ClusterVGGT as Vggt
-    from .cluster_fast_vggt import ClusterFastVGGT as FastVggt
+    from .cluster_vggt_omega_with_frontend import ClusterVGGTOmegaWithFrontend as VggtOmegaWithFrontend
     from .cluster_vggt_with_frontend import ClusterVGGTWithFrontend as VggtWithFrontend
 
 # Short name → (module, class) for lazy attribute access.
@@ -36,6 +38,10 @@ _MOD_MAP = {
     "Anysplat": ("gtsfm.cluster_optimizer.cluster_anysplat", "ClusterAnySplat"),
     "Cacher": ("gtsfm.cluster_optimizer.cluster_optimizer_cacher", "ClusterOptimizerCacher"),
     "VggtWithFrontend": ("gtsfm.cluster_optimizer.cluster_vggt_with_frontend", "ClusterVGGTWithFrontend"),
+    "VggtOmegaWithFrontend": (
+        "gtsfm.cluster_optimizer.cluster_vggt_omega_with_frontend",
+        "ClusterVGGTOmegaWithFrontend",
+    ),
 }
 
 

--- a/gtsfm/cluster_optimizer/cluster_vggt_omega_with_frontend.py
+++ b/gtsfm/cluster_optimizer/cluster_vggt_omega_with_frontend.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, Hashable, NamedTuple, Optional
 
 import gtsam
@@ -333,7 +332,6 @@ class ClusterVGGTOmegaWithFrontend(ClusterMVO):
             return None
 
         global_indices = tuple(int(idx) for idx in keys)
-        image_filenames = context.loader.image_filenames()
 
         # Traditional frontend.
         frontend_graphs = self._build_frontend_graphs(context)

--- a/gtsfm/cluster_optimizer/cluster_vggt_omega_with_frontend.py
+++ b/gtsfm/cluster_optimizer/cluster_vggt_omega_with_frontend.py
@@ -1,0 +1,406 @@
+"""Cluster optimizer that combines a traditional MVO frontend with VGGT-Omega geometry + BA."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Hashable, NamedTuple, Optional
+
+import gtsam
+import numpy as np
+import torch
+from dask.delayed import delayed
+from gtsam import Point2, Point3, SfmTrack
+
+import gtsfm.common.types as gtsfm_types
+from gtsfm.bundle.bundle_adjustment import BundleAdjustmentOptions
+from gtsfm.cluster_optimizer.cluster_mvo import ClusterMVO
+from gtsfm.cluster_optimizer.cluster_optimizer_base import ClusterComputationGraph, ClusterContext
+from gtsfm.cluster_optimizer.cluster_vggt import (
+    _aggregate_vggt_metrics,
+    _run_cluster_ba,
+    _save_pre_ba_reconstruction_as_text,
+    _save_reconstruction_as_text,
+)
+from gtsfm.common.gtsfm_data import GtsfmData
+from gtsfm.common.sfm_track import SfmTrack2d
+from gtsfm.frontend.correspondence_generator.correspondence_generator_base import CorrespondenceGeneratorBase
+from gtsfm.frontend.vggt_omega_geometry_transformer import (
+    VggtOmegaGeometryTransformer,
+    load_image_batch_vggt_omega_loader,
+    load_model,
+)
+from gtsfm.multi_view_optimizer import get_2d_tracks
+from gtsfm.products.visibility_graph import visibility_graph_keys
+from gtsfm.two_view_estimator import TwoViewEstimator
+from gtsfm.ui.gtsfm_process import UiMetadata
+from gtsfm.utils import torch as torch_utils
+from gtsfm.utils.logger import get_logger
+
+logger = get_logger()
+
+# Module-level cache to avoid reloading VGGT weights per cluster.
+_VGGT_OMEGA_MODEL_CACHE: dict[Hashable, Any] = {}
+
+
+class VggtOmegaGeometryResult(NamedTuple):
+    """Outputs of VGGT geometry prediction needed for downstream processing."""
+
+    cameras: dict[int, gtsfm_types.CAMERA_TYPE]
+    dense_points: np.ndarray  # (N, H, W, 3) world-space 3D points per pixel
+    depth_confidence: np.ndarray  # (N, H, W) per-pixel depth confidence scores
+    original_coords: np.ndarray  # (N, 6) VGGT crop/pad metadata
+
+
+def _extract_v_corr_idxs(two_view_results) -> dict:
+    """Pull verified correspondence index arrays out of two-view results."""
+    return {ij: result.v_corr_idxs for ij, result in two_view_results.items()}
+
+
+def _get_image_shapes(loader, image_indices: tuple[int, ...]) -> dict[int, tuple[int, int]]:
+    """Return original (height, width) for each requested image index."""
+    return {idx: loader.get_image(idx).value_array.shape[:2] for idx in image_indices}
+
+
+def _resolve_vggt_omega_model(cache_key: Hashable | None) -> Any | None:
+    """Fetch (or lazily load) a VGGT Omega model for the current worker."""
+    if cache_key is None:
+        return None
+    if cache_key in _VGGT_OMEGA_MODEL_CACHE:
+        return _VGGT_OMEGA_MODEL_CACHE[cache_key]
+    logger.info("⏳ Loading VGGT Omega model weights...")
+    model = load_model(torch.device("cuda"))
+    _VGGT_OMEGA_MODEL_CACHE[cache_key] = model
+    logger.info("✅ VGGT Omega model weights loaded successfully.")
+    return model
+
+
+def _run_vggt_omega_geometry(
+    image_batch: torch.Tensor,
+    original_coords: torch.Tensor,
+    *,
+    transformer: VggtOmegaGeometryTransformer,
+    image_indices: tuple[int, ...],
+    seed: int = 42,
+    model_cache_key: Hashable | None = None,
+    cluster_label: Optional[str] = None,
+) -> VggtOmegaGeometryResult:
+    """Run VGGT Omega geometry prediction, returning cameras and dense 3D points."""
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+    if cluster_label:
+        logger.info("🔵 Running VGGT geometry on %s with %d images.", cluster_label, image_batch.shape[0])
+
+    cached_model = _resolve_vggt_omega_model(model_cache_key)
+    geo_output = transformer.predict(image_batch, model=cached_model)
+
+    original_coords_np = original_coords.to(torch.float32).cpu().numpy()
+    cameras = {
+        global_idx: torch_utils.camera_from_matrices(
+            geo_output.extrinsic[local_idx].to(torch.float32).cpu().numpy(),
+            geo_output.intrinsic[local_idx].to(torch.float32).cpu().numpy(),
+            crop_coords=original_coords_np[local_idx],
+            use_cal3ds2=True,
+        )
+        for local_idx, global_idx in enumerate(image_indices)
+    }
+
+    result = VggtOmegaGeometryResult(
+        cameras=cameras,
+        dense_points=geo_output.dense_points.to(torch.float32).cpu().numpy(),
+        depth_confidence=geo_output.depth_confidence.to(torch.float32).cpu().numpy(),
+        original_coords=original_coords_np,
+    )
+
+    if geo_output.device.type == "cuda":
+        del geo_output
+        torch.cuda.empty_cache()
+
+    return result
+
+
+def _scale_camera_intrinsics(
+    camera: gtsfm_types.CAMERA_TYPE, scale_x: float, scale_y: float
+) -> gtsfm_types.CAMERA_TYPE:
+    """Return a copy of camera with intrinsics uniformly scaled, pose unchanged."""
+    pose = camera.pose()
+    cal = camera.calibration()
+    if isinstance(cal, gtsam.Cal3DS2):
+        return gtsam.PinholeCameraCal3DS2(
+            pose,
+            gtsam.Cal3DS2(
+                cal.fx() * scale_x,
+                cal.fy() * scale_y,
+                0.0,
+                cal.px() * scale_x,
+                cal.py() * scale_y,
+                cal.k1(),
+                cal.k2(),
+                cal.p1(),
+                cal.p2(),
+            ),
+        )
+    if isinstance(cal, gtsam.Cal3_S2):
+        return gtsam.PinholeCameraCal3_S2(
+            pose,
+            gtsam.Cal3_S2(cal.fx() * scale_x, cal.fy() * scale_y, 0.0, cal.px() * scale_x, cal.py() * scale_y),
+        )
+    raise ValueError(f"Unsupported calibration type: {type(cal)}")
+
+
+def _build_gtsfm_data_from_vggt_omega_depth(
+    vggt_omega_result: VggtOmegaGeometryResult,
+    tracks_2d: list[SfmTrack2d],
+    image_shapes: dict[int, tuple[int, int]],
+    image_indices: tuple[int, ...],
+    num_images: int,
+    min_track_length: int = 2,
+) -> GtsfmData:
+    """Build GtsfmData using VGGT Omega cameras (rescaled to original resolution) and frontend 2D tracks.
+
+    VGGT Omega camera intrinsics are scaled from VGGT pixel space to original image resolution so
+    that the frontend keypoints (in original coords) can be used directly as BA measurements.
+    VGGT Omega pixel coordinates are used only to look up per-pixel depth values for 3D initialisation.
+
+    Args:
+        vggt_omega_result: Cameras, dense 3D points, and crop metadata from VGGT.
+        tracks_2d: 2D feature tracks from the frontend (in original image coordinates).
+        image_shapes: Original (height, width) per global image index.
+        image_indices: Ordered global image indices corresponding to the N VGGT frames.
+        num_images: Total number of images in the scene.
+        min_track_length: Minimum observations per track; shorter tracks are dropped.
+
+    Returns:
+        GtsfmData with intrinsics-rescaled VGGT cameras and depth-initialised tracks whose
+        2D measurements are in the original keypoint coordinate system.
+    """
+    cameras = vggt_omega_result.cameras
+    dense_points = vggt_omega_result.dense_points  # (N, H_vggt, W_vggt, 3)
+    depth_confidence = vggt_omega_result.depth_confidence  # (N, H_vggt, W_vggt)
+    original_coords = vggt_omega_result.original_coords  # (N, 6): [left, top, right, bottom, sw, sh]
+
+    _, H_vggt, W_vggt = dense_points.shape[:3]
+    global_to_local = {gidx: lidx for lidx, gidx in enumerate(image_indices)}
+
+    # Register cameras with intrinsics rescaled to original image resolution.
+    gtsfm_data = GtsfmData(number_images=num_images)
+    for global_idx, camera in cameras.items():
+        if global_idx in image_shapes and global_idx in global_to_local:
+            orig_H, orig_W = image_shapes[global_idx]
+            local_idx = global_to_local[global_idx]
+            scaled_W = float(original_coords[local_idx, 4])
+            scaled_H = float(original_coords[local_idx, 5])
+            camera = _scale_camera_intrinsics(camera, scale_x=orig_W / scaled_W, scale_y=orig_H / scaled_H)
+        gtsfm_data.add_camera(global_idx, camera)
+
+    for track_2d in tracks_2d:
+        if track_2d.number_measurements() < min_track_length:
+            continue
+
+        points_3d: list[np.ndarray] = []
+        confidences: list[float] = []
+        valid_measurements: list[tuple[int, np.ndarray]] = []
+
+        for m in track_2d.measurements:
+            global_idx = m.i
+            if global_idx not in global_to_local or global_idx not in image_shapes:
+                continue
+
+            local_idx = global_to_local[global_idx]
+            orig_H, orig_W = image_shapes[global_idx]
+
+            # Map frontend keypoints into VGGT Omega dense-map coordinates using the actual
+            # per-axis resized image dimensions plus the crop/pad offsets recorded in
+            # original_coords for this image.
+            left, top = original_coords[local_idx, 0], original_coords[local_idx, 1]
+            scaled_W, scaled_H = original_coords[local_idx, 4], original_coords[local_idx, 5]
+            u_scale = scaled_W / orig_W if orig_W > 0 else 0.0
+            v_scale = scaled_H / orig_H if orig_H > 0 else 0.0
+            u_c = int(round(m.uv[0] * u_scale - left))
+            v_c = int(round(m.uv[1] * v_scale - top))
+            if not (0.0 <= u_c < W_vggt and 0.0 <= v_c < H_vggt):
+                continue
+
+            pt3d = dense_points[local_idx, v_c, u_c]
+            conf = float(depth_confidence[local_idx, v_c, u_c])
+            if np.isfinite(pt3d).all() and np.isfinite(conf):
+                points_3d.append(pt3d)
+                confidences.append(conf)
+                valid_measurements.append((global_idx, m.uv))  # original keypoint coords
+
+        if len(points_3d) < min_track_length:
+            continue
+
+        weights = np.array(confidences)
+        weights /= weights.sum()
+        point_3d_mean = np.average(points_3d, axis=0, weights=weights)
+        sfm_track = SfmTrack(Point3(*point_3d_mean.astype(float)))
+        for gidx, uv in valid_measurements:
+            if gidx in cameras:
+                sfm_track.addMeasurement(gidx, Point2(*uv.astype(float)))
+
+        if sfm_track.numberMeasurements() >= min_track_length:
+            gtsfm_data.add_track(sfm_track)
+
+    logger.info("Built GtsfmData with %d cameras and %d tracks.", len(cameras), gtsfm_data.number_tracks())
+    return gtsfm_data
+
+
+def _load_vggt_omega_inputs(
+    loader,
+    indices: list[int],
+):
+    """Load and preprocess a batch of images for VGGT Omega."""
+    image_batch, original_coords = load_image_batch_vggt_omega_loader(loader, indices)
+    return image_batch, original_coords
+
+
+class ClusterVGGTOmegaWithFrontend(ClusterMVO):
+    """Cluster optimizer that combines a traditional MVO frontend with VGGT poses.
+
+    Camera poses come from VGGT Omega geometry prediction. 2D feature tracks come from the
+    frontend (correspondence generation + two-view estimation). Each track's 3D point is
+    initialised from VGGT Omega's dense depth map rather than via triangulation, then refined
+    by cluster-level bundle adjustment.
+    """
+
+    def __init__(
+        self,
+        correspondence_generator: CorrespondenceGeneratorBase,
+        two_view_estimator: TwoViewEstimator,
+        geometry_transformer: VggtOmegaGeometryTransformer | None = None,
+        ba_options: BundleAdjustmentOptions | None = None,
+        # Cluster BA params
+        pre_ba_max_reproj_error: float = 14.0,
+        post_ba_max_reproj_error: float = 3.0,
+        drop_camera_with_no_track: bool = False,
+        min_track_length: int = 2,
+        # VGGT model loading
+        seed: int = 42,
+        model_cache_key: Hashable | bool | None = None,
+        metric_constructed_only: bool = False,
+        # Frontend params
+        save_two_view_viz: bool = False,
+        pose_angular_error_thresh: float = 3,
+        output_worker: Optional[str] = None,
+    ) -> None:
+        super().__init__(
+            correspondence_generator=correspondence_generator,
+            two_view_estimator=two_view_estimator,
+            multiview_optimizer=None,  # VGGT Omega depth replaces triangulation + MVO
+            save_two_view_viz=save_two_view_viz,
+            pose_angular_error_thresh=pose_angular_error_thresh,
+            output_worker=output_worker,
+        )
+        self.geometry_transformer = geometry_transformer or VggtOmegaGeometryTransformer()
+        self.ba_options = ba_options or BundleAdjustmentOptions()
+        self._pre_ba_max_reproj_error = pre_ba_max_reproj_error
+        self._post_ba_max_reproj_error = post_ba_max_reproj_error
+        self._drop_camera_with_no_track = drop_camera_with_no_track
+        self._min_track_length = min_track_length
+        self._metric_constructed_only = metric_constructed_only
+        self._seed = seed
+
+        if model_cache_key is False:
+            self._model_cache_key: Hashable | None = None
+        elif model_cache_key is None:
+            self._model_cache_key = "default_vggt_omega_loader"
+        else:
+            self._model_cache_key = model_cache_key
+
+    def __repr__(self) -> str:
+        components = [
+            f"correspondence_generator={self.correspondence_generator}",
+            f"two_view_estimator={self.two_view_estimator}",
+            f"ba_options={self.ba_options}",
+        ]
+        return "ClusterVGGTOmegaWithFrontend(\n  " + ",\n  ".join(components) + "\n)"
+
+    @staticmethod
+    def get_ui_metadata() -> UiMetadata:
+        return UiMetadata(
+            display_name="VGGT Omega + Frontend",
+            input_products=("Key Images",),
+            output_products=("VGGT Omega Reconstruction",),
+            parent_plate="Cluster Optimizer",
+        )
+
+    def create_computation_graph(self, context: ClusterContext) -> ClusterComputationGraph | None:
+        keys = sorted(visibility_graph_keys(context.visibility_graph))
+        if not keys:
+            return None
+
+        global_indices = tuple(int(idx) for idx in keys)
+        image_filenames = context.loader.image_filenames()
+
+        # Traditional frontend.
+        frontend_graphs = self._build_frontend_graphs(context)
+        io_tasks, metrics = self._build_frontend_output_graphs(context, frontend_graphs)
+
+        # VGGT Omega geometry prediction → cameras + dense 3D points.
+        image_batch_graph, original_coords_graph = delayed(_load_vggt_omega_inputs, nout=2)(
+            context.loader,
+            global_indices,
+        )
+        vggt_omega_result_graph = delayed(_run_vggt_omega_geometry)(
+            image_batch_graph,
+            original_coords_graph,
+            transformer=self.geometry_transformer,
+            image_indices=global_indices,
+            seed=self._seed,
+            model_cache_key=self._model_cache_key,
+            cluster_label=context.label,
+        )
+
+        # 3. 2D tracks from frontend correspondences.
+        v_corr_idxs_graph = delayed(_extract_v_corr_idxs)(frontend_graphs.two_view_results)
+        tracks_2d_graph = delayed(get_2d_tracks)(v_corr_idxs_graph, frontend_graphs.padded_keypoints)
+
+        # 4. Original image shapes (needed to map frontend pixel coords → VGGT Omega pixel coords).
+        image_shapes_graph = delayed(_get_image_shapes)(context.loader, global_indices)
+
+        # 5. Build GtsfmData: lift 2D tracks to 3D using VGGT depth map.
+        ba_input_graph = delayed(_build_gtsfm_data_from_vggt_omega_depth)(
+            vggt_omega_result_graph,
+            tracks_2d_graph,
+            image_shapes=image_shapes_graph,
+            image_indices=global_indices,
+            num_images=context.num_images,
+            min_track_length=self._min_track_length,
+        )
+
+        # 6. Cluster-level BA.
+        ba_result_graph, pre_ba_result_graph = delayed(_run_cluster_ba, nout=2)(
+            ba_input_graph,
+            ba_options=self.ba_options,
+            pre_ba_max_reproj_error=self._pre_ba_max_reproj_error,
+            post_ba_max_reproj_error=self._post_ba_max_reproj_error,
+            drop_camera_with_no_track=self._drop_camera_with_no_track,
+            min_track_length=self._min_track_length,
+            cluster_label=context.label,
+        )
+
+        # 7. Metrics + I/O.
+        cameras_gt = [context.one_view_data_dict[idx].camera_gt for idx in range(context.num_images)]
+        metrics.append(
+            delayed(_aggregate_vggt_metrics)(
+                ba_result_graph,
+                cameras_gt=cameras_gt,
+                pre_ba_result=pre_ba_result_graph,
+                save_dir=str(context.output_paths.metrics),
+                metric_constructed_only=self._metric_constructed_only,
+            )
+        )
+        with self._output_annotation():
+            io_tasks.append(delayed(_save_reconstruction_as_text)(ba_result_graph, context.output_paths.results))
+            io_tasks.append(
+                delayed(_save_pre_ba_reconstruction_as_text)(pre_ba_result_graph, context.output_paths.results)
+            )
+
+        return ClusterComputationGraph(
+            io_tasks=tuple(io_tasks),
+            metric_tasks=tuple(metrics),
+            sfm_result=ba_result_graph,
+        )

--- a/gtsfm/configs/vggt_omega_sift_frontend_megaloc_phototourism.yaml
+++ b/gtsfm/configs/vggt_omega_sift_frontend_megaloc_phototourism.yaml
@@ -1,0 +1,128 @@
+# VGGT-Omega-with-frontend configuration.
+# Poses from VGGT Omega geometry; 2D tracks from the SIFT frontend.
+# 3D points are depth-lifted from VGGT Omega dense predictions, then refined by cluster BA.
+
+# @package _global_
+_target_: gtsfm.scene_optimizer.SceneOptimizer
+
+loader:
+  _target_: gtsfm.loader.Olsson
+  dataset_dir: ??? # Required: set to the dataset root on the command line.
+  images_dir: null
+  max_resolution: 760
+
+image_pairs_generator:
+  _target_: gtsfm.retriever.image_pairs_generator.ImagePairsGenerator
+  global_descriptor:
+    _target_: gtsfm.frontend.cacher.global_descriptor_cacher.GlobalDescriptorCacher
+    global_descriptor_obj:
+      _target_: gtsfm.frontend.global_descriptor.MegaLoc
+  retriever:
+    _target_: gtsfm.retriever.Similarity
+    num_matched: 15
+    min_score: 0.3
+  batch_size: 16
+
+graph_partitioner:
+  _target_: gtsfm.graph_partitioner.Metis
+  min_cameras_to_partition: 12
+  max_cameras: 40
+  split_oversized_nodes: true
+
+cluster_optimizer:
+  _target_: gtsfm.cluster_optimizer.Cacher
+  optimizer:
+    _target_: gtsfm.cluster_optimizer.VggtOmegaWithFrontend
+
+    correspondence_generator:
+      _target_: gtsfm.frontend.correspondence_generator.det_desc_correspondence_generator.DetDescCorrespondenceGenerator
+      detector_descriptor:
+        _target_: gtsfm.frontend.cacher.detector_descriptor_cacher.DetectorDescriptorCacher
+        detector_descriptor_obj:
+          _target_: gtsfm.frontend.detector_descriptor.colmap_sift.ColmapSIFTDetectorDescriptor
+          max_keypoints: 3000
+
+      matcher:
+        _target_: gtsfm.frontend.cacher.matcher_cacher.MatcherCacher
+        matcher_obj:
+          _target_: gtsfm.frontend.matcher.twoway_matcher.TwoWayMatcher
+          ratio_test_threshold: 0.8
+
+    two_view_estimator:
+      _target_: gtsfm.two_view_estimator_cacher.TwoViewEstimatorCacher
+      two_view_estimator_obj:
+        _target_: gtsfm.two_view_estimator.TwoViewEstimator
+        bundle_adjust_2view: True
+        eval_threshold_px: 4 # in px
+        ba_reproj_error_thresholds: [0.5]
+        bundle_adjust_2view_maxiters: 100
+
+        verifier:
+          _target_: gtsfm.frontend.verifier.ransac.Ransac
+          use_intrinsics_in_verification: True
+          estimation_threshold_px: 4 # for H/E/F estimators
+
+        triangulation_options:
+          _target_: gtsfm.data_association.point3d_initializer.TriangulationOptions
+          reproj_error_threshold: 100.0
+          mode:
+            _target_: gtsfm.data_association.point3d_initializer.TriangulationSamplingMode
+            value: NO_RANSAC
+
+        inlier_support_processor:
+          _target_: gtsfm.two_view_estimator.InlierSupportProcessor
+          min_num_inliers_est_model: 15
+          min_inlier_ratio_est_model: 0.1
+
+    geometry_transformer:
+      _target_: gtsfm.frontend.vggt_omega_geometry_transformer.VggtOmegaGeometryTransformer
+
+    ba_options:
+      _target_: gtsfm.bundle.bundle_adjustment.BundleAdjustmentOptions
+      shared_calib: false
+      use_calibration_prior: true
+      use_pose_prior_all_cameras: true
+      use_gnc: true
+      gnc_loss: TLS
+      factor_weight_outlier_threshold: 1e-6
+
+    pre_ba_max_reproj_error: 14.0
+    post_ba_max_reproj_error: 3.0
+    drop_camera_with_no_track: false
+    min_track_length: 3
+    seed: 42
+    model_cache_key: null
+    metric_constructed_only: false
+
+# --- Merging options ---
+merging_options:
+  _target_: gtsfm.cluster_merging.MergingOptions
+  run_bundle_adjustment: true
+  merge_duplicate_tracks: true
+  drop_child_if_merging_fail: true
+  drop_outlier_after_camera_merging: true
+  drop_camera_with_no_track: false
+  keep_all_cameras: false
+  plot_reprojection_histograms: true
+  use_nonlinear_sim3_alignment: true
+  max_track_correspondences_for_sim3: 150
+  scale_and_average_focal_length: false
+  pre_ba_max_reproj_error: 14.0
+  pre_ba_min_track_length: 3
+  post_ba_max_reproj_error: 3.0
+  min_track_length: 3
+  allow_post_ba_reproj_filtering: true
+  metric_constructed_only: true
+  ba_options:
+    _target_: gtsfm.bundle.bundle_adjustment.BundleAdjustmentOptions
+    shared_calib: false
+    use_calibration_prior: true
+    use_pose_prior_all_cameras: true
+    use_gnc: false
+    gnc_loss: TLS
+    factor_weight_outlier_threshold: 1e-6
+
+# --- Bridge params ---
+bridge_min_similarity: 0.0
+bridge_top_k: 10
+bridge_min_component_size: 3

--- a/gtsfm/frontend/vggt_omega_geometry_transformer.py
+++ b/gtsfm/frontend/vggt_omega_geometry_transformer.py
@@ -213,7 +213,7 @@ def resolve_weights_path(weights_path: PathLike | None = None) -> Path:
     checkpoint = Path(weights_path) if weights_path is not None else DEFAULT_WEIGHTS_PATH
     if not checkpoint.exists():
         raise FileNotFoundError(
-            f"VGGT Omega checkpoint not found at {checkpoint}. Download weights via `scripts/download_model_weights.sh`."
+            f"VGGT Omega weights not found at {checkpoint}. Download weights via `scripts/download_model_weights.sh`."
         )
     return checkpoint
 

--- a/gtsfm/frontend/vggt_omega_geometry_transformer.py
+++ b/gtsfm/frontend/vggt_omega_geometry_transformer.py
@@ -1,0 +1,317 @@
+"""VGGT Omega implementation of the GeometryTransformer abstraction."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, List, Optional, Union
+
+import numpy as np
+import torch
+from PIL import Image as PILImage
+from torchvision import transforms as TF
+
+from gtsfm.frontend.geometry_transformer import GeometryTransformer, GeometryTransformerOutput
+from gtsfm.utils import logger as logger_utils
+from gtsfm.utils import torch as torch_utils
+
+PathLike = Union[str, Path]
+
+logger = logger_utils.get_logger()
+
+# ---------------------------------------------------------------------------
+# Submodule / path management
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+THIRDPARTY_ROOT = REPO_ROOT / "thirdparty"
+VGGT_OMEGA_SUBMODULE_PATH = THIRDPARTY_ROOT / "vggt-omega"
+DEFAULT_WEIGHTS_PATH = VGGT_OMEGA_SUBMODULE_PATH / "weights" / "vggt_omega_1b_512.pt"
+
+
+def _ensure_submodule_on_path(path: Path, name: str) -> None:
+    """Add a vendored thirdparty module to ``sys.path`` if needed."""
+    if not path.exists():
+        raise ImportError(
+            f"Required submodule '{name}' not found at {path}. "
+            "Run 'git submodule update --init --recursive' to fetch it."
+        )
+    path_str = str(path)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)
+
+
+_ensure_submodule_on_path(VGGT_OMEGA_SUBMODULE_PATH, "vggt_omega")
+
+
+def unproject_depth_map_to_point_map(depth_map: np.ndarray, extrinsic: np.ndarray, intrinsic: np.ndarray) -> np.ndarray:
+    depth = depth_map[..., 0]
+    num_frames, height, width = depth.shape
+
+    y, x = np.meshgrid(np.arange(height), np.arange(width), indexing="ij")
+    x = np.broadcast_to(x[None], (num_frames, height, width))
+    y = np.broadcast_to(y[None], (num_frames, height, width))
+
+    fx = intrinsic[:, 0, 0][:, None, None]
+    fy = intrinsic[:, 1, 1][:, None, None]
+    cx = intrinsic[:, 0, 2][:, None, None]
+    cy = intrinsic[:, 1, 2][:, None, None]
+
+    camera_points = np.stack(
+        [
+            (x - cx) / fx * depth,
+            (y - cy) / fy * depth,
+            depth,
+        ],
+        axis=-1,
+    )
+
+    rotation = extrinsic[:, :3, :3]
+    translation = extrinsic[:, :3, 3]
+    points3d: np.ndarray = np.einsum(
+        "sij,shwj->shwi",
+        np.transpose(rotation, (0, 2, 1)),
+        camera_points - translation[:, None, None, :],
+    )
+    return points3d
+
+
+from vggt_omega.models import VGGTOmega
+from vggt_omega.utils.pose_enc import encoding_to_camera
+
+# ---------------------------------------------------------------------------
+# Image loading
+# ---------------------------------------------------------------------------
+
+DEFAULT_FIXED_RESOLUTION_VGGT_OMEGA = 512
+
+
+def load_image_batch_vggt_omega_loader(
+    loader,
+    indices: List[int],
+    mode: str = "balanced",
+    image_resolution: int = DEFAULT_FIXED_RESOLUTION_VGGT_OMEGA,
+    patch_size: int = 16,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Load loader-resized images and preprocess them for VGGT-Omega.
+
+    ``original_coords`` maps pixels from ``loader.get_image()`` into the final
+    padded Omega tensor. Each row is ``[left, top, right, bottom, scaled_w,
+    scaled_h]`` and can be used as::
+
+        u_omega = u_loader * scaled_w / loader_w - left
+        v_omega = v_loader * scaled_h / loader_h - top
+
+    Args:
+        loader: Loader instance providing ``get_image``.
+        indices: List of image indices to load.
+        mode: ``balanced` keeps the total token count close to image_resolution**2.
+            `max_size` resizes the longest side to image_resolution.
+        image_resolution: Vggt-Omega preprocessing resolution.
+        patch_size: Vggt-Omega image patch size.
+
+    Returns:
+        Batched images shaped ``(N, 3, H, W)`` and coordinates shaped ``(N, 6)``.
+    """
+    # checks from vggt-omega
+    if mode not in ("balanced", "max_size"):
+        raise ValueError("Mode must be either 'balanced' or 'max_size'")
+    if image_resolution <= 0:
+        raise ValueError("image_resolution must be positive")
+    if patch_size <= 0:
+        raise ValueError("patch_size must be positive")
+    if image_resolution % patch_size != 0:
+        raise ValueError("image_resolution must be divisible by patch_size")
+
+    images: list[torch.Tensor] = []
+    transforms: list[tuple[int, int, int, int, int, int, int, int]] = []
+    to_tensor = TF.ToTensor()
+
+    for idx in indices:
+        image = PILImage.fromarray(loader.get_image(idx).value_array).convert("RGB")
+        loader_w, loader_h = image.size
+
+        crop_x = 0
+        crop_y = 0
+        crop_w = loader_w
+        crop_h = loader_h
+        aspect_ratio = loader_h / max(loader_w, 1)
+        if aspect_ratio < 0.5:
+            crop_w = min(loader_w, max(1, int(round(loader_h / 0.5))))
+            crop_x = max((loader_w - crop_w) // 2, 0)
+        elif aspect_ratio > 2.0:
+            crop_h = min(loader_h, max(1, int(round(loader_w * 2.0))))
+            crop_y = max((loader_h - crop_h) // 2, 0)
+
+        image = image.crop((crop_x, crop_y, crop_x + crop_w, crop_y + crop_h))
+        cropped_aspect_ratio = crop_h / max(crop_w, 1)
+
+        if mode == "balanced":
+            num_patches = (image_resolution // patch_size) ** 2
+            width_patches = max(1, int(np.round(np.sqrt(num_patches / cropped_aspect_ratio))))
+            height_patches = max(1, int(np.round(num_patches / np.sqrt(num_patches / cropped_aspect_ratio))))
+            target_w = width_patches * patch_size
+            target_h = height_patches * patch_size
+        elif cropped_aspect_ratio >= 1.0:
+            target_h = image_resolution
+            target_w = max(
+                patch_size,
+                int(np.round((image_resolution / cropped_aspect_ratio) / patch_size)) * patch_size,
+            )
+        else:
+            target_w = image_resolution
+            target_h = max(
+                patch_size,
+                int(np.round((image_resolution * cropped_aspect_ratio) / patch_size)) * patch_size,
+            )
+
+        image = image.resize((target_w, target_h), PILImage.Resampling.BICUBIC)
+        images.append(to_tensor(image))
+        transforms.append((loader_w, loader_h, crop_x, crop_y, crop_w, crop_h, target_w, target_h))
+
+    batch_h = max(image.shape[1] for image in images)
+    batch_w = max(image.shape[2] for image in images)
+    padded_images: list[torch.Tensor] = []
+    original_coords: list[list[float]] = []
+
+    for image, transform in zip(images, transforms):
+        loader_w, loader_h, crop_x, crop_y, crop_w, crop_h, target_w, target_h = transform
+        pad_left = (batch_w - target_w) // 2
+        pad_right = batch_w - target_w - pad_left
+        pad_top = (batch_h - target_h) // 2
+        pad_bottom = batch_h - target_h - pad_top
+        padded_images.append(
+            torch.nn.functional.pad(
+                image,
+                (pad_left, pad_right, pad_top, pad_bottom),
+                mode="constant",
+                value=1.0,
+            )
+        )
+
+        resize_x = target_w / crop_w
+        resize_y = target_h / crop_h
+        scaled_w = loader_w * resize_x
+        scaled_h = loader_h * resize_y
+
+        # this is because the existing frontend expects u_omega = u_loader * resize_x - left
+        # and natural mapping for this transform is u_omega = (u_loader - crop_x) * resize_x + pad_left
+        left = crop_x * resize_x - pad_left
+        top = crop_y * resize_y - pad_top
+        original_coords.append([left, top, left + batch_w, top + batch_h, scaled_w, scaled_h])
+
+    return torch.stack(padded_images), torch.tensor(original_coords, dtype=torch.float32)
+
+
+# ---------------------------------------------------------------------------
+# Model loading
+# ---------------------------------------------------------------------------
+
+
+def resolve_weights_path(weights_path: PathLike | None = None) -> Path:
+    """Return a concrete path to the VGGT Omega checkpoint, validating that it exists."""
+    checkpoint = Path(weights_path) if weights_path is not None else DEFAULT_WEIGHTS_PATH
+    if not checkpoint.exists():
+        raise FileNotFoundError(
+            f"VGGT Omega checkpoint not found at {checkpoint}. Download weights via `scripts/download_model_weights.sh`."
+        )
+    return checkpoint
+
+
+def load_model(
+    device: torch.device,
+):
+    """Load the VGGT Omega model weights on the requested device."""
+    if device.type != "cuda":
+        raise RuntimeError("VGGT-Omega requires CUDA.")
+    checkpoint = resolve_weights_path(DEFAULT_WEIGHTS_PATH)
+    model = VGGTOmega()
+    model.load_state_dict(torch.load(checkpoint, map_location="cpu"))
+
+    model.eval()
+    model.to(device)
+    return model
+
+
+# ---------------------------------------------------------------------------
+# VggtOmegaGeometryTransformer
+# ---------------------------------------------------------------------------
+
+
+class VggtOmegaGeometryTransformer(GeometryTransformer):
+    """Runs VGGT Omega model inference to predict poses, depths, and dense points."""
+
+    def __init__(self):
+        self.resolved_dtype = torch.float32
+
+    def predict(
+        self,
+        images: torch.Tensor,
+        *,
+        model: Optional[VGGTOmega] = None,
+        **kwargs: Any,
+    ) -> GeometryTransformerOutput:
+        """Run VGGT Omega forward pass and return unified output.
+
+        Args:
+            images: Tensor shaped ``(N, 3, H, W)``.
+
+        Returns:
+            class:`GeometryTransformerOutput` with poses, depths, and dense points.
+        """
+        self.resolved_device = torch_utils.default_device()
+        images = images.to(self.resolved_device, dtype=self.resolved_dtype)
+        if model is None:
+            model = load_model(self.resolved_device)
+        else:
+            model = model.to(self.resolved_device)
+            assert model is not None
+            model.eval()
+
+        with torch.inference_mode():
+            predictions = model(images)
+
+        extrinsics, intrinsics = encoding_to_camera(
+            predictions["pose_enc"],
+            predictions["images"].shape[-2:],
+        )
+
+        depth = predictions["depth"]
+        depth_conf = predictions["depth_conf"]
+
+        dense_points = unproject_depth_map_to_point_map(
+            depth.squeeze(0).detach().float().cpu().numpy(),
+            extrinsics.squeeze(0).detach().float().cpu().numpy(),
+            intrinsics.squeeze(0).detach().float().cpu().numpy(),
+        )
+
+        return GeometryTransformerOutput(
+            device=self.resolved_device,
+            dtype=self.resolved_dtype,
+            images=images,
+            extrinsic=extrinsics.squeeze(0),
+            intrinsic=intrinsics.squeeze(0),
+            depth_map=depth.squeeze(0).squeeze(-1),
+            depth_confidence=depth_conf.squeeze(0),
+            dense_points=torch.from_numpy(dense_points).to(
+                self.resolved_device,
+                dtype=self.resolved_dtype,
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+__all__ = [
+    "DEFAULT_WEIGHTS_PATH",
+    "REPO_ROOT",
+    "THIRDPARTY_ROOT",
+    "VGGT_OMEGA_SUBMODULE_PATH",
+    "VggtOmegaGeometryTransformer",
+    "_ensure_submodule_on_path",
+    "load_image_batch_vggt_omega_loader",
+    "load_model",
+    "resolve_weights_path",
+]

--- a/gtsfm/utils/torch.py
+++ b/gtsfm/utils/torch.py
@@ -62,7 +62,7 @@ def cal3_bundler_from_intrinsic(matrix: np.ndarray, crop_coords) -> gtsam.Cal3Bu
 
 
 def cal3ds2_from_intrinsic(matrix: np.ndarray, crop_coords) -> gtsam.Cal3_S2:
-    """Map a 3x3 intrinsic matrix to a Cal3_S2."""
+    """Map a 3x3 intrinsic matrix to a Cal3DS2."""
     fx = float(matrix[0, 0])
     fy = float(matrix[1, 1])
     cx = float(matrix[0, 2])

--- a/scripts/download_model_weights.sh
+++ b/scripts/download_model_weights.sh
@@ -1,5 +1,45 @@
 
 # Download model weights for different modules available for use in GTSFM
+
+help() {
+    cat <<EOF
+A minimalistic script to download weights for required models. VGGT-Omega weights cannot be distributed
+under their license. First get access to the model checkpoints and then the following flag is required.
+--hf_token, followed by the hugging face token with checkpoint access.
+If no hf_token is passed then other weights are downloaded normally except VGGT-Omega.
+Usage:
+  bash scripts/download_model_weights.sh
+  bash scripts/download_model_weights.sh --hf_token <token>
+EOF
+    exit 0
+}
+
+case "$#" in
+    0)
+        HF_TOKEN=""
+        ;;
+    1)
+        if [[ "$1" == "--help" ]]; then
+            help
+        else
+            echo "Invalid argument"
+            exit 1
+        fi
+        ;;
+    2)
+        if [[ "$1" == "--hf_token" ]]; then
+            HF_TOKEN="$2"
+        else
+            echo "Invalid argument"
+            exit 1
+        fi
+        ;;
+    *)
+        echo "Invalid number of arguments. Check --help"
+        exit 1
+        ;;
+esac
+
 # Note: SuperPoint and SuperGlue code and checkpoints may *not* be used for commercial purposes
 
 #################### SuperPoint & SuperGlue ##########################
@@ -45,11 +85,22 @@ wget $D2NET_CKPT_URL -O $D2NET_WEIGHTS_DIR/d2_tf.pth
 
 NETVLAD_WEIGHTS_DIR="./thirdparty/hloc/weights"
 NETVLAD_CKPT_URL="https://github.com/johnwlambert/gtsfm-datasets-mirror/releases/download/gerrard-hall-100/VGG16-NetVLAD-Pitts30K.mat"
-mkdir $NETVLAD_WEIGHTS_DIR
+mkdir -p $NETVLAD_WEIGHTS_DIR
 wget $NETVLAD_CKPT_URL -O $NETVLAD_WEIGHTS_DIR/VGG16-NetVLAD-Pitts30K.mat
 
 ##################### vggt #############################
 VGGT_WEIGHTS_DIR="./thirdparty/vggt/weights"
 VGGT_CKPT_URL="https://huggingface.co/facebook/VGGT-1B/resolve/main/model.pt"
-mkdir $VGGT_WEIGHTS_DIR
+mkdir -p $VGGT_WEIGHTS_DIR
 wget $VGGT_CKPT_URL -O $VGGT_WEIGHTS_DIR/model.pt
+
+##################### vggt-omega #############################
+if [[ -z "$HF_TOKEN" ]]; then
+    echo "Hugging Face token not provided; skipping VGGT-Omega weights."
+else
+    VGGT_OMEGA_WEIGHTS_DIR="./thirdparty/vggt-omega/weights"
+    mkdir -p $VGGT_OMEGA_WEIGHTS_DIR
+    hf download facebook/VGGT-Omega vggt_omega_1b_512.pt \
+    --token "$HF_TOKEN" \
+    --local-dir "$VGGT_OMEGA_WEIGHTS_DIR"
+fi


### PR DESCRIPTION
This PR adds the VGGT-Omega backend to the GTSfM pipeline.
Since the VGGT-Omega weights are protected under a license and cannot be distributed, the user needs to get access to the model and then download the weights using their `hf_token `using `scripts/download_weights.sh --hf_token <your hf_token>`

Since the VGGT-Omega poses can be considered accurate, we add a factor to the prior camera poses. (can be experimented with)
We also set the camera type to Cal3DS2 to incorporate different focal lengths (fx and fy) and include distortion parameters.