### PR TITLE
Pin measured (EXIF/dataset) intrinsics in cluster builds; model-focal fallback for metadata-less cameras

### DIFF
--- a/gtsfm/cluster_optimizer/cluster_mvo.py
+++ b/gtsfm/cluster_optimizer/cluster_mvo.py
@@ -6,11 +6,10 @@ import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping, Optional, cast
+from typing import Any, Mapping, Optional
 
 import numpy as np
 from dask.delayed import Delayed, delayed
-from dask.distributed import Future, worker_client
 from gtsam import Pose3, Similarity3  # type: ignore
 
 import gtsfm.common.types as gtsfm_types
@@ -33,7 +32,7 @@ from gtsfm.multi_view_optimizer import MultiViewOptimizer
 from gtsfm.products.one_view_data import OneViewData
 from gtsfm.products.two_view_result import TwoViewResult
 from gtsfm.products.visibility_graph import AnnotatedGraph, VisibilityGraph
-from gtsfm.two_view_estimator import TwoViewEstimator, create_two_view_estimator_futures
+from gtsfm.two_view_estimator import TwoViewEstimator, create_two_view_results_inline
 from gtsfm.ui.gtsfm_process import UiMetadata
 from gtsfm.utils import transform
 
@@ -114,22 +113,25 @@ class ClusterMVO(ClusterOptimizerBase):
     def _run_correspondence_generator(
         correspondence_generator: CorrespondenceGeneratorBase,
         visibility_graph: VisibilityGraph,
-        image_future_keys: list[str],
+        images: list[Image],
     ) -> tuple[list[Keypoints], AnnotatedGraph[np.ndarray], float]:
-        """Execute correspondence generation inside a worker task."""
+        """Run correspondence generation inline (no nested Dask submission).
+
+        ``images`` arrives materialized as a normal Dask dependency (``images[i]`` is image ``i``).
+        Detection + matching run in plain loops over the cache-backed primitives — no ``worker_client()``,
+        so the entire frontend working set is never held resident on one worker at once.
+        """
 
         logger.info("🔵 Running correspondence generation for %d pairs.", len(visibility_graph))
 
         if len(visibility_graph) == 0:
             return [], {}, 0.0
 
-        with worker_client() as nested_client:
-            image_futures = [Future(key=key, client=nested_client) for key in image_future_keys]
-            start_time = time.time()
-            keypoints_list, putative_corr_idxs_dict = correspondence_generator.generate_correspondences(
-                nested_client, image_futures, visibility_graph
-            )
-            duration_sec = time.time() - start_time
+        start_time = time.time()
+        keypoints_list, putative_corr_idxs_dict = correspondence_generator.generate_correspondences_inline(
+            images, visibility_graph
+        )
+        duration_sec = time.time() - start_time
 
         return keypoints_list, putative_corr_idxs_dict, duration_sec
 
@@ -142,24 +144,20 @@ class ClusterMVO(ClusterOptimizerBase):
         gt_scene_mesh: Optional[Any],
         one_view_data_dict: dict[int, OneViewData],
     ) -> tuple[AnnotatedGraph[TwoViewResult], float]:
-        """Execute two-view estimation inside a worker task."""
+        """Run two-view estimation inline (no nested Dask submission)."""
         logger.info("🔵 Running two-view estimation for %d pairs.", len(putative_corr_idxs_dict))
 
-        with worker_client() as nested_client:
-            start_time = time.time()
-            two_view_result_futures = create_two_view_estimator_futures(
-                client=nested_client,
-                two_view_estimator=two_view_estimator,
-                keypoints_list=keypoints_list,
-                putative_corr_idxs_dict=putative_corr_idxs_dict,
-                relative_pose_priors=relative_pose_priors,
-                gt_scene_mesh=gt_scene_mesh,
-                one_view_data_dict=one_view_data_dict,
-            )
-            gathered_tve_futures = nested_client.gather(two_view_result_futures)
-            duration_sec = time.time() - start_time
+        start_time = time.time()
+        all_two_view_results = create_two_view_results_inline(
+            two_view_estimator=two_view_estimator,
+            keypoints_list=keypoints_list,
+            putative_corr_idxs_dict=putative_corr_idxs_dict,
+            relative_pose_priors=relative_pose_priors,
+            gt_scene_mesh=gt_scene_mesh,
+            one_view_data_dict=one_view_data_dict,
+        )
+        duration_sec = time.time() - start_time
 
-        all_two_view_results = cast(AnnotatedGraph[TwoViewResult], gathered_tve_futures)
         valid_two_view_results = {edge: result for edge, result in all_two_view_results.items() if result.valid()}
 
         n_total = len(all_two_view_results)
@@ -202,14 +200,16 @@ class ClusterMVO(ClusterOptimizerBase):
         """Create delayed nodes for the full front-end pipeline."""
 
         visibility_edges = list(context.visibility_graph)
-        image_future_keys = [context.image_future_map[idx].key for idx in range(context.num_images)]
+        # Pass the image futures directly as task inputs; Dask materializes them as a normal dependency
+        # (no nested gather), so the correspondence task receives concrete images[i] in index order.
+        image_futures = [context.image_future_map[idx] for idx in range(context.num_images)]
 
         keypoints_graph, putative_corr_idxs_graph, correspondence_duration_graph = delayed(
             ClusterMVO._run_correspondence_generator, nout=3
         )(
             self.correspondence_generator,
             visibility_edges,
-            image_future_keys,
+            image_futures,
         )
 
         padded_keypoints_graph = delayed(_pad_keypoints_list)(keypoints_graph, context.num_images)

--- a/gtsfm/cluster_optimizer/cluster_optimizer_base.py
+++ b/gtsfm/cluster_optimizer/cluster_optimizer_base.py
@@ -55,6 +55,11 @@ class ClusterContext:
     # per-cluster frontend (identical per-edge result). None: the optimizer runs its own frontend.
     global_v_corr_idxs_dict: dict | None = None
     global_keypoints: list | None = None
+    # Measured intrinsics (EXIF / dataset calibration) passed through verbatim, keyed by image index.
+    # Cluster builds PIN these in place of the geometry model's predicted focals; cameras absent from
+    # the dict (loader could only guess a focal) fall back to the model prediction. None or empty: no
+    # passthrough.
+    global_refined_intrinsics: dict | None = None
 
     @property
     def is_root(self) -> bool:

--- a/gtsfm/cluster_optimizer/cluster_optimizer_base.py
+++ b/gtsfm/cluster_optimizer/cluster_optimizer_base.py
@@ -49,6 +49,12 @@ class ClusterContext:
     cluster_path: tuple[int, ...]
     label: str
     visibility_graph: VisibilityGraph
+    # Global frontend products from the verified two-view pass over the full retrieval graph: verified
+    # correspondence indices keyed by image pair, and per-image keypoints (padded to num_images). When
+    # present, ClusterVGGTWithFrontend builds its tracks from these instead of re-running the
+    # per-cluster frontend (identical per-edge result). None: the optimizer runs its own frontend.
+    global_v_corr_idxs_dict: dict | None = None
+    global_keypoints: list | None = None
 
     @property
     def is_root(self) -> bool:

