### PR TITLE
Add short URL for hierarchical paper

### DIFF
--- a/paper/index.html
+++ b/paper/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://nilakarthikesan.github.io/visualization-gtsfm-paper/">
+  <link rel="canonical" href="https://nilakarthikesan.github.io/visualization-gtsfm-paper/">
+  <title>GTSfM Hierarchical Paper</title>
+  <script>
+    window.location.replace("https://nilakarthikesan.github.io/visualization-gtsfm-paper/");
+  </script>
+</head>
+<body>
+  <p>Redirecting to the <a href="https://nilakarthikesan.github.io/visualization-gtsfm-paper/">GTSfM hierarchical paper</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
Adds `paper/index.html` as a lightweight redirect to Nila Karthikesan's hierarchical GTSfM paper:

https://nilakarthikesan.github.io/visualization-gtsfm-paper/

This is intended to provide the memorable short URL `gtsfm.github.io/paper/` when served by the GTSfM GitHub Pages site.