### PR TITLE
Integrate VGGT-Omega as a geometry transformer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "thirdparty/FastVGGT"]
 	path = thirdparty/FastVGGT
 	url = https://github.com/mystorm16/FastVGGT.git
+[submodule "thirdparty/vggt-omega"]
+	path = thirdparty/vggt-omega
+	url = https://github.com/facebookresearch/vggt-omega.git

--- a/gtsfm/cluster_optimizer/cluster_vggt.py
+++ b/gtsfm/cluster_optimizer/cluster_vggt.py
@@ -112,12 +112,22 @@ def _load_vggt_inputs(
     indices: list[int],
     mode: str,
     *,
+    transformer=None,
     save_processed_image: bool = False,
     output_root: Optional[str] = None,
     image_names: Optional[tuple[str, ...]] = None,
 ):
-    """Load and preprocess a batch of images for VGGT."""
-    image_batch, original_coords = load_image_batch_vggt_loader(loader, indices, mode=mode)
+    """Load and preprocess a batch of images for the geometry model.
+
+    Preprocessing follows the geometry transformer: VGGT and VGGT-Omega differ in resolution, patch
+    alignment and cropping, and the per-pixel depth lookup downstream indexes the model's depth map via
+    the ``original_coords`` returned here — so the loader must match the model. ``transformer=None``
+    keeps the legacy VGGT loader.
+    """
+    if transformer is not None:
+        image_batch, original_coords = transformer.load_image_batch(loader, indices, mode=mode)
+    else:
+        image_batch, original_coords = load_image_batch_vggt_loader(loader, indices, mode=mode)
     if not save_processed_image or output_root is None or image_names is None:
         return image_batch, original_coords
     if len(image_names) != image_batch.shape[0]:
@@ -156,6 +166,39 @@ def _load_vggt_inputs(
         comments="",
     )
     return image_batch, original_coords
+
+
+def _model_loading_plan(
+    transformer: Any, weights_path: Optional[Path], model_cache_key: Hashable | bool | None
+) -> tuple[dict[str, Any], Hashable | None]:
+    """Decide how a cluster optimizer's geometry model is loaded on workers.
+
+    Transformers that expose a ``config`` (the VGGT family) are loaded through the shared VGGT loader
+    and cached under a key derived from the weights path and model kwargs. Transformers without a
+    ``config`` (e.g. VGGT-Omega) manage their own model inside ``predict``: they get no loader kwargs
+    and NO shared cache key — a cache key would make ``_resolve_vggt_model`` hand them a cached *VGGT*
+    model.
+
+    Returns:
+        ``(loader_kwargs, cache_key)`` to store on the optimizer.
+    """
+    config = getattr(transformer, "config", None)
+    if config is None:
+        return {}, None
+
+    loader_kwargs: dict[str, Any] = {}
+    if weights_path is not None:
+        loader_kwargs["weights_path"] = weights_path
+    model_kwargs = config.model_ctor_kwargs
+    if model_kwargs:
+        loader_kwargs["model_kwargs"] = model_kwargs
+
+    if model_cache_key is False:
+        return loader_kwargs, None
+    if model_cache_key is None:
+        kwargs_key = tuple(sorted((k, repr(v)) for k, v in model_kwargs.items())) if model_kwargs else None
+        return loader_kwargs, ("default_vggt_loader", weights_path, kwargs_key)
+    return loader_kwargs, model_cache_key
 
 
 def _resolve_vggt_model(cache_key: Hashable | None, loader_kwargs: dict[str, Any] | None) -> Any | None:
@@ -403,28 +446,14 @@ class ClusterVGGT(ClusterOptimizerBase):
         self._drop_camera_with_no_track = drop_camera_with_no_track
 
         # --- Model caching ---