--- a/gtsfm/cluster_optimizer/cluster_optimizer_cacher.py
+++ b/gtsfm/cluster_optimizer/cluster_optimizer_cacher.py
@@ -98,6 +98,7 @@ class ClusterOptimizerCacher(ClusterOptimizerBase):
         components = [
             one_view_data.image_fname,
             repr(one_view_data.intrinsics),
+            str(one_view_data.intrinsics_from_exif),
             repr(one_view_data.absolute_pose_prior),
             repr(one_view_data.camera_gt),
             repr(one_view_data.pose_gt),

--- a/gtsfm/cluster_optimizer/cluster_vggt_with_frontend.py
+++ b/gtsfm/cluster_optimizer/cluster_vggt_with_frontend.py
@@ -53,6 +53,11 @@ def _extract_v_corr_idxs(two_view_results) -> dict:
     return {ij: result.v_corr_idxs for ij, result in two_view_results.items()}
 
 
+def _identity(x):
+    """Wrap an eager value as a single delayed node (so it is embedded once, not per consumer)."""
+    return x
+
+
 def _get_image_shapes(loader, image_indices: tuple[int, ...]) -> dict[int, tuple[int, int]]:
     """Return original (height, width) for each requested image index."""
     return {idx: loader.get_image(idx).value_array.shape[:2] for idx in image_indices}
@@ -355,9 +360,35 @@ class ClusterVGGTWithFrontend(ClusterMVO):
         image_filenames = context.loader.image_filenames()
         image_names = tuple(str(image_filenames[idx]) for idx in keys)
 
-        # Traditional frontend.
-        frontend_graphs = self._build_frontend_graphs(context)
-        io_tasks, metrics = self._build_frontend_output_graphs(context, frontend_graphs)
+        # This cluster's 2D tracks. When the context carries the globally-verified correspondences,
+        # subset them to this cluster's edges and build the tracks EAGERLY in the main process — the
+        # per-cluster frontend would recompute the identical per-edge result (same edges, same two-view
+        # estimator), serially and redundantly across overlapping clusters. Without them (optimizer used
+        # standalone), run the traditional per-cluster frontend.
+        if context.global_v_corr_idxs_dict is not None and context.global_keypoints is not None:
+            cluster_v_corr = {
+                ij: context.global_v_corr_idxs_dict[ij]
+                for ij in context.visibility_graph
+                if ij in context.global_v_corr_idxs_dict
+            }
+            tracks_2d = get_2d_tracks(cluster_v_corr, context.global_keypoints)
+            logger.info(
+                "♻️  [%s] Reusing global correspondences: %d/%d cluster edges → %d tracks (frontend skipped).",
+                context.label,
+                len(cluster_v_corr),
+                len(context.visibility_graph),
+                len(tracks_2d),
+            )
+            v_corr_idxs_graph = delayed(_identity)(cluster_v_corr)
+            tracks_2d_graph = delayed(_identity)(tracks_2d)
+            padded_keypoints_graph = delayed(_identity)(context.global_keypoints)
+            io_tasks, metrics = [], []
+        else:
+            frontend_graphs = self._build_frontend_graphs(context)
+            io_tasks, metrics = self._build_frontend_output_graphs(context, frontend_graphs)
+            v_corr_idxs_graph = delayed(_extract_v_corr_idxs)(frontend_graphs.two_view_results)
+            tracks_2d_graph = delayed(get_2d_tracks)(v_corr_idxs_graph, frontend_graphs.padded_keypoints)
+            padded_keypoints_graph = frontend_graphs.padded_keypoints
 
         # VGGT geometry prediction → cameras + dense 3D points.
         image_batch_graph, original_coords_graph = delayed(_load_vggt_inputs, nout=2)(
@@ -379,26 +410,22 @@ class ClusterVGGTWithFrontend(ClusterMVO):
             cluster_label=context.label,
         )
 
-        # 3. 2D tracks from frontend correspondences.
-        v_corr_idxs_graph = delayed(_extract_v_corr_idxs)(frontend_graphs.two_view_results)
-        tracks_2d_graph = delayed(get_2d_tracks)(v_corr_idxs_graph, frontend_graphs.padded_keypoints)
-
-        # 4. Original image shapes (needed to map frontend pixel coords → VGGT pixel coords).
+        # Original image shapes (needed to map frontend pixel coords → VGGT pixel coords).
         image_shapes_graph = delayed(_get_image_shapes)(context.loader, global_indices)
 
-        # 4b. Optional: refine VGGT's predicted intrinsics via Fetzer joint
+        # Optional: refine VGGT's predicted intrinsics via Fetzer joint
         # optimization over the frontend's F-matrices (keeps VGGT's predicted poses).
         refined_intrinsics_graph = None
         if self._use_view_graph_calibration:
             refined_intrinsics_graph = delayed(_refine_vggt_intrinsics_via_view_graph)(
                 vggt_result_graph,
                 v_corr_idxs_graph,
-                frontend_graphs.padded_keypoints,
+                padded_keypoints_graph,
                 image_shapes_graph,
                 global_indices,
             )
 
-        # 5. Build GtsfmData: lift 2D tracks to 3D using VGGT depth map.
+        # Build GtsfmData: lift 2D tracks to 3D using VGGT depth map.
         ba_input_graph = delayed(_build_gtsfm_data_from_vggt_depth)(
             vggt_result_graph,
             tracks_2d_graph,
@@ -409,7 +436,7 @@ class ClusterVGGTWithFrontend(ClusterMVO):
             refined_intrinsics=refined_intrinsics_graph,
         )
 
-        # 6. Cluster-level BA.
+        # Cluster-level BA.
         ba_result_graph, pre_ba_result_graph = delayed(_run_cluster_ba, nout=2)(
             ba_input_graph,
             ba_options=self.ba_options,
@@ -422,7 +449,7 @@ class ClusterVGGTWithFrontend(ClusterMVO):
             use_multi_view_retriangulation=self._use_multi_view_retriangulation,
         )
 
-        # 7. Metrics + I/O.
+        # Metrics + I/O.
         cameras_gt = [context.one_view_data_dict[idx].camera_gt for idx in range(context.num_images)]
         metrics.append(
             delayed(_aggregate_vggt_metrics)(

--- a/gtsfm/cluster_optimizer/cluster_vggt_with_frontend.py
+++ b/gtsfm/cluster_optimizer/cluster_vggt_with_frontend.py
@@ -43,9 +43,9 @@ class VggtGeometryResult(NamedTuple):
     """Outputs of VGGT geometry prediction needed for downstream processing."""
 
     cameras: dict[int, gtsfm_types.CAMERA_TYPE]
-    dense_points: np.ndarray       # (N, H, W, 3) world-space 3D points per pixel
-    depth_confidence: np.ndarray   # (N, H, W) per-pixel depth confidence scores
-    original_coords: np.ndarray    # (N, 6) VGGT crop/pad metadata
+    dense_points: np.ndarray  # (N, H, W, 3) world-space 3D points per pixel
+    depth_confidence: np.ndarray  # (N, H, W) per-pixel depth confidence scores
+    original_coords: np.ndarray  # (N, 6) VGGT crop/pad metadata
 
 
 def _extract_v_corr_idxs(two_view_results) -> dict:
@@ -112,9 +112,7 @@ def _run_vggt_geometry(
     return result
 
 
-def _scale_camera_intrinsics(
-    camera: gtsfm_types.CAMERA_TYPE, scale: float
-) -> gtsfm_types.CAMERA_TYPE:
+def _scale_camera_intrinsics(camera: gtsfm_types.CAMERA_TYPE, scale: float) -> gtsfm_types.CAMERA_TYPE:
     """Return a copy of camera with intrinsics uniformly scaled, pose unchanged."""
     pose = camera.pose()
     cal = camera.calibration()
@@ -159,7 +157,7 @@ def _build_gtsfm_data_from_vggt_depth(
         2D measurements are in the original keypoint coordinate system.
     """
     cameras = vggt_result.cameras
-    dense_points = vggt_result.dense_points        # (N, H_vggt, W_vggt, 3)
+    dense_points = vggt_result.dense_points  # (N, H_vggt, W_vggt, 3)
     depth_confidence = vggt_result.depth_confidence  # (N, H_vggt, W_vggt)
     original_coords = vggt_result.original_coords  # (N, 6): [left, top, right, bottom, sw, sh]
 
@@ -167,12 +165,13 @@ def _build_gtsfm_data_from_vggt_depth(
     global_to_local = {gidx: lidx for lidx, gidx in enumerate(image_indices)}
 
     # Register cameras with intrinsics in original image resolution. If
-    # `refined_intrinsics` is supplied (from view-graph calibration), use those
-    # directly; otherwise rescale VGGT's predicted intrinsics from VGGT pixel space.
+    # `refined_intrinsics` is supplied (measured passthrough / view-graph calibration), use those
+    # directly; cameras ABSENT from it fall back to rescaling the model's predicted intrinsics from
+    # VGGT pixel space, same as when no refinement is supplied at all.
     gtsfm_data = GtsfmData(number_images=num_images)
     for global_idx, camera in cameras.items():
         if global_idx in image_shapes and global_idx in global_to_local:
-            if refined_intrinsics is not None:
+            if refined_intrinsics is not None and global_idx in refined_intrinsics:
                 camera = type(camera)(camera.pose(), refined_intrinsics[global_idx])
             else:
                 _, orig_W = image_shapes[global_idx]
@@ -413,10 +412,21 @@ class ClusterVGGTWithFrontend(ClusterMVO):
         # Original image shapes (needed to map frontend pixel coords → VGGT pixel coords).
         image_shapes_graph = delayed(_get_image_shapes)(context.loader, global_indices)
 
-        # Optional: refine VGGT's predicted intrinsics via Fetzer joint
-        # optimization over the frontend's F-matrices (keeps VGGT's predicted poses).
+        # Intrinsics for the BA cameras (VGGT's poses are always kept). Per-camera preference:
+        #   1. Measured intrinsics (EXIF / dataset calibration) passed through ClusterContext — pinned
+        #      verbatim, so every cluster sharing a camera anchors the SAME calibration.
+        #   2. Per-cluster Fetzer refinement of the model focals over this cluster's F-matrices
+        #      (use_view_graph_calibration; keeps VGGT's predicted poses).
+        #   3. The geometry model's predicted focal, rescaled to original resolution — also the
+        #      fallback for cameras ABSENT from 1 (loaders that could only guess a focal).
         refined_intrinsics_graph = None
-        if self._use_view_graph_calibration:
+        if context.global_refined_intrinsics is not None:
+            refined_intrinsics_graph = {
+                idx: context.global_refined_intrinsics[idx]
+                for idx in global_indices
+                if idx in context.global_refined_intrinsics
+            }
+        elif self._use_view_graph_calibration:
             refined_intrinsics_graph = delayed(_refine_vggt_intrinsics_via_view_graph)(
                 vggt_result_graph,
                 v_corr_idxs_graph,

--- a/gtsfm/configs/vggt_sift_frontend_megaloc_phototourism.yaml
+++ b/gtsfm/configs/vggt_sift_frontend_megaloc_phototourism.yaml
@@ -19,14 +19,16 @@ image_pairs_generator:
       _target_: gtsfm.frontend.global_descriptor.MegaLoc
   retriever:
     _target_: gtsfm.retriever.Similarity
-    num_matched: 15
-    min_score: 0.5
+    # Over-retrieve: the global two-view verification prunes non-geometric edges, so retrieval only
+    # needs recall — precision comes from verification.
+    num_matched: 100
+    min_score: 0.15
   batch_size: 16
 
 graph_partitioner:
   _target_: gtsfm.graph_partitioner.Metis
-  min_cameras_to_partition: 12
-  max_cameras: 40
+  min_cameras_to_partition: 30
+  max_cameras: 70
   split_oversized_nodes: true
 
 cluster_optimizer:
@@ -39,8 +41,8 @@ cluster_optimizer:
       detector_descriptor:
         _target_: gtsfm.frontend.cacher.detector_descriptor_cacher.DetectorDescriptorCacher
         detector_descriptor_obj:
-          _target_: gtsfm.frontend.detector_descriptor.sift.SIFTDetectorDescriptor
-          max_keypoints: 5000
+          _target_: gtsfm.frontend.detector_descriptor.colmap_sift.ColmapSIFTDetectorDescriptor
+          max_keypoints: 8192
 
       matcher:
         _target_: gtsfm.frontend.cacher.matcher_cacher.MatcherCacher
@@ -58,9 +60,9 @@ cluster_optimizer:
         bundle_adjust_2view_maxiters: 100
 
         verifier:
-          _target_: gtsfm.frontend.verifier.ransac.Ransac
-          use_intrinsics_in_verification: True
-          estimation_threshold_px: 4 # for H/E/F estimators
+          # PoseLib 5-point + LO-RANSAC + 2-view bundle.
+          _target_: gtsfm.frontend.verifier.poselib_verifier.PoseLibVerifier
+          estimation_threshold_px: 2
 
         triangulation_options:
           _target_: gtsfm.data_association.point3d_initializer.TriangulationOptions
@@ -71,8 +73,8 @@ cluster_optimizer:
 
         inlier_support_processor:
           _target_: gtsfm.two_view_estimator.InlierSupportProcessor
-          min_num_inliers_est_model: 15
-          min_inlier_ratio_est_model: 0.1
+          min_num_inliers_est_model: 30
+          min_inlier_ratio_est_model: 0.15
 
     geometry_transformer:
       _target_: gtsfm.frontend.vggt_geometry_transformer.VggtGeometryTransformer

--- a/gtsfm/frontend/correspondence_generator/colmap_correspondence_generator.py
+++ b/gtsfm/frontend/correspondence_generator/colmap_correspondence_generator.py
@@ -123,6 +123,25 @@ class ColmapCorrespondenceGenerator(CorrespondenceGeneratorBase):
 
         return corr_idxs
 
+    def generate_correspondences_inline(
+        self, images: List[Image], visibility_graph: VisibilityGraph
+    ) -> Tuple[List[Keypoints], Dict[Tuple[int, int], np.ndarray]]:
+        """Read keypoints and matches for the given images from the Colmap DB.
+
+        Note: the matches read from the DB are already geometrically verified.
+
+        Args:
+            images: List of all images.
+            visibility_graph: The visibility graph defining which image pairs to process.
+
+        Returns:
+            List of keypoints, one entry for each input images.
+            Correspondences as indices of keypoints, for pairs of images.
+        """
+        gtsfm_id_to_pycolmap_id, keypoints = self._read_image_ids_and_keypoints(images)
+        corr_idxs = self._read_matches(visibility_graph, gtsfm_id_to_pycolmap_id)
+        return keypoints, corr_idxs
+
     def generate_correspondences(
         self, client: Client, images: List[Future], visibility_graph: VisibilityGraph
     ) -> Tuple[List[Keypoints], Dict[Tuple[int, int], np.ndarray]]:
@@ -137,10 +156,4 @@ class ColmapCorrespondenceGenerator(CorrespondenceGeneratorBase):
             List of keypoints, one entry for each input images.
             Putative correspondence as indices of keypoints, for pairs of images.
         """
-        # Note: we will end up reading verified correspondences from the colmap DB.
-        images_actual = client.gather(images)
-
-        gtsfm_id_to_pycolmap_id, keypoints = self._read_image_ids_and_keypoints(images_actual)
-        corr_idxs = self._read_matches(visibility_graph, gtsfm_id_to_pycolmap_id)
-
-        return keypoints, corr_idxs
+        return self.generate_correspondences_inline(client.gather(images), visibility_graph)

--- a/gtsfm/frontend/correspondence_generator/correspondence_generator_base.py
+++ b/gtsfm/frontend/correspondence_generator/correspondence_generator_base.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Tuple
 import numpy as np
 from dask.distributed import Client, Future
 
+from gtsfm.common.image import Image
 from gtsfm.common.keypoints import Keypoints
 from gtsfm.products.visibility_graph import VisibilityGraph
 
@@ -28,6 +29,29 @@ class CorrespondenceGeneratorBase:
         Args:
             client: Dask client, used to execute the front-end as futures.
             images: List of all images, as futures.
+            visibility_graph: The visibility graph defining which image pairs to process.
+
+        Returns:
+            List of keypoints, one entry for each input images.
+            Putative correspondence as indices of keypoints, for pairs of images.
+        """
+
+    @abstractmethod
+    def generate_correspondences_inline(
+        self,
+        images: List[Image],
+        visibility_graph: VisibilityGraph,
+    ) -> Tuple[List[Keypoints], Dict[Tuple[int, int], np.ndarray]]:
+        """Generate putative correspondences inline, i.e. without submitting Dask tasks.
+
+        Same contract as ``generate_correspondences`` but takes concrete images and runs detection/matching
+        in plain loops in the calling process. This is the entry point for the per-cluster frontend, which
+        already executes inside a Dask task: submitting further tasks from there (``worker_client()``)
+        keeps every feature/correspondence future of the cluster resident on one worker during the nested
+        gather.
+
+        Args:
+            images: Materialized images, indexed by position (``images[i]`` is image ``i``).
             visibility_graph: The visibility graph defining which image pairs to process.
 
         Returns:

--- a/gtsfm/frontend/correspondence_generator/det_desc_correspondence_generator.py
+++ b/gtsfm/frontend/correspondence_generator/det_desc_correspondence_generator.py
@@ -3,17 +3,21 @@
 Authors: John Lambert
 """
 
+import time
 from typing import Dict, List, Tuple
 
 import numpy as np
 from dask.distributed import Client, Future
 
+import gtsfm.utils.logger as logger_utils
 from gtsfm.common.image import Image
 from gtsfm.common.keypoints import Keypoints
 from gtsfm.frontend.correspondence_generator.correspondence_generator_base import CorrespondenceGeneratorBase
 from gtsfm.frontend.detector_descriptor.detector_descriptor_base import DetectorDescriptorBase
 from gtsfm.frontend.matcher.matcher_base import MatcherBase
 from gtsfm.products.visibility_graph import VisibilityGraph
+
+logger = logger_utils.get_logger()
 
 
 class DetDescCorrespondenceGenerator(CorrespondenceGeneratorBase):
@@ -83,5 +87,65 @@ class DetDescCorrespondenceGenerator(CorrespondenceGeneratorBase):
         putative_corr_idxs_dict = client.gather(putative_corr_idxs_futures)
         keypoints_futures = client.map(lambda f: f[0], features_futures)
         keypoints_list = client.gather(keypoints_futures)
+
+        return keypoints_list, putative_corr_idxs_dict
+
+    def generate_correspondences_inline(
+        self,
+        images: List[Image],
+        visibility_graph: VisibilityGraph,
+    ) -> Tuple[List[Keypoints], Dict[Tuple[int, int], np.ndarray]]:
+        """Inline, no-Dask variant of ``generate_correspondences``.
+
+        Detection runs once per image and matching once per pair, in plain Python loops calling the
+        (cache-backed) detector-descriptor and matcher directly. Computed-and-discarded item by item, so
+        peak memory is bounded to one cluster's features rather than a worker-resident pile of every
+        feature/correspondence future. Mirrors the synchronous style of ``ColmapCorrespondenceGenerator``.
+
+        Args:
+            images: Materialized images indexed by position (``images[i]`` is image ``i``).
+            visibility_graph: Image pairs ``(i1, i2)`` to match; indices reference ``images``.
+
+        Returns:
+            keypoints_list: one ``Keypoints`` per image, in index order.
+            putative_corr_idxs_dict: per-pair putative correspondence indices.
+        """
+        num_images = len(images)
+        logger.info("🔵 [frontend] Detecting + describing features on %d images...", num_images)
+        det_start = time.time()
+        features: List[Tuple[Keypoints, np.ndarray]] = []
+        for i, image in enumerate(images):
+            features.append(self._detector_descriptor.detect_and_describe(image))
+            if (i + 1) % 250 == 0 or (i + 1) == num_images:
+                logger.info("🔵 [frontend] detection %d/%d images (%.0fs)", i + 1, num_images, time.time() - det_start)
+        keypoints_list = [keypoints for keypoints, _ in features]
+
+        num_pairs = len(visibility_graph)
+        logger.info("🔵 [frontend] Matching %d pairs...", num_pairs)
+        match_start = time.time()
+        putative_corr_idxs_dict: Dict[Tuple[int, int], np.ndarray] = {}
+        for p, (i1, i2) in enumerate(visibility_graph):
+            keypoints_i1, descriptors_i1 = features[i1]
+            keypoints_i2, descriptors_i2 = features[i2]
+            putative_corr_idxs_dict[(i1, i2)] = self._matcher.match(
+                keypoints_i1,
+                keypoints_i2,
+                descriptors_i1,
+                descriptors_i2,
+                im_shape_i1=images[i1].shape,
+                im_shape_i2=images[i2].shape,
+            )
+            if (p + 1) % 5000 == 0 or (p + 1) == num_pairs:
+                elapsed = time.time() - match_start
+                rate = (p + 1) / elapsed if elapsed > 0 else 0.0
+                eta = (num_pairs - (p + 1)) / rate if rate > 0 else 0.0
+                logger.info(
+                    "🔵 [frontend] matching %d/%d pairs (%.0fs, %.0f pair/s, ETA %.0fs)",
+                    p + 1,
+                    num_pairs,
+                    elapsed,
+                    rate,
+                    eta,
+                )
 
         return keypoints_list, putative_corr_idxs_dict

--- a/gtsfm/frontend/correspondence_generator/image_correspondence_generator.py
+++ b/gtsfm/frontend/correspondence_generator/image_correspondence_generator.py
@@ -87,6 +87,17 @@ class ImageCorrespondenceGenerator(CorrespondenceGeneratorBase):
         keypoints_list, putative_corr_idxs_dict = self._aggregator.aggregate(keypoints_dict=pairwise_correspondences)
         return keypoints_list, putative_corr_idxs_dict
 
+    def generate_correspondences_inline(
+        self,
+        images: List[Image],
+        visibility_graph: VisibilityGraph,
+    ) -> Tuple[List[Keypoints], Dict[Tuple[int, int], np.ndarray]]:
+        """Inline (no-Dask) variant of ``generate_correspondences``: match each pair in a plain loop."""
+        pairwise_correspondences = {
+            (i1, i2): self._matcher.match(image_i1=images[i1], image_i2=images[i2]) for i1, i2 in visibility_graph
+        }
+        return self._aggregator.aggregate(keypoints_dict=pairwise_correspondences)
+
     def generate_correspondences_and_estimate_two_view(
         self,
         client: Client,

--- a/gtsfm/frontend/correspondence_generator/mast3r_correspondence_generator.py
+++ b/gtsfm/frontend/correspondence_generator/mast3r_correspondence_generator.py
@@ -92,9 +92,29 @@ class Mast3rCorrespondenceGenerator(CorrespondenceGeneratorBase):
         pairwise_correspondences: Dict[Tuple[int, int], Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]] = (
             client.gather(pairwise_correspondence_futures)
         )
-        logger.info(
-            "Mast3r computed correspondences for %d edges, aggregating them...", len(pairwise_correspondence_futures)
-        )
+        return self._aggregate(pairwise_correspondences)
+
+    def generate_correspondences_inline(
+        self,
+        images: List[Image],
+        visibility_graph: VisibilityGraph,
+    ) -> Tuple[List[Keypoints], Dict[Tuple[int, int], np.ndarray]]:
+        """Inline (no-Dask) variant of ``generate_correspondences``: run MASt3R on each pair in a plain loop."""
+        logger.info("⏳ Loading MASt3R model weights...")
+        model = AsymmetricMASt3R.from_pretrained(_MODEL_PATH).eval()
+
+        pairwise_correspondences = {
+            (i1, i2): Mast3rCorrespondenceGenerator.apply_mast3r(model, images[i1], images[i2])
+            for i1, i2 in visibility_graph
+        }
+        return self._aggregate(pairwise_correspondences)
+
+    def _aggregate(
+        self, pairwise_correspondences: Dict[Tuple[int, int], Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]]
+    ) -> Tuple[List[Keypoints], Dict[Tuple[int, int], np.ndarray]]:
+        """Merge per-pair MASt3R matches into per-image keypoints (de-duplicated by feature-grid index) and
+        per-pair correspondence indices into those keypoints."""
+        logger.info("Mast3r computed correspondences for %d edges, aggregating them...", len(pairwise_correspondences))
 
         keypoints_for_image = {}
         indices_for_image = {}

--- a/gtsfm/frontend/correspondence_generator/synthetic_correspondence_generator.py
+++ b/gtsfm/frontend/correspondence_generator/synthetic_correspondence_generator.py
@@ -16,6 +16,7 @@ from gtsam import Pose3
 import gtsfm.common.types as gtsfm_types
 import gtsfm.utils.logger as logger_utils
 import gtsfm.visualization.open3d_vis_utils as open3d_vis_utils
+from gtsfm.common.image import Image
 from gtsfm.common.keypoints import Keypoints
 from gtsfm.frontend.correspondence_generator.correspondence_generator_base import CorrespondenceGeneratorBase
 from gtsfm.frontend.correspondence_generator.keypoint_aggregator.keypoint_aggregator_base import KeypointAggregatorBase
@@ -48,24 +49,17 @@ class SyntheticCorrespondenceGenerator(CorrespondenceGeneratorBase):
             KeypointAggregatorDedup() if deduplicate else KeypointAggregatorUnique()
         )
 
-    def generate_correspondences(
-        self,
-        client: Client,
-        images: List[Future],
-        visibility_graph: VisibilityGraph,
-        num_sampled_3d_points: int = 5000,
-    ) -> Tuple[List[Keypoints], Dict[Tuple[int, int], np.ndarray]]:
-        """Apply the correspondence generator to generate putative correspondences (in parallel).
+    def _prepare_scene(self, num_sampled_3d_points: int) -> Tuple[TanksAndTemplesLoader, str, np.ndarray, int, int]:
+        """Load the scene, sample 3d points from its mesh once, and save the mesh to disk (it does not pickle).
 
         Args:
-            client: Dask client, used to execute the front-end as futures.
-            images: List of all images, as futures.
-            visibility_graph: The visibility graph defining which image pairs to process.
             num_sampled_3d_points: Number of 3d points to sample from the mesh surface and to project.
 
         Returns:
-            List of keypoints, with one entry for each input image.
-            Putative correspondences as indices of keypoints (N,2), for pairs of images (i1,i2).
+            Tanks & Temples loader for the scene.
+            Path to the saved Open3d mesh.
+            Sampled 3d points, of shape (N,3).
+            Image height and width, in pixels.
         """
         dataset_dir = self._dataset_root
         scene_name = self._scene_name
@@ -96,10 +90,33 @@ class SyntheticCorrespondenceGenerator(CorrespondenceGeneratorBase):
         open3d_mesh_path = tempfile.NamedTemporaryFile(suffix=".obj").name
         open3d.io.write_triangle_mesh(filename=open3d_mesh_path, mesh=mesh)
 
-        loader_future = client.scatter(loader, broadcast=False)
-
         # TODO(johnwlambert): Remove assumption that image pair shares the same image shape.
         image_height_px, image_width_px, _ = loader.get_image(0).shape
+        return loader, open3d_mesh_path, sampled_points, image_height_px, image_width_px
+
+    def generate_correspondences(
+        self,
+        client: Client,
+        images: List[Future],
+        visibility_graph: VisibilityGraph,
+        num_sampled_3d_points: int = 5000,
+    ) -> Tuple[List[Keypoints], Dict[Tuple[int, int], np.ndarray]]:
+        """Apply the correspondence generator to generate putative correspondences (in parallel).
+
+        Args:
+            client: Dask client, used to execute the front-end as futures.
+            images: List of all images, as futures.
+            visibility_graph: The visibility graph defining which image pairs to process.
+            num_sampled_3d_points: Number of 3d points to sample from the mesh surface and to project.
+
+        Returns:
+            List of keypoints, with one entry for each input image.
+            Putative correspondences as indices of keypoints (N,2), for pairs of images (i1,i2).
+        """
+        loader, open3d_mesh_path, sampled_points, image_height_px, image_width_px = self._prepare_scene(
+            num_sampled_3d_points
+        )
+        loader_future = client.scatter(loader, broadcast=False)
 
         def apply_synthetic_corr_generator(loader_: LoaderBase, **kwargs) -> Tuple[Keypoints, Keypoints]:
             return generate_synthetic_correspondences_for_image_pair(
@@ -124,6 +141,33 @@ class SyntheticCorrespondenceGenerator(CorrespondenceGeneratorBase):
 
         keypoints_list, putative_corr_idxs_dict = self._aggregator.aggregate(keypoints_dict=pairwise_correspondences)
         return keypoints_list, putative_corr_idxs_dict
+
+    def generate_correspondences_inline(
+        self,
+        images: List[Image],
+        visibility_graph: VisibilityGraph,
+        num_sampled_3d_points: int = 5000,
+    ) -> Tuple[List[Keypoints], Dict[Tuple[int, int], np.ndarray]]:
+        """Inline (no-Dask) variant of ``generate_correspondences``.
+
+        The synthetic correspondences are projected from the scene's GT cameras and mesh, so ``images`` is
+        only accepted to satisfy the interface (indices refer to the loader).
+        """
+        loader, open3d_mesh_path, sampled_points, image_height_px, image_width_px = self._prepare_scene(
+            num_sampled_3d_points
+        )
+        pairwise_correspondences = {
+            (i1, i2): generate_synthetic_correspondences_for_image_pair(
+                camera_i1=loader.get_camera(index=i1),
+                camera_i2=loader.get_camera(index=i2),
+                open3d_mesh_fpath=open3d_mesh_path,
+                points=sampled_points,
+                image_height_px=image_height_px,
+                image_width_px=image_width_px,
+            )
+            for i1, i2 in visibility_graph
+        }
+        return self._aggregator.aggregate(keypoints_dict=pairwise_correspondences)
 
 
 def generate_synthetic_correspondences_for_image_pair(

--- a/gtsfm/loader/loader_base.py
+++ b/gtsfm/loader/loader_base.py
@@ -257,6 +257,20 @@ class LoaderBase(GTSFMProcess):
             raise ValueError(f"Unsupported calibration type {type(intrinsics_full_res)} for rescaling intrinsics.")
         return rescaled_intrinsics
 
+    def intrinsics_from_exif(self, index: int) -> bool:
+        """Whether the intrinsics for `index` are measured (EXIF / dataset calibration) vs guessed.
+
+        Loaders that fall back to the default-focal heuristic for metadata-less images must override
+        this and report False for exactly those images (see OneDSfMLoader).
+
+        Args:
+            index: The index to fetch.
+
+        Returns:
+            True if the intrinsics come from real metadata or a calibration; False for a heuristic guess.
+        """
+        return True
+
     def get_camera_intrinsics(self, index: int) -> Optional[gtsfm_types.CALIBRATION_TYPE]:
         """Get the camera intrinsics at the given index, for a possibly resized image.
 
@@ -558,6 +572,7 @@ class LoaderBase(GTSFMProcess):
             idx: OneViewData(
                 image_fname=image_fnames[idx],
                 intrinsics=intrinsics[idx],
+                intrinsics_from_exif=self.intrinsics_from_exif(idx),
                 absolute_pose_prior=absolute_pose_priors[idx],
                 camera_gt=cameras_gt[idx],
                 pose_gt=gt_wTi_list[idx],

--- a/gtsfm/loader/one_d_sfm_loader.py
+++ b/gtsfm/loader/one_d_sfm_loader.py
@@ -115,6 +115,12 @@ class OneDSFMLoader(LoaderBase):
             default_focal_length_factor=self._default_focal_length_factor
         )
 
+    def intrinsics_from_exif(self, index: int) -> bool:
+        """True iff the image carries usable EXIF; otherwise get_camera_intrinsics_full_res guessed."""
+        if index < 0 or index >= len(self):
+            raise IndexError("Image index is invalid")
+        return io_utils.load_image(self._image_paths[index]).get_intrinsics_from_exif() is not None
+
     def get_camera_pose(self, index: int) -> Optional[Pose3]:
         """Get the camera pose (in world coordinates) at the given index.
 

--- a/gtsfm/products/one_view_data.py
+++ b/gtsfm/products/one_view_data.py
@@ -22,3 +22,8 @@ class OneViewData:
     absolute_pose_prior: Optional[PosePrior]
     camera_gt: Optional[gtsfm_types.CAMERA_TYPE]
     pose_gt: Optional[Pose3]
+    # Whether `intrinsics` was MEASURED (EXIF metadata or a dataset calibration) rather than guessed.
+    # False when the loader substituted the default-focal heuristic (focal = factor * max(H, W)) for a
+    # camera with no usable metadata. Measured intrinsics may be pinned during reconstruction; a guess
+    # must never be.
+    intrinsics_from_exif: bool = True

--- a/gtsfm/runner.py
+++ b/gtsfm/runner.py
@@ -17,7 +17,16 @@ from gtsfm.cluster_optimizer import Multiview
 from gtsfm.loader.configuration import add_loader_args, build_loader_overrides
 from gtsfm.utils.configuration import log_full_configuration
 
-dask_config.set({"distributed.scheduler.worker-ttl": None})
+dask_config.set(
+    {
+        "distributed.scheduler.worker-ttl": None,
+        # Tolerate long event-loop stalls (bulk image loads, the in-process global frontend) without
+        # tearing down the client<->scheduler/worker comms. With the 30s defaults these comms close
+        # mid-run on large single-node scenes, surfacing as CommClosedError / "lost dependencies".
+        "distributed.comm.timeouts.connect": "300s",
+        "distributed.comm.timeouts.tcp": "300s",
+    }
+)
 
 logger = logger_utils.get_logger()
 

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -21,6 +21,7 @@ from gtsfm.cluster_optimizer import Base, save_metrics_reports
 from gtsfm.cluster_optimizer.cluster_mvo import ClusterMVO, _pad_keypoints_list
 from gtsfm.cluster_optimizer.cluster_optimizer_base import ClusterContext
 from gtsfm.common.gtsfm_data import GtsfmData
+from gtsfm.common.types import CALIBRATION_TYPE
 from gtsfm.common.keypoints import Keypoints
 from gtsfm.common.outputs import OutputPaths, cluster_label, prepare_output_paths
 from gtsfm.evaluation.metrics import GtsfmMetric, GtsfmMetricsGroup
@@ -102,6 +103,30 @@ def _collect_metric_results(*results: object) -> list[GtsfmMetricsGroup]:
 def _finalize_io_tasks(*_args: object) -> None:
     """Barrier task used to depend on all I/O side effects."""
     return None
+
+
+def exif_intrinsics_passthrough(one_view_data_dict: dict[int, OneViewData]) -> dict[int, CALIBRATION_TYPE]:
+    """Collect the cameras whose intrinsics were MEASURED (EXIF / dataset calibration), for pinning.
+
+    Cluster builds pin these verbatim in place of the geometry model's predicted focals, so every
+    cluster sharing a camera anchors the SAME calibration — separator cameras stay consistent across
+    parent/child BAs instead of drifting apart through the focal/depth ambiguity. Cameras whose loader
+    could only GUESS a focal (default-focal heuristic; roughly 19-40% of 1DSfM phototourism images
+    carry no usable EXIF, and the guess is ~17% off on average) are EXCLUDED: pinning a wrong focal is
+    far worse than keeping the model's predicted focal, so those cameras fall back to the model
+    prediction in the cluster builds.
+
+    Args:
+        one_view_data_dict: Per-image data from the loader.
+
+    Returns:
+        Measured intrinsics keyed by image index (possibly empty).
+    """
+    return {
+        idx: ovd.intrinsics
+        for idx, ovd in one_view_data_dict.items()
+        if ovd.intrinsics is not None and ovd.intrinsics_from_exif
+    }
 
 
 def verify_visibility_graph(
@@ -292,6 +317,16 @@ class SceneOptimizer:
         image_future_map = self.loader.get_image_futures(client)
         one_view_data_dict = self.loader.get_one_view_data_dict()
 
+        # Measured-intrinsics passthrough: hand every EXIF-/calibration-backed camera its intrinsics
+        # verbatim via ClusterContext; cluster builds pin them in place of model-predicted focals.
+        global_refined_intrinsics = exif_intrinsics_passthrough(one_view_data_dict)
+        logger.info(
+            "🔭 Calibration: measured (EXIF/dataset) intrinsics for %d/%d cameras; the rest keep "
+            "model-predicted focals.",
+            len(global_refined_intrinsics),
+            len(one_view_data_dict),
+        )
+
         # Global two-view verification: run the frontend ONCE over the full retrieval graph and keep only
         # the edges where a two-view model was verified. Everything downstream — partitioning, per-cluster
         # reconstruction, merging — consumes the VERIFIED graph, so clusters are never carved along
@@ -379,6 +414,7 @@ class SceneOptimizer:
                         visibility_graph=visibility_graph,
                         global_v_corr_idxs_dict=v_corr_idxs_dict,
                         global_keypoints=padded_keypoints_list,
+                        global_refined_intrinsics=global_refined_intrinsics or None,
                     )
 
                 context_tree = cluster_tree.map_with_path(to_context)

--- a/gtsfm/scene_optimizer.py
+++ b/gtsfm/scene_optimizer.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Optional, TypeVar, cast
 
 import matplotlib
+import numpy as np
 from dask.delayed import delayed
 from dask.distributed import Client, Future, performance_report
 from omegaconf import OmegaConf
@@ -17,17 +18,23 @@ import gtsfm.utils.logger as logger_utils
 from gtsfm import cluster_merging
 from gtsfm.cluster_merging import MergingOptions
 from gtsfm.cluster_optimizer import Base, save_metrics_reports
+from gtsfm.cluster_optimizer.cluster_mvo import ClusterMVO, _pad_keypoints_list
 from gtsfm.cluster_optimizer.cluster_optimizer_base import ClusterContext
 from gtsfm.common.gtsfm_data import GtsfmData
+from gtsfm.common.keypoints import Keypoints
 from gtsfm.common.outputs import OutputPaths, cluster_label, prepare_output_paths
 from gtsfm.evaluation.metrics import GtsfmMetric, GtsfmMetricsGroup
 from gtsfm.evaluation.retrieval_metrics import save_retrieval_two_view_metrics
+from gtsfm.frontend.correspondence_generator.correspondence_generator_base import CorrespondenceGeneratorBase
 from gtsfm.graph_partitioner.graph_partitioner_base import GraphPartitionerBase
 from gtsfm.graph_partitioner.single_partitioner import SinglePartitioner
 from gtsfm.loader.loader_base import LoaderBase
-from gtsfm.products.visibility_graph import VisibilityGraph
+from gtsfm.products.one_view_data import OneViewData
+from gtsfm.products.visibility_graph import AnnotatedGraph, VisibilityGraph, visibility_graph_keys
 from gtsfm.retriever.image_pairs_generator import ImagePairsGenerator
+from gtsfm.two_view_estimator import TwoViewEstimator, create_v_corr_idxs_futures, create_v_corr_idxs_inline
 from gtsfm.ui.process_graph_generator import ProcessGraphGenerator
+from gtsfm.utils.graph import get_nodes_in_largest_connected_component
 from gtsfm.utils.tree import PreOrderIter
 from gtsfm.utils.tree_dask import submit_tree_map_with_children
 
@@ -95,6 +102,81 @@ def _collect_metric_results(*results: object) -> list[GtsfmMetricsGroup]:
 def _finalize_io_tasks(*_args: object) -> None:
     """Barrier task used to depend on all I/O side effects."""
     return None
+
+
+def verify_visibility_graph(
+    client: Client,
+    correspondence_generator: CorrespondenceGeneratorBase,
+    two_view_estimator: TwoViewEstimator,
+    loader: LoaderBase,
+    image_future_map: dict[int, Future],
+    one_view_data_dict: dict[int, OneViewData],
+    visibility_graph: VisibilityGraph,
+) -> tuple[list[Keypoints], AnnotatedGraph[np.ndarray]]:
+    """Run the frontend once over the retrieval graph, returning keypoints + verified correspondences.
+
+    Correspondence generation and two-view estimation run over ALL retrieval edges; an edge survives iff
+    its ``TwoViewResult.valid()``. Only the verified correspondence indices are kept (each heavy
+    ``TwoViewResult`` is dropped the moment it is reduced), and every ``run_2view`` call warms the
+    two-view cache, so per-cluster frontends that run afterwards are cache hits.
+
+    Dispatches on pool size: with multiple workers the frontend fans out across the pool and only the
+    lean per-chunk ``v_corr_idxs`` sub-dicts are gathered; with at most one worker everything runs inline
+    in this process, leaving no scheduler<->worker comm surface for a multi-hour run to trip over.
+
+    Args:
+        client: Dask client.
+        correspondence_generator: Frontend correspondence generator (detection + matching).
+        two_view_estimator: Two-view estimator applied to every pair.
+        loader: Dataset loader (pose priors, GT mesh, image count).
+        image_future_map: Scattered images, keyed by image index.
+        one_view_data_dict: Per-image intrinsics / GT data.
+        visibility_graph: Retrieval graph to verify.
+
+    Returns:
+        keypoints_list: Per-image keypoints, padded to ``len(loader)``.
+        v_corr_idxs_dict: Verified correspondence indices for every surviving edge.
+    """
+    num_images = len(loader)
+    image_futures = [image_future_map[idx] for idx in range(num_images)]
+    relative_pose_priors = loader.get_relative_pose_priors(list(visibility_graph)) or {}
+    gt_scene_mesh = loader.get_gt_scene_trimesh()
+    try:
+        num_workers = len(client.scheduler_info()["workers"])
+    except Exception:
+        num_workers = 1
+
+    if num_workers <= 1:
+        logger.info("🔵 [frontend] 1 worker → running the global frontend inline (in-process).")
+        images = client.gather(image_futures)
+        keypoints_list, putative_corr_idxs_dict, _ = ClusterMVO._run_correspondence_generator(
+            correspondence_generator, list(visibility_graph), images
+        )
+        padded_keypoints_list = _pad_keypoints_list(keypoints_list, num_images)
+        v_corr_idxs_dict = create_v_corr_idxs_inline(
+            two_view_estimator,
+            padded_keypoints_list,
+            putative_corr_idxs_dict,
+            relative_pose_priors,
+            gt_scene_mesh,
+            one_view_data_dict,
+        )
+    else:
+        logger.info("🔵 [frontend] %d workers → running the global frontend in parallel.", num_workers)
+        keypoints_list, putative_corr_idxs_dict = correspondence_generator.generate_correspondences(
+            client, image_futures, list(visibility_graph)
+        )
+        padded_keypoints_list = _pad_keypoints_list(keypoints_list, num_images)
+        v_corr_idxs_dict = create_v_corr_idxs_futures(
+            client,
+            two_view_estimator,
+            padded_keypoints_list,
+            putative_corr_idxs_dict,
+            relative_pose_priors,
+            gt_scene_mesh,
+            one_view_data_dict,
+        )
+    return padded_keypoints_list, v_corr_idxs_dict
 
 
 class SceneOptimizer:
@@ -208,6 +290,41 @@ class SceneOptimizer:
         retriever_metrics, visibility_graph, similarity_matrix = self._run_retriever(client, base_output_paths)
         base_metrics_groups.append(retriever_metrics)
         image_future_map = self.loader.get_image_futures(client)
+        one_view_data_dict = self.loader.get_one_view_data_dict()
+
+        # Global two-view verification: run the frontend ONCE over the full retrieval graph and keep only
+        # the edges where a two-view model was verified. Everything downstream — partitioning, per-cluster
+        # reconstruction, merging — consumes the VERIFIED graph, so clusters are never carved along
+        # similarity edges that have no verifiable geometry. Optimizers without a two-view frontend
+        # (pure feedforward, e.g. ClusterVGGT / AnySplat) cannot verify and keep the retrieval graph.
+        padded_keypoints_list: Optional[list[Keypoints]] = None
+        v_corr_idxs_dict: Optional[AnnotatedGraph[np.ndarray]] = None
+        correspondence_generator = getattr(self.cluster_optimizer, "correspondence_generator", None)
+        two_view_estimator = getattr(self.cluster_optimizer, "two_view_estimator", None)
+        if correspondence_generator is not None and two_view_estimator is not None:
+            retrieval_edge_count = len(visibility_graph)
+            logger.info("🔎 GTSFM: Global two-view verification over %d retrieval edges...", retrieval_edge_count)
+            padded_keypoints_list, v_corr_idxs_dict = verify_visibility_graph(
+                client,
+                correspondence_generator,
+                two_view_estimator,
+                self.loader,
+                image_future_map,
+                one_view_data_dict,
+                visibility_graph,
+            )
+            verified_graph = sorted(v_corr_idxs_dict.keys())
+            all_nodes = visibility_graph_keys(verified_graph)
+            largest_cc = set(get_nodes_in_largest_connected_component(verified_graph)) if verified_graph else set()
+            logger.info(
+                "🔎 Verified graph: %d/%d edges; nodes=%d, largest_cc=%d, dropped_by_partition=%d",
+                len(verified_graph),
+                retrieval_edge_count,
+                len(all_nodes),
+                len(largest_cc),
+                len(all_nodes) - len(largest_cc),
+            )
+            visibility_graph = verified_graph
 
         # Bridge reconnection: add cross-component edges to reconnect island components.
         if similarity_matrix is not None and self._bridge_min_similarity > 0:
@@ -240,7 +357,6 @@ class SceneOptimizer:
         save_retrieval_two_view_metrics(base_output_paths)
 
         logger.info("🔥 GTSFM: Scheduling cluster optimizations...")
-        one_view_data_dict = self.loader.get_one_view_data_dict()
         merged_scene: Optional[cluster_merging.MergedNodeSummary] = None
 
         with performance_report(filename="dask_reports/scene-optimizer.html"):
@@ -261,6 +377,8 @@ class SceneOptimizer:
                         cluster_path=path,
                         label=cluster_label(path),
                         visibility_graph=visibility_graph,
+                        global_v_corr_idxs_dict=v_corr_idxs_dict,
+                        global_keypoints=padded_keypoints_list,
                     )
 
                 context_tree = cluster_tree.map_with_path(to_context)

--- a/gtsfm/two_view_estimator.py
+++ b/gtsfm/two_view_estimator.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
-from dask.distributed import Client, Future
+from dask.distributed import Client, Future, as_completed
 from gtsam import Pose3, Rot3, SfmTrack, Unit3  # type: ignore
 
 import gtsfm.common.types as gtsfm_types
@@ -889,6 +889,198 @@ def create_two_view_estimator_futures(
 
     logger.info(f"Submitted {len(two_view_result_futures)} tasks to workers")
     return two_view_result_futures
+
+
+def create_two_view_results_inline(
+    two_view_estimator: TwoViewEstimator,
+    keypoints_list: List[Keypoints],
+    putative_corr_idxs_dict: AnnotatedGraph[np.ndarray],
+    relative_pose_priors: Dict[Tuple[int, int], PosePrior],
+    gt_scene_mesh: Optional[Any],
+    one_view_data_dict: Dict[int, OneViewData],
+) -> AnnotatedGraph[TwoViewResult]:
+    """Inline (no-Dask) variant of ``create_two_view_estimator_futures``.
+
+    Runs ``run_2view`` for every pair in a plain loop instead of scattering the estimator and submitting a
+    per-pair task to a nested client. Used by the cluster frontend to avoid the ``worker_client()``
+    tasks-launching-tasks pattern. Kwargs mirror ``create_two_view_estimator_futures`` exactly.
+    """
+    two_view_results: AnnotatedGraph[TwoViewResult] = {}
+    for (i1, i2), putative_corr_idxs in putative_corr_idxs_dict.items():
+        view1, view2 = one_view_data_dict[i1], one_view_data_dict[i2]
+        two_view_results[(i1, i2)] = two_view_estimator.run_2view(
+            keypoints_i1=keypoints_list[i1],
+            keypoints_i2=keypoints_list[i2],
+            putative_corr_idxs=putative_corr_idxs,
+            camera_intrinsics_i1=view1.intrinsics,
+            camera_intrinsics_i2=view2.intrinsics,
+            i2Ti1_prior=relative_pose_priors.get((i1, i2)),
+            gt_camera_i1=view1.camera_gt,
+            gt_camera_i2=view2.camera_gt,
+            gt_scene_mesh=gt_scene_mesh,
+            i1=i1,
+            i2=i2,
+        )
+    return two_view_results
+
+
+def create_v_corr_idxs_inline(
+    two_view_estimator: TwoViewEstimator,
+    keypoints_list: List[Keypoints],
+    putative_corr_idxs_dict: AnnotatedGraph[np.ndarray],
+    relative_pose_priors: Dict[Tuple[int, int], PosePrior],
+    gt_scene_mesh: Optional[Any],
+    one_view_data_dict: Dict[int, OneViewData],
+) -> AnnotatedGraph[np.ndarray]:
+    """Variant of ``create_two_view_results_inline`` that retains only the ``v_corr_idxs`` of each VALID pair.
+
+    Each ``TwoViewResult`` (three ``TwoViewEstimationReport``s plus the putative indices) is dropped as soon
+    as its verified-correspondence indices are extracted, so memory is bounded by the output rather than by
+    the number of pairs. ``run_2view`` runs exactly as in the full variant, so its side effects (the
+    ``TwoViewEstimatorCacher``) are unchanged; the ``valid()`` filter mirrors
+    ``ClusterMVO._run_two_view_estimation``.
+    """
+    v_corr_idxs_dict: AnnotatedGraph[np.ndarray] = {}
+    num_pairs = len(putative_corr_idxs_dict)
+    start_time = time.time()
+    for p, ((i1, i2), putative_corr_idxs) in enumerate(putative_corr_idxs_dict.items()):
+        view1, view2 = one_view_data_dict[i1], one_view_data_dict[i2]
+        result = two_view_estimator.run_2view(
+            keypoints_i1=keypoints_list[i1],
+            keypoints_i2=keypoints_list[i2],
+            putative_corr_idxs=putative_corr_idxs,
+            camera_intrinsics_i1=view1.intrinsics,
+            camera_intrinsics_i2=view2.intrinsics,
+            i2Ti1_prior=relative_pose_priors.get((i1, i2)),
+            gt_camera_i1=view1.camera_gt,
+            gt_camera_i2=view2.camera_gt,
+            gt_scene_mesh=gt_scene_mesh,
+            i1=i1,
+            i2=i2,
+        )
+        if result.valid():
+            v_corr_idxs_dict[(i1, i2)] = result.v_corr_idxs
+        # `result` (with its reports + putative idxs) goes out of scope each iteration -> not retained.
+        if (p + 1) % 2000 == 0 or (p + 1) == num_pairs:
+            elapsed = time.time() - start_time
+            rate = (p + 1) / elapsed if elapsed > 0 else 0.0
+            eta = (num_pairs - (p + 1)) / rate if rate > 0 else 0.0
+            logger.info(
+                "🔵 [two-view] %d/%d pairs (%d valid, %.0fs, %.1f pair/s, ETA %.0fs)",
+                p + 1,
+                num_pairs,
+                len(v_corr_idxs_dict),
+                elapsed,
+                rate,
+                eta,
+            )
+    return v_corr_idxs_dict
+
+
+def create_v_corr_idxs_futures(
+    client: Client,
+    two_view_estimator: TwoViewEstimator,
+    keypoints_list: List[Keypoints],
+    putative_corr_idxs_dict: AnnotatedGraph[np.ndarray],
+    relative_pose_priors: Dict[Tuple[int, int], PosePrior],
+    gt_scene_mesh: Optional[Any],
+    one_view_data_dict: Dict[int, OneViewData],
+    chunk_size: Optional[int] = None,
+    broadcast: bool = True,
+) -> AnnotatedGraph[np.ndarray]:
+    """Parallel variant of ``create_v_corr_idxs_inline`` over the Dask worker pool.
+
+    The pairs are split into chunks, each run as one task with ``create_v_corr_idxs_inline`` as its body, so
+    a worker only ever returns the small ``{(i1, i2): v_corr_idxs}`` sub-dict of its chunk and the client
+    merges those. The shared read-only inputs are scattered ONCE, each as a single blob (a bare
+    ``client.scatter`` of a list/dict would explode it into per-element futures), rather than being embedded
+    in every task. Chunking also bounds the blast radius of a lost worker to its own chunks.
+
+    Args:
+        client: Dask client whose workers run the chunks.
+        two_view_estimator: Estimator applied per pair (``run_2view``); side effects are unchanged.
+        keypoints_list: Per-image keypoints, indexed by image index.
+        putative_corr_idxs_dict: Putative correspondences per pair (the work to distribute).
+        relative_pose_priors: Optional per-pair relative pose priors.
+        gt_scene_mesh: Optional GT scene mesh.
+        one_view_data_dict: Per-image intrinsics / GT camera data.
+        chunk_size: Pairs per chunk; ``None`` targets ~4 chunks per worker.
+        broadcast: Replicate the scattered blobs to every worker up front (default). Scattered data cannot be
+            recomputed, so with a single holder (``broadcast=False``) losing that worker fails the whole
+            stage; replicas survive a worker loss. Set ``False`` only when memory-bound on a stable cluster.
+
+    Returns:
+        ``{(i1, i2): v_corr_idxs}`` for every VALID pair, identical to ``create_v_corr_idxs_inline``.
+    """
+    pairs = list(putative_corr_idxs_dict.keys())
+    num_pairs = len(pairs)
+    if num_pairs == 0:
+        return {}
+
+    try:
+        n_workers = max(1, len(client.scheduler_info()["workers"]))
+    except Exception:
+        n_workers = 1
+    if chunk_size is None:
+        target_chunks = max(n_workers * 4, 1)
+        chunk_size = max(1, (num_pairs + target_chunks - 1) // target_chunks)
+
+    # hash=False: these scatters are one-shot and function-scoped, so give them unique keys rather than
+    # content-hashed ones. Content hashing tokenizes the (large) inputs and, worse, reuses the key when equal
+    # inputs are scattered again while the previous copy is still being released ("lost dependencies").
+    def _scatter_blob(obj: Any) -> Future:
+        # Wrap in a 1-list so scatter treats the list/dict as ONE object (returns one future) instead of
+        # scattering each element/value separately.
+        return client.scatter([obj], broadcast=broadcast, hash=False)[0]
+
+    estimator_future = client.scatter(two_view_estimator, broadcast=True, hash=False)
+    keypoints_future = _scatter_blob(keypoints_list)
+    priors_future = _scatter_blob(relative_pose_priors)
+    one_view_data_future = _scatter_blob(one_view_data_dict)
+    # A None mesh is passed straight through (nothing to scatter); otherwise scatter it as a blob too.
+    mesh_arg: Any = _scatter_blob(gt_scene_mesh) if gt_scene_mesh is not None else None
+
+    chunks = [
+        {p: putative_corr_idxs_dict[p] for p in pairs[start : start + chunk_size]}
+        for start in range(0, num_pairs, chunk_size)
+    ]
+    logger.info(
+        "🔵 [two-view|parallel] %d pairs over %d worker(s) in %d chunks (~%d pairs/chunk).",
+        num_pairs,
+        n_workers,
+        len(chunks),
+        chunk_size,
+    )
+
+    # pure=False: run_2view is side-effecting (cacher/DB writes) and each chunk is distinct — never
+    # memoize/dedupe. Positional args follow create_v_corr_idxs_inline's signature exactly.
+    chunk_futures = [
+        client.submit(
+            create_v_corr_idxs_inline,
+            estimator_future,
+            keypoints_future,
+            chunk,
+            priors_future,
+            mesh_arg,
+            one_view_data_future,
+            pure=False,
+        )
+        for chunk in chunks
+    ]
+
+    v_corr_idxs_dict: AnnotatedGraph[np.ndarray] = {}
+    start_time = time.time()
+    num_chunks = len(chunk_futures)
+    for done_count, future in enumerate(as_completed(chunk_futures), start=1):
+        v_corr_idxs_dict.update(future.result())
+        logger.info(
+            "🔵 [two-view|parallel] %d/%d chunks done (%d valid pairs, %.0fs).",
+            done_count,
+            num_chunks,
+            len(v_corr_idxs_dict),
+            time.time() - start_time,
+        )
+    return v_corr_idxs_dict
 
 
 def get_two_view_reports_summary(

--- a/tests/frontend/correspondence_generator/test_generate_correspondences_inline.py
+++ b/tests/frontend/correspondence_generator/test_generate_correspondences_inline.py
@@ -1,0 +1,130 @@
+"""Tests that inline (no-Dask) correspondence generation matches the Dask path exactly.
+
+The per-cluster frontend runs ``generate_correspondences_inline`` inside a Dask task instead of submitting
+nested tasks through ``worker_client()``. These tests pin the two entry points to the same result for the
+two generator families that run in that frontend, using deterministic stubs whose outputs depend on the
+image shapes (so a shape that is not threaded through correctly shows up as a mismatch).
+
+Authors: Kathirvel Gounder
+"""
+
+import unittest
+from typing import Dict, List, Tuple
+
+import numpy as np
+from dask.distributed import Client, LocalCluster
+
+from gtsfm.common.image import Image
+from gtsfm.common.keypoints import Keypoints
+from gtsfm.frontend.correspondence_generator.det_desc_correspondence_generator import DetDescCorrespondenceGenerator
+from gtsfm.frontend.correspondence_generator.image_correspondence_generator import ImageCorrespondenceGenerator
+
+
+class _StubDetectorDescriptor:
+    """Deterministic detector-descriptor: keypoint count and layout follow the image size."""
+
+    def detect_and_describe(self, image: Image) -> Tuple[Keypoints, np.ndarray]:
+        num = 3 + image.width % 4
+        coords = np.stack([np.arange(num) * image.width / num, np.arange(num) * image.height / num], axis=1)
+        coords = coords.astype(np.float32)
+        return Keypoints(coordinates=coords), coords / 100.0
+
+
+class _StubMatcher:
+    """Deterministic descriptor matcher whose match count depends on the image shapes it is handed."""
+
+    def match(
+        self,
+        keypoints_i1: Keypoints,
+        keypoints_i2: Keypoints,
+        descriptors_i1: np.ndarray,
+        descriptors_i2: np.ndarray,
+        im_shape_i1: Tuple[int, ...],
+        im_shape_i2: Tuple[int, ...],
+    ) -> np.ndarray:
+        num = min(len(keypoints_i1), len(keypoints_i2), 1 + (im_shape_i1[0] + im_shape_i2[1]) % 3)
+        return np.stack([np.arange(num), np.arange(num)], axis=1).astype(np.int32)
+
+
+class _StubImageMatcher:
+    """Deterministic image matcher (detector-free): keypoints follow the pair's image sizes."""
+
+    def match(self, image_i1: Image, image_i2: Image) -> Tuple[Keypoints, Keypoints]:
+        num = 2 + (image_i1.width + image_i2.width) % 3
+        offsets = np.arange(num, dtype=np.float32)[:, None]
+        kp1 = np.array([[image_i1.width / 2, image_i1.height / 2]], dtype=np.float32) + offsets
+        kp2 = np.array([[image_i2.width / 3, image_i2.height / 3]], dtype=np.float32) + offsets
+        return Keypoints(coordinates=kp1), Keypoints(coordinates=kp2)
+
+
+def _make_images(num_images: int = 5) -> List[Image]:
+    return [Image(value_array=np.zeros((40 + 7 * i, 60 + 5 * i, 3), dtype=np.uint8)) for i in range(num_images)]
+
+
+def _all_pairs(num_images: int) -> List[Tuple[int, int]]:
+    return [(i1, i2) for i1 in range(num_images) for i2 in range(i1 + 1, num_images)]
+
+
+class TestGenerateCorrespondencesInline(unittest.TestCase):
+    """The inline entry point must reproduce the Dask entry point exactly."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.cluster = LocalCluster(n_workers=2, threads_per_worker=1, processes=False, dashboard_address=":0")
+        cls.client = Client(cls.cluster)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.client.close()
+        cls.cluster.close()
+
+    def _assert_same(
+        self,
+        expected: Tuple[List[Keypoints], Dict[Tuple[int, int], np.ndarray]],
+        actual: Tuple[List[Keypoints], Dict[Tuple[int, int], np.ndarray]],
+    ) -> None:
+        expected_keypoints, expected_corr = expected
+        actual_keypoints, actual_corr = actual
+        self.assertEqual(len(expected_keypoints), len(actual_keypoints))
+        for kp_expected, kp_actual in zip(expected_keypoints, actual_keypoints):
+            np.testing.assert_array_equal(kp_expected.coordinates, kp_actual.coordinates)
+        self.assertEqual(set(expected_corr.keys()), set(actual_corr.keys()))
+        for edge in expected_corr:
+            np.testing.assert_array_equal(expected_corr[edge], actual_corr[edge])
+
+    def test_det_desc_inline_matches_dask(self) -> None:
+        generator = DetDescCorrespondenceGenerator(
+            matcher=_StubMatcher(), detector_descriptor=_StubDetectorDescriptor()
+        )
+        images = _make_images()
+        visibility_graph = _all_pairs(len(images))
+
+        expected = generator.generate_correspondences(self.client, self.client.scatter(images), visibility_graph)
+        actual = generator.generate_correspondences_inline(images, visibility_graph)
+
+        self._assert_same(expected, actual)
+        self.assertEqual(len(actual[1]), len(visibility_graph))
+
+    def test_image_inline_matches_dask(self) -> None:
+        generator = ImageCorrespondenceGenerator(matcher=_StubImageMatcher(), deduplicate=True)
+        images = _make_images()
+        visibility_graph = _all_pairs(len(images))
+
+        expected = generator.generate_correspondences(self.client, self.client.scatter(images), visibility_graph)
+        actual = generator.generate_correspondences_inline(images, visibility_graph)
+
+        self._assert_same(expected, actual)
+        self.assertEqual(len(actual[1]), len(visibility_graph))
+
+    def test_empty_visibility_graph(self) -> None:
+        generator = DetDescCorrespondenceGenerator(
+            matcher=_StubMatcher(), detector_descriptor=_StubDetectorDescriptor()
+        )
+        images = _make_images(3)
+        keypoints_list, corr = generator.generate_correspondences_inline(images, [])
+        self.assertEqual(len(keypoints_list), 3)
+        self.assertEqual(corr, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_create_v_corr_idxs_futures.py
+++ b/tests/test_create_v_corr_idxs_futures.py
@@ -1,0 +1,151 @@
+"""Unit tests for the parallel global two-view frontend (``create_v_corr_idxs_futures``).
+
+The parallel path chunks the pairs and runs ``create_v_corr_idxs_inline`` on each chunk across the Dask
+worker pool, scattering the shared read-only inputs once. These tests assert it returns EXACTLY the same
+``{(i1, i2): v_corr_idxs}`` dict as the serial inline reference for any chunking, and that the ``valid()``
+filter is honored. A deterministic stub estimator isolates the orchestration (chunking / scatter-as-blob /
+merge) from real two-view geometry; cross-process worker pickling is exercised separately by end-to-end runs.
+
+Authors: Kathirvel Gounder
+"""
+
+import unittest
+
+import numpy as np
+from dask.distributed import Client, LocalCluster
+
+from gtsfm.common.keypoints import Keypoints
+from gtsfm.two_view_estimator import create_v_corr_idxs_futures, create_v_corr_idxs_inline
+
+
+class _StubResult:
+    """Minimal stand-in for TwoViewResult exposing only what the frontend reduction reads."""
+
+    def __init__(self, v_corr_idxs: np.ndarray, is_valid: bool) -> None:
+        self.v_corr_idxs = v_corr_idxs
+        self._is_valid = is_valid
+
+    def valid(self) -> bool:
+        return self._is_valid
+
+
+class _StubTwoViewEstimator:
+    """Deterministic stand-in for ``TwoViewEstimator.run_2view``.
+
+    ``v_corr_idxs`` is derived from the pair's putative indices plus a per-pair offset, so inline and
+    parallel results can be compared exactly and a chunk can never be confused for another. Pairs whose
+    index sum is odd are marked invalid, exercising the ``valid()`` filter (invalid pairs must be dropped).
+    """
+
+    def run_2view(self, *, putative_corr_idxs, i1, i2, **kwargs) -> _StubResult:
+        is_valid = (i1 + i2) % 2 == 0
+        v_corr_idxs = putative_corr_idxs + (i1 * 1000 + i2)
+        return _StubResult(v_corr_idxs, is_valid)
+
+
+class _StubOneViewData:
+    """Per-image data with the attributes the frontend reads (all unused by the stub estimator)."""
+
+    def __init__(self) -> None:
+        self.intrinsics = None
+        self.camera_gt = None
+
+
+def _make_inputs(num_images: int = 8):
+    """Build deterministic keypoints, a fully-connected putative graph, priors, and per-view data."""
+    keypoints_list = [Keypoints(np.full((5, 2), i, dtype=np.float32)) for i in range(num_images)]
+    putative_corr_idxs_dict = {
+        (i, j): np.arange(6, dtype=np.int32).reshape(3, 2) + (i + j)
+        for i in range(num_images)
+        for j in range(i + 1, num_images)
+    }
+    one_view_data_dict = {i: _StubOneViewData() for i in range(num_images)}
+    relative_pose_priors: dict = {}
+    return keypoints_list, putative_corr_idxs_dict, relative_pose_priors, one_view_data_dict
+
+
+class TestCreateVCorrIdxsFutures(unittest.TestCase):
+    """Parallel two-view must equal the serial inline reference for any chunking."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Threaded workers (processes=False): 2 workers, no cross-process pickling — deterministic and fast.
+        # This still exercises chunking, scatter-as-blob, and the as_completed merge, which is the new code.
+        cls.cluster = LocalCluster(n_workers=2, threads_per_worker=1, processes=False, dashboard_address=":0")
+        cls.client = Client(cls.cluster)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.client.close()
+        cls.cluster.close()
+
+    def _assert_same(self, expected: dict, actual: dict) -> None:
+        self.assertEqual(set(expected.keys()), set(actual.keys()))
+        for edge in expected:
+            np.testing.assert_array_equal(expected[edge], actual[edge])
+
+    def test_parallel_matches_inline_default_chunking(self) -> None:
+        """Default chunk sizing must reproduce the inline result exactly."""
+        estimator = _StubTwoViewEstimator()
+        keypoints_list, putative, priors, one_view = _make_inputs()
+
+        expected = create_v_corr_idxs_inline(
+            two_view_estimator=estimator,
+            keypoints_list=keypoints_list,
+            putative_corr_idxs_dict=putative,
+            relative_pose_priors=priors,
+            gt_scene_mesh=None,
+            one_view_data_dict=one_view,
+        )
+        actual = create_v_corr_idxs_futures(self.client, estimator, keypoints_list, putative, priors, None, one_view)
+        self._assert_same(expected, actual)
+        # Sanity: the valid() filter dropped the odd-sum pairs (so it is not a trivial pass-through).
+        self.assertTrue(all((i1 + i2) % 2 == 0 for (i1, i2) in actual))
+        self.assertLess(len(actual), len(putative))
+
+    def test_parallel_matches_inline_tiny_chunks(self) -> None:
+        """Force many single-pair chunks (chunk_size=1) to stress the chunk/merge boundary."""
+        estimator = _StubTwoViewEstimator()
+        keypoints_list, putative, priors, one_view = _make_inputs()
+
+        expected = create_v_corr_idxs_inline(
+            two_view_estimator=estimator,
+            keypoints_list=keypoints_list,
+            putative_corr_idxs_dict=putative,
+            relative_pose_priors=priors,
+            gt_scene_mesh=None,
+            one_view_data_dict=one_view,
+        )
+        actual = create_v_corr_idxs_futures(
+            self.client, estimator, keypoints_list, putative, priors, None, one_view, chunk_size=1
+        )
+        self._assert_same(expected, actual)
+
+    def test_single_chunk_matches_inline(self) -> None:
+        """A chunk_size >= num_pairs (one chunk on one worker) must reproduce the inline result."""
+        estimator = _StubTwoViewEstimator()
+        keypoints_list, putative, priors, one_view = _make_inputs()
+
+        expected = create_v_corr_idxs_inline(
+            two_view_estimator=estimator,
+            keypoints_list=keypoints_list,
+            putative_corr_idxs_dict=putative,
+            relative_pose_priors=priors,
+            gt_scene_mesh=None,
+            one_view_data_dict=one_view,
+        )
+        actual = create_v_corr_idxs_futures(
+            self.client, estimator, keypoints_list, putative, priors, None, one_view, chunk_size=10_000
+        )
+        self._assert_same(expected, actual)
+
+    def test_empty_graph_returns_empty(self) -> None:
+        """No pairs → empty dict, no tasks submitted."""
+        estimator = _StubTwoViewEstimator()
+        keypoints_list, _, priors, one_view = _make_inputs()
+        actual = create_v_corr_idxs_futures(self.client, estimator, keypoints_list, {}, priors, None, one_view)
+        self.assertEqual(actual, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_exif_calibration_passthrough.py
+++ b/tests/test_exif_calibration_passthrough.py
@@ -1,0 +1,101 @@
+"""Tests for the measured-intrinsics passthrough and per-camera calibration arbitration.
+
+Cameras whose intrinsics were measured (EXIF / dataset calibration) are passed through the
+SceneOptimizer verbatim and pinned in the cluster builds; cameras whose loader could only guess a
+focal are excluded and fall back to the geometry model's predicted focal, rescaled to original
+resolution.
+
+Authors: Kathirvel Gounder
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+from gtsam import Cal3Bundler, PinholeCameraCal3Bundler, Pose3
+
+from gtsfm.cluster_optimizer.cluster_optimizer_cacher import ClusterOptimizerCacher
+from gtsfm.cluster_optimizer.cluster_vggt_with_frontend import VggtGeometryResult, _build_gtsfm_data_from_vggt_depth
+from gtsfm.products.one_view_data import OneViewData
+from gtsfm.scene_optimizer import exif_intrinsics_passthrough
+
+
+def _one_view_data(fx: float, from_exif: bool) -> OneViewData:
+    return OneViewData(
+        image_fname="img.jpg",
+        intrinsics=Cal3Bundler(fx, 0.0, 0.0, 100.0, 75.0),
+        absolute_pose_prior=None,
+        camera_gt=None,
+        pose_gt=None,
+        intrinsics_from_exif=from_exif,
+    )
+
+
+class TestExifIntrinsicsPassthrough(unittest.TestCase):
+    def test_only_measured_cameras_pass_through(self) -> None:
+        one_view_data_dict = {
+            0: _one_view_data(800.0, from_exif=True),
+            1: _one_view_data(900.0, from_exif=False),
+            2: _one_view_data(1000.0, from_exif=True),
+        }
+        passthrough = exif_intrinsics_passthrough(one_view_data_dict)
+        self.assertEqual(set(passthrough.keys()), {0, 2})
+        self.assertEqual(passthrough[0].fx(), 800.0)
+        self.assertEqual(passthrough[2].fx(), 1000.0)
+
+    def test_default_provenance_is_measured(self) -> None:
+        """Loaders that never guess need no override: the default marks intrinsics as measured."""
+        one_view_data = OneViewData(
+            image_fname="img.jpg",
+            intrinsics=Cal3Bundler(800.0, 0.0, 0.0, 100.0, 75.0),
+            absolute_pose_prior=None,
+            camera_gt=None,
+            pose_gt=None,
+        )
+        self.assertTrue(one_view_data.intrinsics_from_exif)
+
+    def test_provenance_changes_cluster_cache_key(self) -> None:
+        """Pinning toggles cluster output, so provenance must participate in the cache key."""
+        cacher = ClusterOptimizerCacher(optimizer=MagicMock())
+        hash_measured = cacher._hash_one_view_data(_one_view_data(800.0, from_exif=True))
+        hash_guessed = cacher._hash_one_view_data(_one_view_data(800.0, from_exif=False))
+        self.assertNotEqual(hash_measured, hash_guessed)
+
+
+class TestBuildCalibrationArbitration(unittest.TestCase):
+    def test_sparse_refined_intrinsics_fall_back_to_model_focal(self) -> None:
+        """Cameras absent from refined_intrinsics keep the model focal, rescaled to original res."""
+        num_local, H, W = 2, 8, 8
+        model_cal = Cal3Bundler(100.0, 0.0, 0.0, 4.0, 4.0)  # in VGGT pixel space (scaled width = 8)
+        cameras = {
+            0: PinholeCameraCal3Bundler(Pose3(), model_cal),
+            1: PinholeCameraCal3Bundler(Pose3(), model_cal),
+        }
+        original_coords = np.zeros((num_local, 6), dtype=np.float32)
+        original_coords[:, 4] = W
+        original_coords[:, 5] = H
+        vggt_result = VggtGeometryResult(
+            cameras=cameras,
+            dense_points=np.zeros((num_local, H, W, 3), dtype=np.float32),
+            depth_confidence=np.ones((num_local, H, W), dtype=np.float32),
+            original_coords=original_coords,
+        )
+        image_shapes = {0: (16, 16), 1: (16, 16)}  # original resolution = 2x the VGGT resolution
+        measured_cal = Cal3Bundler(555.0, 0.0, 0.0, 8.0, 8.0)
+
+        data = _build_gtsfm_data_from_vggt_depth(
+            vggt_result,
+            tracks_2d=[],
+            image_shapes=image_shapes,
+            image_indices=(0, 1),
+            num_images=2,
+            min_track_length=2,
+            refined_intrinsics={0: measured_cal},
+        )
+
+        self.assertAlmostEqual(data.get_camera(0).calibration().fx(), 555.0)  # pinned verbatim
+        self.assertAlmostEqual(data.get_camera(1).calibration().fx(), 200.0)  # model 100 x (16/8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_verify_visibility_graph.py
+++ b/tests/test_verify_visibility_graph.py
@@ -1,0 +1,129 @@
+"""Tests for the global two-view verification pass (``scene_optimizer.verify_visibility_graph``).
+
+The pass dispatches on worker-pool size: one worker runs the frontend inline in the calling process,
+several workers fan it out and gather only the lean v_corr sub-dicts. These tests pin both arms to the
+same verified graph and correspondences, using deterministic stubs (an edge is verified iff its index
+sum is even).
+
+Authors: Kathirvel Gounder
+"""
+
+import unittest
+from typing import List, Tuple
+
+import numpy as np
+from dask.distributed import Client, LocalCluster
+
+from gtsfm.common.image import Image
+from gtsfm.common.keypoints import Keypoints
+from gtsfm.frontend.correspondence_generator.det_desc_correspondence_generator import DetDescCorrespondenceGenerator
+from gtsfm.scene_optimizer import verify_visibility_graph
+
+
+class _StubDetectorDescriptor:
+    """Deterministic detector-descriptor: keypoint count and layout follow the image size."""
+
+    def detect_and_describe(self, image: Image) -> Tuple[Keypoints, np.ndarray]:
+        num = 4 + image.width % 3
+        coords = np.stack([np.arange(num) * image.width / num, np.arange(num) * image.height / num], axis=1)
+        coords = coords.astype(np.float32)
+        return Keypoints(coordinates=coords), coords / 100.0
+
+
+class _StubMatcher:
+    """Deterministic descriptor matcher: pairs the first min(n1, n2) keypoints."""
+
+    def match(self, keypoints_i1, keypoints_i2, descriptors_i1, descriptors_i2, im_shape_i1, im_shape_i2):
+        num = min(len(keypoints_i1), len(keypoints_i2))
+        return np.stack([np.arange(num), np.arange(num)], axis=1).astype(np.int32)
+
+
+class _StubResult:
+    def __init__(self, v_corr_idxs: np.ndarray, is_valid: bool) -> None:
+        self.v_corr_idxs = v_corr_idxs
+        self._is_valid = is_valid
+
+    def valid(self) -> bool:
+        return self._is_valid
+
+
+class _StubTwoViewEstimator:
+    """Verifies an edge iff its index sum is even; v_corr derives from the pair so edges are distinct."""
+
+    def run_2view(self, *, putative_corr_idxs, i1, i2, **kwargs) -> _StubResult:
+        return _StubResult(putative_corr_idxs + (i1 * 1000 + i2), (i1 + i2) % 2 == 0)
+
+
+class _StubOneViewData:
+    """Per-image data with the attributes the two-view loop reads (unused by the stub estimator)."""
+
+    def __init__(self) -> None:
+        self.intrinsics = None
+        self.camera_gt = None
+
+
+class _StubLoader:
+    """Minimal loader surface consumed by the verification pass."""
+
+    def __init__(self, num_images: int) -> None:
+        self._num_images = num_images
+
+    def __len__(self) -> int:
+        return self._num_images
+
+    def get_relative_pose_priors(self, pairs) -> dict:
+        return {}
+
+    def get_gt_scene_trimesh(self):
+        return None
+
+
+def _make_images(num_images: int) -> List[Image]:
+    return [Image(value_array=np.zeros((30 + 5 * i, 45 + 7 * i, 3), dtype=np.uint8)) for i in range(num_images)]
+
+
+def _run_with_workers(n_workers: int, num_images: int = 6):
+    """Run the verification pass on a fresh local cluster with the given worker count."""
+    images = _make_images(num_images)
+    visibility_graph = [(i1, i2) for i1 in range(num_images) for i2 in range(i1 + 1, num_images)]
+    with (
+        LocalCluster(n_workers=n_workers, threads_per_worker=1, processes=False, dashboard_address=":0") as cluster,
+        Client(cluster) as client,
+    ):
+        image_future_map = dict(enumerate(client.scatter(images)))
+        keypoints_list, v_corr_idxs_dict = verify_visibility_graph(
+            client,
+            DetDescCorrespondenceGenerator(matcher=_StubMatcher(), detector_descriptor=_StubDetectorDescriptor()),
+            _StubTwoViewEstimator(),
+            _StubLoader(num_images),
+            image_future_map,
+            {i: _StubOneViewData() for i in range(num_images)},
+            visibility_graph,
+        )
+    return keypoints_list, v_corr_idxs_dict, visibility_graph
+
+
+class TestVerifyVisibilityGraph(unittest.TestCase):
+    def test_inline_and_parallel_arms_agree(self) -> None:
+        """The 1-worker (inline) and multi-worker (fan-out) arms must produce identical results."""
+        keypoints_inline, v_corr_inline, _ = _run_with_workers(n_workers=1)
+        keypoints_parallel, v_corr_parallel, _ = _run_with_workers(n_workers=2)
+
+        self.assertEqual(len(keypoints_inline), len(keypoints_parallel))
+        for kp_a, kp_b in zip(keypoints_inline, keypoints_parallel):
+            np.testing.assert_array_equal(kp_a.coordinates, kp_b.coordinates)
+        self.assertEqual(set(v_corr_inline.keys()), set(v_corr_parallel.keys()))
+        for edge in v_corr_inline:
+            np.testing.assert_array_equal(v_corr_inline[edge], v_corr_parallel[edge])
+
+    def test_only_verified_edges_survive(self) -> None:
+        """The verified graph keeps exactly the edges the two-view estimator validates."""
+        keypoints_list, v_corr_idxs_dict, visibility_graph = _run_with_workers(n_workers=1, num_images=6)
+        expected_edges = {(i1, i2) for (i1, i2) in visibility_graph if (i1 + i2) % 2 == 0}
+        self.assertEqual(set(v_corr_idxs_dict.keys()), expected_edges)
+        self.assertLess(len(v_corr_idxs_dict), len(visibility_graph))
+        self.assertEqual(len(keypoints_list), 6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Stacked on #1135** (verified view graph), which stacks on #1134 — review the **last commit only** (`Pin measured (EXIF/dataset) intrinsics in cluster builds`); the earlier commits are those PRs. Will rebase as the stack merges.

## What

Every cluster BA currently refines the same physical camera's focal independently, starting from the geometry model's prediction. Through the focal/depth ambiguity each cluster drifts that focal differently, so the parent and child copies of a **separator camera** disagree — which is exactly the correspondence the Sim3 merge aligns on. This PR pins each camera's focal to one authoritative value wherever a *measured* value exists:

1. **`OneViewData.intrinsics_from_exif`** — provenance bit: were these intrinsics measured (EXIF metadata or a dataset calibration), or did the loader substitute the default-focal heuristic (`focal = 1.2 × max(H, W)`)? `LoaderBase` defaults to True; `OneDSfMLoader` — the only loader that guesses — overrides it with per-image EXIF presence.
2. **`SceneOptimizer.exif_intrinsics_passthrough`** collects the measured cameras' intrinsics and hands them to every cluster via `ClusterContext.global_refined_intrinsics`. Data-driven, no flag — same pattern as the verified-graph globals in #1135.
3. **Per-camera arbitration in `ClusterVGGTWithFrontend`**: measured passthrough (pinned verbatim → bit-identical across all clusters sharing the camera) → per-cluster Fetzer (`use_view_graph_calibration`, unchanged) → model-predicted focal rescaled to original resolution. The build now tolerates a **sparse** refined dict: cameras absent from it fall back to the model focal (previously `refined_intrinsics` was all-or-nothing).

## Why trust EXIF over refinement

Tower-of-London gold audit against 592 GT cameras: **EXIF focals: 1.91% median error, +0.06% bias.** After Fetzer self-calibration refined them: **5.26% median, −4.0% bias, 74% of cameras >3% off** — refinement *degraded* the metadata it started from (56% of verified edges are Fetzer-degenerate: planar/focal-unstable). Model-predicted focals for EXIF-less cameras sit at ~1–2% median error. Pinning a *guessed* focal, however, is worse than any of these — hence the provenance bit rather than pinning everything (~19–40% of 1DSfM phototourism images carry no usable EXIF; the heuristic is ~17% off on average).

## Cache note

Provenance is now part of the cluster cache key (`_hash_one_view_data`) because pinning changes cluster output. Side effect: **all existing cluster caches invalidate once** on upgrade.

## Tests

`tests/test_exif_calibration_passthrough.py`: passthrough keeps only measured cameras; provenance defaults to measured; cache key is provenance-sensitive; sparse-dict fallback yields pinned focal for present cameras and rescaled model focal for absent ones. Full `tests/loader` suite green (89 tests across affected suites; argoverse skipped — missing optional dep).

## Review focus

- `OneDSfMLoader.intrinsics_from_exif` loads the image a second time (once for intrinsics, once for provenance) during `get_one_view_data_dict`. One extra pass over the images at startup; if that's objectionable I can thread provenance through `get_camera_intrinsics_full_res` instead at the cost of a wider API change.
- Semantics of "measured": includes dataset calibrations (Olsson GT-K, Colmap), not just EXIF — the field name follows the EXIF case since that's the phototourism reality. Happy to rename to `intrinsics_measured` if preferred.
- Precedence: measured passthrough takes priority over per-cluster Fetzer when both are present.

## Context

Part of the series landing the ECCV'26 SFM-DL hierarchical pipeline into `mapping-vggt` (after #1134, #1135). Remaining: merge guards + BA prior tuning, post-merge retriangulation + final free BA, trackless-camera annex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
