### PR TITLE
Deploy paper directory with GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,33 @@
+name: Deploy paper to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "paper/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: paper
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Adds a minimal GitHub Pages workflow that publishes only the existing `paper/` directory on pushes to `master` that touch the paper or the workflow itself.

Once Pages is enabled to use GitHub Actions in the repository settings, the site will be served from the repository's Pages URL and the existing `paper/index.html` redirect will become the site root.