-        self._loader_kwargs: dict[str, Any] = {}
-        if self._weights_path is not None:
-            self._loader_kwargs["weights_path"] = self._weights_path
-        model_kwargs = self.geometry_transformer.config.model_ctor_kwargs
-        if model_kwargs:
-            self._loader_kwargs["model_kwargs"] = model_kwargs
-
-        if model_cache_key is False:
-            self._model_cache_key: Hashable | None = None
-        elif model_cache_key is None:
-            kwargs_key = (
-                tuple(sorted((k, repr(v)) for k, v in model_kwargs.items()))
-                if model_kwargs
-                else None
-            )
-            self._model_cache_key = ("default_vggt_loader", self._weights_path, kwargs_key)
-        else:
-            self._model_cache_key = model_cache_key
+        self._loader_kwargs, self._model_cache_key = _model_loading_plan(
+            self.geometry_transformer, self._weights_path, model_cache_key
+        )
 
     def __repr__(self) -> str:
         components = [
-            f"geometry_transformer={self.geometry_transformer.config}",
+            f"geometry_transformer="
+            f"{getattr(self.geometry_transformer, 'config', None) or type(self.geometry_transformer).__name__}",
             f"tracker={self.tracker.config}",
             f"ba_options={self.ba_options}",
             f"weights_path={self._weights_path}",
@@ -463,6 +492,7 @@ class ClusterVGGT(ClusterOptimizerBase):
             context.loader,
             global_indices,
             mode=self._input_mode,
+            transformer=self.geometry_transformer,
             save_processed_image=self._save_processed_image,
             output_root=str(context.output_paths.results),
             image_names=image_names,

--- a/gtsfm/cluster_optimizer/cluster_vggt_with_frontend.py
+++ b/gtsfm/cluster_optimizer/cluster_vggt_with_frontend.py
@@ -17,6 +17,7 @@ from gtsfm.cluster_optimizer.cluster_optimizer_base import ClusterComputationGra
 from gtsfm.cluster_optimizer.cluster_vggt import (
     _aggregate_vggt_metrics,
     _load_vggt_inputs,
+    _model_loading_plan,
     _resolve_vggt_model,
     _run_cluster_ba,
     _save_pre_ba_reconstruction_as_text,
@@ -270,26 +271,18 @@ class ClusterVGGTWithFrontend(ClusterMVO):
         self._seed = seed
 
         self._weights_path = Path(weights_path) if weights_path is not None else None
-        self._loader_kwargs: dict[str, Any] = {}
-        if self._weights_path is not None:
-            self._loader_kwargs["weights_path"] = self._weights_path
-        model_kwargs = self.geometry_transformer.config.model_ctor_kwargs
-        if model_kwargs:
-            self._loader_kwargs["model_kwargs"] = model_kwargs
-
-        if model_cache_key is False:
-            self._model_cache_key: Hashable | None = None
-        elif model_cache_key is None:
-            kwargs_key = tuple(sorted((k, repr(v)) for k, v in model_kwargs.items())) if model_kwargs else None
-            self._model_cache_key = ("default_vggt_loader", self._weights_path, kwargs_key)
-        else:
-            self._model_cache_key = model_cache_key
+        self._loader_kwargs, self._model_cache_key = _model_loading_plan(
+            self.geometry_transformer, self._weights_path, model_cache_key
+        )
 
     def __repr__(self) -> str:
         components = [
             f"correspondence_generator={self.correspondence_generator}",
             f"two_view_estimator={self.two_view_estimator}",
-            f"geometry_transformer={self.geometry_transformer.config}",
+            # Transformers without a `config` (e.g. VggtOmegaGeometryTransformer) contribute their class
+            # name to the cache key instead — stable across runs and distinct from any VGGT config repr.
+            f"geometry_transformer="
+            f"{getattr(self.geometry_transformer, 'config', None) or type(self.geometry_transformer).__name__}",
             f"ba_options={self.ba_options}",
         ]
         return "ClusterVGGTWithFrontend(\n  " + ",\n  ".join(components) + "\n)"
@@ -321,6 +314,7 @@ class ClusterVGGTWithFrontend(ClusterMVO):
             context.loader,
             global_indices,
             mode=self._input_mode,
+            transformer=self.geometry_transformer,
             output_root=str(context.output_paths.results),
             image_names=image_names,
         )

--- a/gtsfm/configs/vggt_omega_sift_frontend_megaloc_phototourism.yaml
+++ b/gtsfm/configs/vggt_omega_sift_frontend_megaloc_phototourism.yaml
@@ -1,0 +1,134 @@
+# VGGT-Omega-with-frontend configuration.
+# Identical to vggt_sift_frontend_megaloc_phototourism.yaml except for the geometry model: VGGT-Omega
+# runs through the same ClusterVGGTWithFrontend via the injected geometry_transformer, so the two configs
+# form a controlled A/B of the per-cluster geometry model.
+#
+# VGGT-Omega weights are gated (CC-BY-NC-4.0, non-redistributable) and CUDA-only:
+#   git submodule update --init thirdparty/vggt-omega
+#   bash scripts/download_model_weights.sh --hf_token <token>
+
+# @package _global_
+_target_: gtsfm.scene_optimizer.SceneOptimizer
+
+loader:
+  _target_: gtsfm.loader.Olsson
+  dataset_dir: ??? # Required: set to the dataset root on the command line.
+  images_dir: null
+  max_resolution: 760 # Source resolution for the frontend; omega resizes to 512 internally.
+
+image_pairs_generator:
+  _target_: gtsfm.retriever.image_pairs_generator.ImagePairsGenerator
+  global_descriptor:
+    _target_: gtsfm.frontend.cacher.global_descriptor_cacher.GlobalDescriptorCacher
+    global_descriptor_obj:
+      _target_: gtsfm.frontend.global_descriptor.MegaLoc
+  retriever:
+    _target_: gtsfm.retriever.Similarity
+    num_matched: 15
+    min_score: 0.5
+  batch_size: 16
+
+graph_partitioner:
+  _target_: gtsfm.graph_partitioner.Metis
+  min_cameras_to_partition: 12
+  max_cameras: 40
+  split_oversized_nodes: true
+
+cluster_optimizer:
+  _target_: gtsfm.cluster_optimizer.Cacher
+  optimizer:
+    _target_: gtsfm.cluster_optimizer.VggtWithFrontend
+
+    correspondence_generator:
+      _target_: gtsfm.frontend.correspondence_generator.det_desc_correspondence_generator.DetDescCorrespondenceGenerator
+      detector_descriptor:
+        _target_: gtsfm.frontend.cacher.detector_descriptor_cacher.DetectorDescriptorCacher
+        detector_descriptor_obj:
+          _target_: gtsfm.frontend.detector_descriptor.sift.SIFTDetectorDescriptor
+          max_keypoints: 5000
+
+      matcher:
+        _target_: gtsfm.frontend.cacher.matcher_cacher.MatcherCacher
+        matcher_obj:
+          _target_: gtsfm.frontend.matcher.twoway_matcher.TwoWayMatcher
+          ratio_test_threshold: 0.8
+
+    two_view_estimator:
+      _target_: gtsfm.two_view_estimator_cacher.TwoViewEstimatorCacher
+      two_view_estimator_obj:
+        _target_: gtsfm.two_view_estimator.TwoViewEstimator
+        bundle_adjust_2view: True
+        eval_threshold_px: 4 # in px
+        ba_reproj_error_thresholds: [0.5]
+        bundle_adjust_2view_maxiters: 100
+
+        verifier:
+          _target_: gtsfm.frontend.verifier.ransac.Ransac
+          use_intrinsics_in_verification: True
+          estimation_threshold_px: 4 # for H/E/F estimators
+
+        triangulation_options:
+          _target_: gtsfm.data_association.point3d_initializer.TriangulationOptions
+          reproj_error_threshold: 100.0
+          mode:
+            _target_: gtsfm.data_association.point3d_initializer.TriangulationSamplingMode
+            value: NO_RANSAC
+
+        inlier_support_processor:
+          _target_: gtsfm.two_view_estimator.InlierSupportProcessor
+          min_num_inliers_est_model: 15
+          min_inlier_ratio_est_model: 0.1
+
+    geometry_transformer:
+      # Omega preprocesses images itself (512px, 16-patch aligned); the optimizer's input_mode is ignored.
+      _target_: gtsfm.frontend.vggt_omega_geometry_transformer.VggtOmegaGeometryTransformer
+
+
+    ba_options:
+      _target_: gtsfm.bundle.bundle_adjustment.BundleAdjustmentOptions
+      shared_calib: false
+      use_calibration_prior: false
+      use_gnc: true
+      gnc_loss: TLS
+      factor_weight_outlier_threshold: 1e-6
+
+    pre_ba_max_reproj_error: 14.0
+    post_ba_max_reproj_error: 3.0
+    drop_camera_with_no_track: false
+    min_track_length: 3
+    input_mode: crop
+    seed: 42
+    model_cache_key: null
+
+# --- Merging options ---
+merging_options:
+  _target_: gtsfm.cluster_merging.MergingOptions
+  run_bundle_adjustment: true
+  merge_duplicate_tracks: true
+  drop_child_if_merging_fail: true
+  drop_outlier_after_camera_merging: true
+  drop_camera_with_no_track: false
+  keep_all_cameras: false
+  plot_reprojection_histograms: true
+  use_nonlinear_sim3_alignment: true
+  max_track_correspondences_for_sim3: 150
+  scale_and_average_focal_length: false
+  pre_ba_max_reproj_error: 14.0
+  pre_ba_min_track_length: 3
+  post_ba_max_reproj_error: 3.0
+  min_track_length: 3
+  allow_post_ba_reproj_filtering: true
+  metric_constructed_only: true
+  ba_options:
+    _target_: gtsfm.bundle.bundle_adjustment.BundleAdjustmentOptions
+    shared_calib: false
+    use_calibration_prior: false
+    use_pose_prior: true
+    use_gnc: false
+    gnc_loss: TLS
+    factor_weight_outlier_threshold: 1e-6
+
+# --- Bridge params ---
+bridge_min_similarity: 0.0
+bridge_top_k: 10
+bridge_min_component_size: 3

--- a/gtsfm/frontend/geometry_transformer.py
+++ b/gtsfm/frontend/geometry_transformer.py
@@ -64,3 +64,23 @@ class GeometryTransformer(abc.ABC):
         Returns:
             A :class:`GeometryTransformerOutput` containing poses, depths, points, etc.
         """
+
+    def load_image_batch(self, loader, indices, mode: str = "crop"):
+        """Load + preprocess a batch of images for this geometry model.
+
+        Image preprocessing (resolution, patch alignment, cropping) is model-specific, and the
+        per-pixel depth lookup downstream indexes the model's depth map using the ``original_coords``
+        returned here — so the loader MUST match the resolution the model outputs. The default is the
+        VGGT loader; models with different preprocessing (e.g. VGGT-Omega) override this.
+
+        Args:
+            loader: GTSFM loader providing ``get_image``.
+            indices: image indices to load.
+            mode: preprocessing mode (VGGT: ``crop``/``pad``). Implementations may ignore it.
+
+        Returns:
+            ``(image_batch, original_coords)`` — the padded image tensor and (N, 6) crop/pad metadata.
+        """
+        from gtsfm.frontend.vggt_geometry_transformer import load_image_batch_vggt_loader
+
+        return load_image_batch_vggt_loader(loader, indices, mode=mode)

--- a/gtsfm/frontend/vggt_omega_geometry_transformer.py
+++ b/gtsfm/frontend/vggt_omega_geometry_transformer.py
@@ -1,0 +1,347 @@
+"""VGGT Omega implementation of the GeometryTransformer abstraction."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, List, Optional, Union
+
+import numpy as np
+import torch
+from PIL import Image as PILImage
+from torchvision import transforms as TF
+
+from gtsfm.frontend.geometry_transformer import GeometryTransformer, GeometryTransformerOutput
+from gtsfm.utils import logger as logger_utils
+from gtsfm.utils import torch as torch_utils
+
+PathLike = Union[str, Path]
+
+logger = logger_utils.get_logger()
+
+# ---------------------------------------------------------------------------
+# Submodule / path management
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+THIRDPARTY_ROOT = REPO_ROOT / "thirdparty"
+VGGT_OMEGA_SUBMODULE_PATH = THIRDPARTY_ROOT / "vggt-omega"
+DEFAULT_WEIGHTS_PATH = VGGT_OMEGA_SUBMODULE_PATH / "weights" / "vggt_omega_1b_512.pt"
+
+
+def _ensure_submodule_on_path(path: Path, name: str) -> None:
+    """Add a vendored thirdparty module to ``sys.path`` if needed."""
+    if not path.exists():
+        raise ImportError(
+            f"Required submodule '{name}' not found at {path}. "
+            "Run 'git submodule update --init --recursive' to fetch it."
+        )
+    path_str = str(path)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)
+
+
+_ensure_submodule_on_path(VGGT_OMEGA_SUBMODULE_PATH, "vggt_omega")
+
+
+def unproject_depth_map_to_point_map(depth_map: np.ndarray, extrinsic: np.ndarray, intrinsic: np.ndarray) -> np.ndarray:
+    depth = depth_map[..., 0]
+    num_frames, height, width = depth.shape
+
+    y, x = np.meshgrid(np.arange(height), np.arange(width), indexing="ij")
+    x = np.broadcast_to(x[None], (num_frames, height, width))
+    y = np.broadcast_to(y[None], (num_frames, height, width))
+
+    fx = intrinsic[:, 0, 0][:, None, None]
+    fy = intrinsic[:, 1, 1][:, None, None]
+    cx = intrinsic[:, 0, 2][:, None, None]
+    cy = intrinsic[:, 1, 2][:, None, None]
+
+    camera_points = np.stack(
+        [
+            (x - cx) / fx * depth,
+            (y - cy) / fy * depth,
+            depth,
+        ],
+        axis=-1,
+    )
+
+    rotation = extrinsic[:, :3, :3]
+    translation = extrinsic[:, :3, 3]
+    points3d: np.ndarray = np.einsum(
+        "sij,shwj->shwi",
+        np.transpose(rotation, (0, 2, 1)),
+        camera_points - translation[:, None, None, :],
+    )
+    return points3d
+
+
+from vggt_omega.models import VGGTOmega
+from vggt_omega.utils.pose_enc import encoding_to_camera
+
+# ---------------------------------------------------------------------------
+# Image loading
+# ---------------------------------------------------------------------------
+
+DEFAULT_FIXED_RESOLUTION_VGGT_OMEGA = 512
+
+
+def load_image_batch_vggt_omega_loader(
+    loader,
+    indices: List[int],
+    mode: str = "balanced",
+    image_resolution: int = DEFAULT_FIXED_RESOLUTION_VGGT_OMEGA,
+    patch_size: int = 16,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Load loader-resized images and preprocess them for VGGT-Omega.
+
+    ``original_coords`` maps pixels from ``loader.get_image()`` into the final
+    padded Omega tensor. Each row is ``[left, top, right, bottom, scaled_w,
+    scaled_h]`` and can be used as::
+
+        u_omega = u_loader * scaled_w / loader_w - left
+        v_omega = v_loader * scaled_h / loader_h - top
+
+    Args:
+        loader: Loader instance providing ``get_image``.
+        indices: List of image indices to load.
+        mode: ``balanced` keeps the total token count close to image_resolution**2.
+            `max_size` resizes the longest side to image_resolution.
+        image_resolution: Vggt-Omega preprocessing resolution.
+        patch_size: Vggt-Omega image patch size.
+
+    Returns:
+        Batched images shaped ``(N, 3, H, W)`` and coordinates shaped ``(N, 6)``.
+    """
+    # checks from vggt-omega
+    if mode not in ("balanced", "max_size"):
+        raise ValueError("Mode must be either 'balanced' or 'max_size'")
+    if image_resolution <= 0:
+        raise ValueError("image_resolution must be positive")
+    if patch_size <= 0:
+        raise ValueError("patch_size must be positive")
+    if image_resolution % patch_size != 0:
+        raise ValueError("image_resolution must be divisible by patch_size")
+
+    images: list[torch.Tensor] = []
+    transforms: list[tuple[int, int, int, int, int, int, int, int]] = []
+    to_tensor = TF.ToTensor()
+
+    for idx in indices:
+        image = PILImage.fromarray(loader.get_image(idx).value_array).convert("RGB")
+        loader_w, loader_h = image.size
+
+        crop_x = 0
+        crop_y = 0
+        crop_w = loader_w
+        crop_h = loader_h
+        aspect_ratio = loader_h / max(loader_w, 1)
+        if aspect_ratio < 0.5:
+            crop_w = min(loader_w, max(1, int(round(loader_h / 0.5))))
+            crop_x = max((loader_w - crop_w) // 2, 0)
+        elif aspect_ratio > 2.0:
+            crop_h = min(loader_h, max(1, int(round(loader_w * 2.0))))
+            crop_y = max((loader_h - crop_h) // 2, 0)
+
+        image = image.crop((crop_x, crop_y, crop_x + crop_w, crop_y + crop_h))
+        cropped_aspect_ratio = crop_h / max(crop_w, 1)
+
+        if mode == "balanced":
+            num_patches = (image_resolution // patch_size) ** 2
+            width_patches = max(1, int(np.round(np.sqrt(num_patches / cropped_aspect_ratio))))
+            height_patches = max(1, int(np.round(num_patches / np.sqrt(num_patches / cropped_aspect_ratio))))
+            target_w = width_patches * patch_size
+            target_h = height_patches * patch_size
+        elif cropped_aspect_ratio >= 1.0:
+            target_h = image_resolution
+            target_w = max(
+                patch_size,
+                int(np.round((image_resolution / cropped_aspect_ratio) / patch_size)) * patch_size,
+            )
+        else:
+            target_w = image_resolution
+            target_h = max(
+                patch_size,
+                int(np.round((image_resolution * cropped_aspect_ratio) / patch_size)) * patch_size,
+            )
+
+        image = image.resize((target_w, target_h), PILImage.Resampling.BICUBIC)
+        images.append(to_tensor(image))
+        transforms.append((loader_w, loader_h, crop_x, crop_y, crop_w, crop_h, target_w, target_h))
+
+    batch_h = max(image.shape[1] for image in images)
+    batch_w = max(image.shape[2] for image in images)
+    padded_images: list[torch.Tensor] = []
+    original_coords: list[list[float]] = []
+
+    for image, transform in zip(images, transforms):
+        loader_w, loader_h, crop_x, crop_y, crop_w, crop_h, target_w, target_h = transform
+        pad_left = (batch_w - target_w) // 2
+        pad_right = batch_w - target_w - pad_left
+        pad_top = (batch_h - target_h) // 2
+        pad_bottom = batch_h - target_h - pad_top
+        padded_images.append(
+            torch.nn.functional.pad(
+                image,
+                (pad_left, pad_right, pad_top, pad_bottom),
+                mode="constant",
+                value=1.0,
+            )
+        )
+
+        resize_x = target_w / crop_w
+        resize_y = target_h / crop_h
+        scaled_w = loader_w * resize_x
+        scaled_h = loader_h * resize_y
+
+        # this is because the existing frontend expects u_omega = u_loader * resize_x - left
+        # and natural mapping for this transform is u_omega = (u_loader - crop_x) * resize_x + pad_left
+        left = crop_x * resize_x - pad_left
+        top = crop_y * resize_y - pad_top
+        original_coords.append([left, top, left + batch_w, top + batch_h, scaled_w, scaled_h])
+
+    return torch.stack(padded_images), torch.tensor(original_coords, dtype=torch.float32)
+
+
+# ---------------------------------------------------------------------------
+# Model loading
+# ---------------------------------------------------------------------------
+
+
+def resolve_weights_path(weights_path: PathLike | None = None) -> Path:
+    """Return a concrete path to the VGGT Omega checkpoint, validating that it exists."""
+    checkpoint = Path(weights_path) if weights_path is not None else DEFAULT_WEIGHTS_PATH
+    if not checkpoint.exists():
+        raise FileNotFoundError(
+            f"VGGT Omega weights not found at {checkpoint}. Download weights via `scripts/download_model_weights.sh`."
+        )
+    return checkpoint
+
+
+def load_model(
+    device: torch.device,
+):
+    """Load the VGGT Omega model weights on the requested device."""
+    if device.type != "cuda":
+        raise RuntimeError("VGGT-Omega requires CUDA.")
+    checkpoint = resolve_weights_path(DEFAULT_WEIGHTS_PATH)
+    model = VGGTOmega()
+    model.load_state_dict(torch.load(checkpoint, map_location="cpu"))
+
+    model.eval()
+    model.to(device)
+    return model
+
+
+# Module-level singleton so each Dask worker loads the ~1B VGGT-Omega weights only ONCE. When this
+# transformer is driven by ClusterVGGTWithFrontend with model_cache_key=False, the optimizer passes
+# model=None for every cluster; without this cache that would reload the 1B model per cluster.
+_OMEGA_MODEL_CACHE: dict[str, Any] = {}
+
+
+def resolve_cached_model(device: torch.device):
+    """Return a per-worker cached VGGT-Omega model, loading the weights once per device."""
+    key = str(device)
+    cached = _OMEGA_MODEL_CACHE.get(key)
+    if cached is None:
+        logger.info("⏳ Loading VGGT-Omega model weights (worker cache)...")
+        cached = load_model(device)
+        _OMEGA_MODEL_CACHE[key] = cached
+        logger.info("✅ VGGT-Omega model weights loaded and cached.")
+    return cached
+
+
+# ---------------------------------------------------------------------------
+# VggtOmegaGeometryTransformer
+# ---------------------------------------------------------------------------
+
+
+class VggtOmegaGeometryTransformer(GeometryTransformer):
+    """Runs VGGT Omega model inference to predict poses, depths, and dense points."""
+
+    def __init__(self):
+        self.resolved_dtype = torch.float32
+
+    def load_image_batch(self, loader, indices, mode: str = "balanced"):
+        """Preprocess images with VGGT-Omega's own loader (512px, 16-patch aligned, aspect-cropped).
+
+        Omega's modes are ``balanced``/``max_size`` (not VGGT's ``crop``/``pad``), so the optimizer's
+        ``input_mode`` does not apply here — anything other than a valid omega mode falls back to
+        ``balanced``. The ``original_coords`` returned match the build's keypoint->depth mapping, so the
+        depth lookup stays consistent with omega's depth-map output resolution.
+        """
+        if mode not in ("balanced", "max_size"):
+            mode = "balanced"
+        return load_image_batch_vggt_omega_loader(loader, indices, mode=mode)
+
+    def predict(
+        self,
+        images: torch.Tensor,
+        *,
+        model: Optional[VGGTOmega] = None,
+        **kwargs: Any,
+    ) -> GeometryTransformerOutput:
+        """Run VGGT Omega forward pass and return unified output.
+
+        Args:
+            images: Tensor shaped ``(N, 3, H, W)``.
+
+        Returns:
+            class:`GeometryTransformerOutput` with poses, depths, and dense points.
+        """
+        self.resolved_device = torch_utils.default_device()
+        images = images.to(self.resolved_device, dtype=self.resolved_dtype)
+        if model is None:
+            model = resolve_cached_model(self.resolved_device)
+        else:
+            model = model.to(self.resolved_device)
+            assert model is not None
+            model.eval()
+
+        with torch.inference_mode():
+            predictions = model(images)
+
+        extrinsics, intrinsics = encoding_to_camera(
+            predictions["pose_enc"],
+            predictions["images"].shape[-2:],
+        )
+
+        depth = predictions["depth"]
+        depth_conf = predictions["depth_conf"]
+
+        dense_points = unproject_depth_map_to_point_map(
+            depth.squeeze(0).detach().float().cpu().numpy(),
+            extrinsics.squeeze(0).detach().float().cpu().numpy(),
+            intrinsics.squeeze(0).detach().float().cpu().numpy(),
+        )
+
+        return GeometryTransformerOutput(
+            device=self.resolved_device,
+            dtype=self.resolved_dtype,
+            images=images,
+            extrinsic=extrinsics.squeeze(0),
+            intrinsic=intrinsics.squeeze(0),
+            depth_map=depth.squeeze(0).squeeze(-1),
+            depth_confidence=depth_conf.squeeze(0),
+            dense_points=torch.from_numpy(dense_points).to(
+                self.resolved_device,
+                dtype=self.resolved_dtype,
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+__all__ = [
+    "DEFAULT_WEIGHTS_PATH",
+    "REPO_ROOT",
+    "THIRDPARTY_ROOT",
+    "VGGT_OMEGA_SUBMODULE_PATH",
+    "VggtOmegaGeometryTransformer",
+    "_ensure_submodule_on_path",
+    "load_image_batch_vggt_omega_loader",
+    "load_model",
+    "resolve_weights_path",
+]

--- a/gtsfm/utils/torch.py
+++ b/gtsfm/utils/torch.py
@@ -62,7 +62,7 @@ def cal3_bundler_from_intrinsic(matrix: np.ndarray, crop_coords) -> gtsam.Cal3Bu
 
 
 def cal3ds2_from_intrinsic(matrix: np.ndarray, crop_coords) -> gtsam.Cal3_S2:
-    """Map a 3x3 intrinsic matrix to a Cal3_S2."""
+    """Map a 3x3 intrinsic matrix to a Cal3DS2."""
     fx = float(matrix[0, 0])
     fy = float(matrix[1, 1])
     cx = float(matrix[0, 2])

--- a/scripts/download_model_weights.sh
+++ b/scripts/download_model_weights.sh
@@ -1,5 +1,45 @@
 
 # Download model weights for different modules available for use in GTSFM
+
+help() {
+    cat <<EOF
+A minimalistic script to download weights for required models. VGGT-Omega weights cannot be distributed
+under their license. First get access to the model checkpoints and then the following flag is required.
+--hf_token, followed by the hugging face token with checkpoint access.
+If no hf_token is passed then other weights are downloaded normally except VGGT-Omega.
+Usage:
+  bash scripts/download_model_weights.sh
+  bash scripts/download_model_weights.sh --hf_token <token>
+EOF
+    exit 0
+}
+
+case "$#" in
+    0)
+        HF_TOKEN=""
+        ;;
+    1)
+        if [[ "$1" == "--help" ]]; then
+            help
+        else
+            echo "Invalid argument"
+            exit 1
+        fi
+        ;;
+    2)
+        if [[ "$1" == "--hf_token" ]]; then
+            HF_TOKEN="$2"
+        else
+            echo "Invalid argument"
+            exit 1
+        fi
+        ;;
+    *)
+        echo "Invalid number of arguments. Check --help"
+        exit 1
+        ;;
+esac
+
 # Note: SuperPoint and SuperGlue code and checkpoints may *not* be used for commercial purposes
 
 #################### SuperPoint & SuperGlue ##########################
@@ -45,11 +85,22 @@ wget $D2NET_CKPT_URL -O $D2NET_WEIGHTS_DIR/d2_tf.pth
 
 NETVLAD_WEIGHTS_DIR="./thirdparty/hloc/weights"
 NETVLAD_CKPT_URL="https://github.com/johnwlambert/gtsfm-datasets-mirror/releases/download/gerrard-hall-100/VGG16-NetVLAD-Pitts30K.mat"
-mkdir $NETVLAD_WEIGHTS_DIR
+mkdir -p $NETVLAD_WEIGHTS_DIR
 wget $NETVLAD_CKPT_URL -O $NETVLAD_WEIGHTS_DIR/VGG16-NetVLAD-Pitts30K.mat
 
 ##################### vggt #############################
 VGGT_WEIGHTS_DIR="./thirdparty/vggt/weights"
 VGGT_CKPT_URL="https://huggingface.co/facebook/VGGT-1B/resolve/main/model.pt"
-mkdir $VGGT_WEIGHTS_DIR
+mkdir -p $VGGT_WEIGHTS_DIR
 wget $VGGT_CKPT_URL -O $VGGT_WEIGHTS_DIR/model.pt
+
+##################### vggt-omega #############################
+if [[ -z "$HF_TOKEN" ]]; then
+    echo "Hugging Face token not provided; skipping VGGT-Omega weights."
+else
+    VGGT_OMEGA_WEIGHTS_DIR="./thirdparty/vggt-omega/weights"
+    mkdir -p $VGGT_OMEGA_WEIGHTS_DIR
+    hf download facebook/VGGT-Omega vggt_omega_1b_512.pt \
+    --token "$HF_TOKEN" \
+    --local-dir "$VGGT_OMEGA_WEIGHTS_DIR"
+fi

--- a/tests/frontend/test_vggt_omega_geometry_transformer.py
+++ b/tests/frontend/test_vggt_omega_geometry_transformer.py
@@ -1,0 +1,79 @@
+"""Unit tests for the VGGT-Omega image preprocessing (CPU-only; no weights required).
+
+The omega loader is what keeps the depth lookup consistent with the model's output resolution, so its
+contract — 16-patch-aligned sizes, a padded batch of mixed aspect ratios, and ``original_coords`` that map
+loader pixels into the padded omega frame — is pinned here.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+import torch
+
+from gtsfm.common.image import Image
+
+try:
+    from gtsfm.frontend.vggt_omega_geometry_transformer import (
+        VggtOmegaGeometryTransformer,
+        load_image_batch_vggt_omega_loader,
+    )
+except ImportError:  # thirdparty/vggt-omega submodule not checked out
+    pytest.skip("vggt-omega submodule not available", allow_module_level=True)
+
+PATCH = 16
+RESOLUTION = 512
+
+
+class _ArrayLoader:
+    """Minimal loader exposing ``get_image`` over in-memory RGB arrays."""
+
+    def __init__(self, shapes: list[tuple[int, int]]) -> None:
+        rng = np.random.default_rng(0)
+        self._images = [Image(value_array=rng.integers(0, 255, (h, w, 3), dtype=np.uint8)) for h, w in shapes]
+
+    def get_image(self, index: int) -> Image:
+        return self._images[index]
+
+
+class TestVggtOmegaLoader(unittest.TestCase):
+    def test_balanced_mode_is_patch_aligned_and_padded(self) -> None:
+        loader = _ArrayLoader([(480, 640), (640, 480), (300, 900)])  # landscape, portrait, wide
+        batch, coords = load_image_batch_vggt_omega_loader(loader, [0, 1, 2], mode="balanced")
+
+        self.assertEqual(batch.shape[0], 3)
+        self.assertEqual(batch.shape[1], 3)
+        self.assertEqual(batch.shape[2] % PATCH, 0)
+        self.assertEqual(batch.shape[3] % PATCH, 0)
+        self.assertEqual(coords.shape, (3, 6))
+        self.assertEqual(coords.dtype, torch.float32)
+
+    def test_max_size_mode_longest_side_is_resolution(self) -> None:
+        loader = _ArrayLoader([(480, 640)])
+        batch, _ = load_image_batch_vggt_omega_loader(loader, [0], mode="max_size")
+        self.assertEqual(max(batch.shape[2], batch.shape[3]), RESOLUTION)
+
+    def test_original_coords_map_loader_pixels_into_padded_frame(self) -> None:
+        loader = _ArrayLoader([(480, 640), (640, 480)])
+        batch, coords = load_image_batch_vggt_omega_loader(loader, [0, 1], mode="balanced")
+        batch_h, batch_w = batch.shape[2], batch.shape[3]
+        for i, (h, w) in enumerate([(480, 640), (640, 480)]):
+            left, top, _, _, scaled_w, scaled_h = coords[i].tolist()
+            # Mapping used by the frontend: u_omega = u_loader * scaled_w / loader_w - left.
+            u = (w / 2) * scaled_w / w - left
+            v = (h / 2) * scaled_h / h - top
+            self.assertTrue(0 <= u < batch_w, f"image {i}: u={u} outside [0,{batch_w})")
+            self.assertTrue(0 <= v < batch_h, f"image {i}: v={v} outside [0,{batch_h})")
+
+    def test_invalid_mode_rejected_by_loader_but_normalized_by_transformer(self) -> None:
+        loader = _ArrayLoader([(480, 640)])
+        with self.assertRaises(ValueError):
+            load_image_batch_vggt_omega_loader(loader, [0], mode="crop")
+        # The transformer maps VGGT-style modes (crop/pad) onto omega's default.
+        batch, coords = VggtOmegaGeometryTransformer().load_image_batch(loader, [0], mode="crop")
+        self.assertEqual(batch.shape[0], 1)
+        self.assertEqual(coords.shape, (1, 6))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Integrates **VGGT-Omega** as a geometry transformer, runnable through the existing `ClusterVGGTWithFrontend` via the injected `geometry_transformer` — so a VGGT vs. VGGT-Omega comparison differs only in the per-cluster geometry model. This is the omega arm used for the ECCV'26 SFM-DL paper results; the verified-view-graph pipeline it was paired with lands separately on `mapping-vggt`.

## What changes

- **`frontend/vggt_omega_geometry_transformer.py`** (new): model loading from the `thirdparty/vggt-omega` submodule, omega's own image preprocessing (`load_image_batch_vggt_omega_loader`: 512 px, 16-patch aligned, aspect-ratio cropped) and `predict` returning the unified `GeometryTransformerOutput`.
- **`frontend/geometry_transformer.py`**: new `GeometryTransformer.load_image_batch` hook — image preprocessing now *follows the transformer* (default = VGGT loader, omega overrides). The per-pixel depth lookup downstream indexes the model's depth map via the `original_coords` returned here, so the loader must match the model. No-op for all VGGT configs.
- **`cluster_optimizer/cluster_vggt.py`, `cluster_vggt_with_frontend.py`**: `_load_vggt_inputs` dispatches to `transformer.load_image_batch`; a new shared `_model_loading_plan` helper replaces the duplicated model-caching blocks in both constructors. Behavior-identical for VGGT, and it closes a real footgun: a transformer without a `config` previously (a) crashed the constructor and, once guarded, (b) inherited the default `("default_vggt_loader", …)` cache key — which makes `_resolve_vggt_model` load a cached **VGGT** model and hand it to omega's `predict`. Config-less transformers now get no shared cache key and manage their own model.
- **`__repr__`** of both optimizers tolerates config-less transformers (class name enters the cluster cache key).
- **`configs/vggt_omega_sift_frontend_megaloc_phototourism.yaml`** (new): identical to `vggt_sift_frontend_megaloc_phototourism.yaml` except the geometry transformer — a controlled A/B.
- **`.gitmodules`** + `thirdparty/vggt-omega` submodule; **`scripts/download_model_weights.sh`** gains `--hf_token` for the gated omega checkpoint (and `mkdir -p` fixes).
- `utils/torch.py`: docstring fix.

## Ops / licensing note

VGGT-Omega weights are **gated and CC-BY-NC-4.0** (non-redistributable) and inference is **CUDA-only**. Nothing is downloaded by default; omega imports are only triggered when the omega transformer is instantiated, so all VGGT paths and tests are unaffected.

```bash
git submodule update --init thirdparty/vggt-omega
bash scripts/download_model_weights.sh --hf_token <token>
```

## Tests

- `tests/frontend/test_vggt_omega_geometry_transformer.py` (new, CPU-only, skips without the submodule): 16-patch alignment in both modes, mixed-aspect batch padding, `original_coords` mapping loader pixels into the padded omega frame, and the transformer's mode normalisation.
- Existing `tests/frontend/test_cluster_vggt.py` / matcher suites unchanged and green.

## Review focus

`_model_loading_plan` (the cache-key policy) and the `load_image_batch` hook. Everything else is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
